### PR TITLE
Push notifications + battery: ntfy/SSE push wake, push-gated slow sync

### DIFF
--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -315,7 +315,19 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
                         offlineText?.let { OfflineBanner(it) }
                         Box(modifier = Modifier.weight(1f)) {
                             when {
-                                loading && rooms.isEmpty() -> StatusText("Loading…")
+                                // First login / restored session: the initial sync
+                                // pulls the whole account (all rooms + history) and
+                                // can take minutes on a large bridged account —
+                                // say so instead of a blank "Loading…", and never
+                                // flash "No conversations" while it's still running
+                                // (the retry budget can exhaust before rooms land).
+                                loading && rooms.isEmpty() -> StatusText(
+                                    if (connection?.state == "connecting") {
+                                        "Downloading your chat history…"
+                                    } else {
+                                        "Loading…"
+                                    },
+                                )
                                 filteredRooms.isNotEmpty() -> LightLazyScrollView(
                                     // Rows are ~70dp; a uniform estimate keeps the lazy
                                     // scrollbar sane (the SDK computes it per-item).
@@ -337,6 +349,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
                                         "No account. Open Settings to sign in with Beeper or a Matrix homeserver."
                                     },
                                 )
+                                connection?.state == "connecting" -> StatusText("Downloading your chat history…")
                                 else -> StatusText("No conversations.")
                             }
                         }
@@ -410,16 +423,8 @@ private fun RoomRow(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-                if (room.lastMessage.isNotBlank()) {
-                    LightText(
-                        text = room.lastMessage,
-                        variant = LightTextVariant.Detail,
-                        lighten = true,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
-                }
+                // No last-message preview subtext (feedback 2026-08-15): the
+                // row is just the thread name + timestamp + unread count.
             }
             Column(horizontalAlignment = Alignment.End) {
                 LightText(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -20,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -59,6 +61,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import kotlin.math.roundToInt
 
 /** Newest image messages whose bytes start downloading on page arrival. */
 private const val MEDIA_PREFETCH_COUNT = 4
@@ -320,6 +323,9 @@ class ThreadViewModel(
     /** Prepends the page of messages older than the oldest one currently shown. */
     fun loadOlder() {
         val oldest = messages.value.firstOrNull() ?: return
+        // An optimistic "local-…" row is not a real event — paging from it
+        // returns nothing and would dead-end pagination (feedback 2026-08-15).
+        if (oldest.id.startsWith(LOCAL_ROW_PREFIX)) return
         if (loadingMore.value || !hasMore.value) return
         viewModelScope.launch {
             loadingMore.value = true
@@ -351,6 +357,9 @@ class ThreadViewModel(
 
 /** Load the next older page when the topmost visible message is within this many of the end. */
 private const val OLDER_LOAD_THRESHOLD = 3
+
+/** Optimistic rows (not yet echoed by sync) carry this id prefix. */
+private const val LOCAL_ROW_PREFIX = "local-"
 
 class ThreadScreen(
     sealedActivity: SealedLightActivity,
@@ -419,22 +428,23 @@ class ThreadScreen(
         // Read status only makes sense in a 1:1 — groups get no tag at all.
         val latestMessageId = remember(messages) { messages.lastOrNull()?.id }
 
-        // Infinite scroll: the list is newest-at-the-bottom (reverseLayout), so
-        // reaching the top (the highest indices, i.e. older messages) loads the
-        // next page automatically — no "Earlier messages" tap. New items are
-        // appended above the viewport, so the reading position stays put.
+        // Infinite scroll, polled rather than snapshotFlow-driven: in this
+        // Compose version reads of LazyListState.layoutInfo don't invalidate
+        // snapshotFlow/derivedStateOf on every scroll (verified 2026-08-15), so
+        // a snapshotFlow trigger never fired — the list sat at its top with
+        // older messages one page away and "older messages don't load". The
+        // poll reads the real layout info each tick; the loadOlder condition
+        // is index-exact (the topmost visible index vs the total), so rows
+        // prepended above the viewport don't re-trigger it.
         LaunchedEffect(listState) {
-            snapshotFlow {
+            while (true) {
                 val info = listState.layoutInfo
-                // reverseLayout: the topmost visible item carries the highest
-                // index. The max visible index is the topmost regardless of
-                // how visibleItemsInfo orders its entries.
-                info.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
-            }.distinctUntilChanged().collect { topIndex ->
-                val total = listState.layoutInfo.totalItemsCount
+                val topIndex = info.visibleItemsInfo.maxOfOrNull { it.index } ?: -1
+                val total = info.totalItemsCount
                 if (total > 0 && topIndex >= total - OLDER_LOAD_THRESHOLD) {
                     viewModel.loadOlder()
                 }
+                delay(if (listState.isScrollInProgress) 50L else 300L)
             }
         }
 
@@ -466,38 +476,86 @@ class ThreadScreen(
                             // (Phase 9); display order is newest-first because
                             // reverseLayout puts index 0 at the bottom.
                             val rows = remember(messages) { buildThreadRows(messages) }
-                            LazyColumn(
-                                state = listState,
-                                reverseLayout = true,
-                                modifier = Modifier.fillMaxSize(),
-                            ) {
-                                items(rows, key = { it.key }) { row ->
-                                    when (row) {
-                                        is ThreadRow.Message -> MessageRow(
-                                            row.message,
-                                            // In a 1:1 the other person's name is
-                                            // redundant — the thread is the
-                                            // conversation with them. In groups,
-                                            // the name shows at the start of each
-                                            // sender's group (same rows that carry
-                                            // the timestamp).
-                                            showSender = !room.isDirect && row.showTime,
-                                            showTime = row.showTime,
-                                            showReadStatus = showReadStatus,
-                                            showDeliveryTag = row.message.id == latestMessageId && room.isDirect,
-                                            mediaBytes = mediaBytes,
-                                            allowMobile = downloadOverMobile,
-                                            playing = row.message.id == playingEventId,
-                                            playingPositionMs = playingPositionMs,
-                                            playingPositionAtMs = playingPositionAtMs,
-                                            onEnsureMedia = viewModel::ensureMedia,
-                                            onPlayVoiceNote = viewModel::playVoiceNote,
-                                            onOpenImage = { bytes ->
-                                                navigateTo(screenFactory = { FullscreenImageScreen(it, bytes) })
-                                            },
-                                        )
-                                        is ThreadRow.DayDivider -> DayDivider(row.label)
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                LazyColumn(
+                                    state = listState,
+                                    reverseLayout = true,
+                                    modifier = Modifier.fillMaxSize(),
+                                ) {
+                                    items(rows, key = { it.key }) { row ->
+                                        when (row) {
+                                            is ThreadRow.Message -> MessageRow(
+                                                row.message,
+                                                // In a 1:1 the other person's name is
+                                                // redundant — the thread is the
+                                                // conversation with them. In groups,
+                                                // the name shows at the start of each
+                                                // sender's group (same rows that carry
+                                                // the timestamp).
+                                                showSender = !room.isDirect && row.showTime,
+                                                showTime = row.showTime,
+                                                showReadStatus = showReadStatus,
+                                                showDeliveryTag = row.message.id == latestMessageId && room.isDirect,
+                                                mediaBytes = mediaBytes,
+                                                allowMobile = downloadOverMobile,
+                                                playing = row.message.id == playingEventId,
+                                                playingPositionMs = playingPositionMs,
+                                                playingPositionAtMs = playingPositionAtMs,
+                                                onEnsureMedia = viewModel::ensureMedia,
+                                                onPlayVoiceNote = viewModel::playVoiceNote,
+                                                onOpenImage = { bytes ->
+                                                    navigateTo(screenFactory = { FullscreenImageScreen(it, bytes) })
+                                                },
+                                            )
+                                            is ThreadRow.DayDivider -> DayDivider(row.label)
+                                        }
                                     }
+                                }
+                                // Thread rows vary in height, so the SDK's
+                                // uniform-height LightLazyScrollView can't drive the
+                                // thumb — ThreadScrollBar estimates from the real
+                                // lazy layout (same rail + thumb look as the SDK
+                                // bar). Polled rather than snapshot-driven: reads of
+                                // LazyListState.layoutInfo don't invalidate on every
+                                // scroll in this Compose version (verified on-device),
+                                // so derivedStateOf/snapshotFlow go stale.
+                                var scrollMetrics by remember {
+                                    mutableStateOf(listState.threadListMetrics())
+                                }
+                                LaunchedEffect(listState) {
+                                    while (true) {
+                                        scrollMetrics = listState.threadListMetrics()
+                                        delay(
+                                            if (listState.isScrollInProgress) 50L else 300L,
+                                        )
+                                    }
+                                }
+                                if (scrollMetrics.overflows) {
+                                    val scope = rememberCoroutineScope()
+                                    ThreadScrollBar(
+                                        contentScrollOffsetPx = scrollMetrics.displayScrollPx,
+                                        maxContentScrollOffsetPx = scrollMetrics.maxScrollPx,
+                                        onScrollTo = { targetPx ->
+                                            val m = scrollMetrics
+                                            if (m.maxScrollPx > 0f && m.avgItemHeightPx > 0f) {
+                                                // targetPx is in flipped (display)
+                                                // space — convert back to list space.
+                                                val target = (m.maxScrollPx - targetPx)
+                                                    .coerceIn(0f, m.maxScrollPx)
+                                                val itemCount = listState.layoutInfo.totalItemsCount
+                                                if (itemCount > 0) {
+                                                    val index = (target / m.avgItemHeightPx)
+                                                        .toInt().coerceIn(0, itemCount - 1)
+                                                    val offset = (target - index * m.avgItemHeightPx)
+                                                        .roundToInt()
+                                                    scope.launch { listState.scrollToItem(index, offset) }
+                                                }
+                                            }
+                                        },
+                                        modifier = Modifier
+                                            .align(Alignment.CenterEnd)
+                                            .fillMaxHeight(),
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScrollBar.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScrollBar.kt
@@ -1,0 +1,213 @@
+package com.lightphone.chats.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.thelightphone.sdk.ui.LightThemeTokens
+import com.thelightphone.sdk.ui.gridUnitsAsDp
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * Scrollbar for the thread's reverseLayout LazyColumn. The SDK's
+ * [com.thelightphone.sdk.ui.LightLazyScrollView] assumes uniform row heights,
+ * which message rows don't have, and its [com.thelightphone.sdk.ui.LightScrollView]
+ * bar is private; the Compose 2026 BOM (foundation 1.10) removed the stock
+ * scrollbar API entirely. So this is a small port of the SDK's bar (identical
+ * rail + thumb, drag + tap), fed by metrics estimated from the real lazy
+ * layout instead of a uniform height.
+ */
+
+private const val SCROLLBAR_WIDTH_UNITS = 2f
+private const val MIN_THUMB_FRACTION = 0.1f
+private const val MAX_THUMB_FRACTION = 0.85f
+
+/** Scroll metrics for a lazy list, estimated from the real layout info
+ *  (viewport × itemCount / average visible height — the estimate the old
+ *  foundation scrollbar used). Flipped for the thread's reverseLayout so the
+ *  thumb sits at the bottom of the track when the list is at its end
+ *  (the newest message). */
+internal class ThreadListMetrics(
+    val scrollPx: Float,
+    val maxScrollPx: Float,
+    val avgItemHeightPx: Float,
+) {
+    val overflows: Boolean get() = maxScrollPx > 0f
+    /** Display offset for the reverse-layout track: 0 = newest (list end). */
+    val displayScrollPx: Float get() = maxScrollPx - scrollPx
+}
+
+internal fun LazyListState.threadListMetrics(): ThreadListMetrics {
+    val layoutInfo = layoutInfo
+    // viewportStartOffset/EndOffset are the visible viewport's pixel bounds —
+    // in reverseLayout the coordinate space is flipped (start can sit above
+    // end), so take the absolute height; this also avoids this Compose
+    // version's packed `Size` accessor.
+    val viewportHeightPx = abs(layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset).toFloat()
+    val visible = layoutInfo.visibleItemsInfo
+    val totalItems = layoutInfo.totalItemsCount
+    if (totalItems == 0 || visible.isEmpty()) return ThreadListMetrics(0f, 0f, 0f)
+    // LazyListItemInfo.size is the item's pixel height in this Compose version.
+    var totalVisibleHeightPx = 0
+    visible.forEach { totalVisibleHeightPx += it.size }
+    val avgItemHeightPx = totalVisibleHeightPx / visible.size.toFloat()
+    val totalContentPx = totalItems * avgItemHeightPx
+    val maxScrollPx = (totalContentPx - viewportHeightPx).coerceAtLeast(0f)
+    // reverseLayout: the scroll origin is the bottom (index 0 = newest), so the
+    // scroll offset is the laid-out `offset` of the bottom-edge visible item
+    // (the lowest index). Index×avg estimates go stale with variable row
+    // heights; the real offset always tracks the scroll.
+    val scrollPx = visible.minByOrNull { it.index }?.offset?.toFloat()
+        ?.coerceAtMost(maxScrollPx) ?: 0f
+    return ThreadListMetrics(scrollPx, maxScrollPx, avgItemHeightPx)
+}
+
+private data class ScrollBarGeometry(
+    val trackWidthPx: Float,
+    val trackHeightPx: Float,
+    val touchWidthPx: Float,
+    val contentScrollOffsetPx: Float,
+    val maxContentScrollOffsetPx: Float,
+) {
+    private val contentHeightPx = trackHeightPx + maxContentScrollOffsetPx
+    private val visibleContentFraction = trackHeightPx / contentHeightPx
+    private val contentScrollFraction = (contentScrollOffsetPx / maxContentScrollOffsetPx).coerceIn(0f, 1f)
+    private val touchLeftPx = (trackWidthPx - touchWidthPx) / 2f
+    private val touchRightPx = touchLeftPx + touchWidthPx
+
+    val thumbHeightPx = trackHeightPx * visibleContentFraction.coerceIn(MIN_THUMB_FRACTION, MAX_THUMB_FRACTION)
+    val maxThumbOffsetPx = trackHeightPx - thumbHeightPx
+    val thumbOffsetPx = contentScrollFraction * maxThumbOffsetPx
+
+    fun containsTouchX(xPx: Float): Boolean =
+        xPx in touchLeftPx..touchRightPx
+
+    fun containsThumb(xPx: Float, yPx: Float): Boolean =
+        containsTouchX(xPx) &&
+            yPx >= thumbOffsetPx &&
+            yPx <= thumbOffsetPx + thumbHeightPx
+
+    fun contentScrollOffsetToPlaceThumbTopAt(thumbTopPx: Float): Float {
+        val fraction = (thumbTopPx / maxThumbOffsetPx).coerceIn(0f, 1f)
+        return fraction * maxContentScrollOffsetPx
+    }
+}
+
+@Composable
+internal fun ThreadScrollBar(
+    contentScrollOffsetPx: Float,
+    maxContentScrollOffsetPx: Float,
+    onScrollTo: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val barColor = LightThemeTokens.colors.content
+    val density = LocalDensity.current
+    val trackWidth = SCROLLBAR_WIDTH_UNITS.gridUnitsAsDp()
+    val railWidth = 1.dp
+    val thumbWidth = 5.dp
+    val touchWidth = thumbWidth * 6
+
+    BoxWithConstraints(
+        modifier = modifier.width(trackWidth),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        val trackHeightPx = with(density) { maxHeight.toPx() }
+        if (trackHeightPx <= 0f) return@BoxWithConstraints
+
+        val geometry = ScrollBarGeometry(
+            trackWidthPx = with(density) { trackWidth.toPx() },
+            trackHeightPx = trackHeightPx,
+            touchWidthPx = with(density) { touchWidth.toPx() },
+            contentScrollOffsetPx = contentScrollOffsetPx,
+            maxContentScrollOffsetPx = maxContentScrollOffsetPx,
+        )
+        val thumbOffsetDp = with(density) { geometry.thumbOffsetPx.toDp() }
+        val thumbHeightDp = with(density) { geometry.thumbHeightPx.toDp() }
+        val currentOnScrollTo by rememberUpdatedState(onScrollTo)
+        val currentGeometry by rememberUpdatedState(geometry)
+
+        fun handleTrackTap(xPx: Float, yPx: Float) {
+            val geometry = currentGeometry
+            if (!geometry.containsTouchX(xPx)) return
+            if (geometry.containsThumb(xPx, yPx)) return
+            val targetThumbTopPx = yPx - geometry.thumbHeightPx / 2f
+            currentOnScrollTo(geometry.contentScrollOffsetToPlaceThumbTopAt(targetThumbTopPx))
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val startGeometry = currentGeometry
+                        if (!startGeometry.containsThumb(down.position.x, down.position.y)) {
+                            return@awaitEachGesture
+                        }
+
+                        down.consume()
+                        val dragStartThumbOffsetPx = startGeometry.thumbOffsetPx
+                        var dragAmountPx = 0f
+
+                        drag(down.id) { change ->
+                            change.consume()
+                            val geometry = currentGeometry
+
+                            dragAmountPx += change.position.y - change.previousPosition.y
+                            val newThumbTop = (dragStartThumbOffsetPx + dragAmountPx)
+                                .coerceIn(0f, geometry.maxThumbOffsetPx)
+                            currentOnScrollTo(geometry.contentScrollOffsetToPlaceThumbTopAt(newThumbTop))
+                        }
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        handleTrackTap(offset.x, offset.y)
+                    }
+                },
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(railWidth)
+                    .fillMaxHeight()
+                    .align(Alignment.Center)
+                    .background(barColor),
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .offset(y = thumbOffsetDp)
+                    .width(trackWidth)
+                    .height(thumbHeightDp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(thumbWidth)
+                        .fillMaxHeight()
+                        .background(barColor),
+                )
+            }
+        }
+    }
+}

--- a/push/README.md
+++ b/push/README.md
@@ -1,0 +1,343 @@
+# Chats push — test rig for push-without-Google on the LP3
+
+How the LP3 can receive Beeper/Matrix push with **no Google services**: the
+standard Matrix **HTTP pusher** path — the same mechanism Beeper's own clients
+use (their config points at `sygnal.beeper.com`, Matrix's reference push
+gateway; the Beeper desktop client on this Linux box is the live proof that
+Beeper → non-FCM delivery exists).
+
+```
+matrix homeserver                    your Linux box (gateway.py)          LP3
+┌──────────────────┐   POST /_matrix/ ┌──────────────────┐   channel    ┌──────────────┐
+│ message arrives  │  push/v1/notify  │  /notify (queue) │ ◄─────────── │ companion    │
+│ push rules match │ ───────────────► │  /wait (long-poll)│  holds open │ wakes, syncs │
+│ pusher data.url  │                  │  /events (SSE)   │             │ once, notif  │
+└──────────────────┘                  └──────────────────┘             └──────────────┘
+```
+
+No tokens leave the phone: the gateway is a dumb relay. The phone gets a
+notification (room, event id, sender, count), does **one** `/sync`, posts the
+local notification, and goes quiet — instead of the current always-on
+long-poll / 5-min rounds.
+
+## Two theories, one gateway, both proven against the local dev Synapse
+
+- **Theory A — self-hosted gateway + companion-held channel.** The companion
+  (or a tiny daemon) keeps one outbound connection to a small gateway on the
+  user's always-on Linux box. `POST /notify` receives the homeserver push;
+  `GET /wait` is the long-poll channel (reconnect on timeout). The LP3 uses
+  OkHttp (already a Trixnity dependency). **PASS (2026-08-16, local Synapse).**
+- **Theory B — UnifiedPush shape.** `GET /events` is an SSE stream (with
+  heartbeats) — exactly the delivery channel a UnifiedPush gateway exposes.
+  The companion could instead be a UP connector with a distributor app on the
+  LP3. Same gateway, same pusher registration. **PASS (2026-08-16, local
+  Synapse).** Not chosen for v1: adds a distributor app; Theory A is fewer
+  moving parts on a calmness-first device.
+- **Theory C — Beeper-native (observation, not built).** Register the pusher
+  with `data.url = https://sygnal.beeper.com` and connect a websocket to
+  sygnal directly — no self-hosted gateway. Same gating question as A/B
+  (does matrix.beeper.com honor an external pusher?), but depends on Beeper's
+  private infra for every delivery. Kept as a fallback if A/B's gating test
+  fails.
+
+## Findings that matter for the real build
+
+- **Modern homeservers use `POST /_matrix/client/v3/pushers/set`** with a
+  **flat** body: `app_id`, `pushkey`, `kind: "http"`, `app_display_name`,
+  `device_display_name`, `lang`, `data.url`. The legacy `PUT /pushers` is gone
+  (this Synapse; Trixnity's `api.push.setPushers` targets the new endpoint).
+  Delete = same endpoint with `kind: null`.
+- **The gateway URL must end in `/_matrix/push/v1/notify`** (Synapse
+  validates this; Beeper's fork may not — the gateway serves both paths).
+- **Synapse blocks pusher URLs to loopback/private IPs** by default (SSRF
+  guard, `403 IP address blocked` in the log). The dev homeserver config at
+  `/tmp/synapse/homeserver.yaml` got an `ip_range_whitelist` for
+  loopback/private (backup: `homeserver.yaml.bak-push-test`). Undo = restore
+  the backup + restart. Only the dev server — real Beeper pushes come from
+  their servers to a public URL.
+- **Full-format notify payload** carries `room_id`, `event_id`, `sender`,
+  `prio`, `count` and the event `content` — enough to render a notification
+  without syncing; `format: "event_id_only"` shrinks it further if wanted.
+- Delivery is asynchronous: Synapse's pusher loop retries with backoff
+  (`Push failed: delaying for Ns`), so a gateway being briefly down is not
+  data loss.
+
+## Run the tests
+
+Requires the local dev Synapse on `127.0.0.1:8008` (running; see root
+`AGENTS.md`). Uses **dummy users on the local dev server only** — nothing
+real, nothing sent anywhere.
+
+```bash
+python3 gateway.py 8721 &          # the gateway
+python3 test_local.py 8721 longpoll   # Theory A: homeserver -> POST -> /wait -> sync
+python3 test_local.py 8721 sse        # Theory B: same, delivered over SSE
+```
+
+`test_local.py` registers a fresh dummy user pair, registers the pusher,
+delivers a message, asserts the notification arrives with the right event id +
+body, then asserts a one-shot `/sync` sees the event, and deletes the pusher.
+
+## LP3 companion integration — IMPLEMENTED (2026-08-16, emulator + LIVE verified)
+
+The direct-SSE channel lives in the companion (`PushChannel.kt`, one object):
+
+1. On login + session restore (`MatrixRepository`): registers the Matrix
+   pusher with `app_id = "com.lightphone.chats"`, a persisted per-install
+   `pushkey`, `format = "event_id_only"` and `data.url` = the gateway's notify
+   endpoint. Idempotent — the same pushkey replaces the pusher on every start.
+2. `PushChannel` holds the OkHttp SSE subscription to the same gateway (manual
+   SSE line-reading on the OkHttp already on the classpath via Trixnity —
+   zero new dependencies; reconnect with backoff; **`readTimeout(90s)`** — the
+   gateway heartbeats every 15s and ntfy's JSON stream keeps a ~45s keepalive,
+   so 90s of silence = dead connection, forcing a reconnect instead of
+   blocking on a half-open socket). Accepts both `data: {…}` SSE frames
+   (gateway.py) and bare `{…}` lines (ntfy's raw JSON stream). On a
+   notification: one `syncOnce(Presence.OFFLINE)`
+   (`MatrixRepository.onPushDelivered`), which the existing notification
+   watcher turns into the local notification via `ChatNotifier`, then idle.
+   **The wake is unconditional once a notification payload is recognized** —
+   Beeper sends counts-style payloads WITHOUT room/event ids
+   (read-receipt/unread updates), and those still warrant a sync.
+3. The screen-off 5-min `syncOnce` rounds stay as the fallback delivery (a
+   silent SSE drop must not mean missed messages) — push makes delivery
+   instant instead of up to 5 minutes late. Now that live delivery is proven,
+   they can be loosened or dropped (O4, PLAN.md).
+
+No tokens or message content leave the phone: `event_id_only` payloads carry
+no content or keys — push is a wake-up signal only.
+
+Config (URLs required — **no default**, polling-only when unset):
+```bash
+adb shell am start -n com.lightphone.chats.server/.MainActivity \
+  --es pushsse <url>      # SSE subscription URL (from the phone's side)
+  --es pushnotify <url>   # pusher data.url (from the homeserver's side)
+  --es pushkey <url>      # pusher pushkey — ntfy routing needs https://ntfy.sh/<topic>
+adb shell am start -n com.lightphone.chats.server/.MainActivity --es pushclear 1  # remove pusher + config (cleanup)
+```
+Two URLs are needed because one side sees the gateway from the phone and the
+other from the homeserver: `pushnotify` must be **public** (Beeper POSTs from
+their servers — a tunnel to the gateway, or ntfy.sh), while `pushsse` is
+whatever the phone can reach (LAN IP, tunnel, `adb reverse` loopback in dev,
+or ntfy.sh's `/json` stream). **The `/_matrix/push/v1/notify` path is
+mandatory** — both Synapse and Beeper reject any other path. ntfy.sh serves
+exactly that path (see "ntfy.sh WORKS" below).
+
+**Verified end-to-end on the emulator (2026-08-16):** dev Synapse → gateway.py
+→ SSE → companion with a dummy account pair — `pusher registered`,
+`SSE connected`, `push received: room=… event=…`, then
+`ChatNotifier: notify <room> — <sender>: <body>` for both screen-on (long-poll
+already delivers; push is the parallel signal) and screen-off idle (slow-sync
+engaged; the push-wake `syncOnce` was the only delivery path). Logcat tags:
+`PushChannel`.
+
+## ntfy.sh WORKS — Matrix Push Gateway at the required path (2026-08-16 re-verification)
+
+Earlier entries in this file called ntfy.sh "dead" — that was wrong. ntfy
+implements a **Matrix Push Gateway** (`/_matrix/push/v1/notify`, docs
+§Matrix Gateway) that routes each push **by the `pushkey` in the payload** to
+an ntfy topic — the body-routing that was assumed not to exist.
+
+**Verified end-to-end (2026-08-16, live):**
+1. **Homeservers accept the URL** — `data.url = https://ntfy.sh/_matrix/push/v1/notify`:
+   local Synapse returns 200 (fresh 4-URL registration test) and **Beeper
+   accepted it on the real account** (`setPushers ACCEPTED`, `--es pushtest`).
+   The path check is path-only — the host is not inspected
+   (`synapse/push/httppusher.py:157`, "url must have a path of
+   '/_matrix/push/v1/notify'").
+2. **ntfy accepts the payloads** — POSTs of Beeper's exact recorded shapes
+   (event-style and counts-style) return `200 {"rejected":[]}` and publish to
+   the topic named by the pushkey.
+3. **App chain (emulator, local Synapse, dummy users):** pusher registered with
+   the URL pushkey → message from user B → Synapse POSTs → ntfy routes → SSE →
+   `push received → waking one sync` → `ChatNotifier` notification.
+4. **The pushkey must be a full URL** (`https://ntfy.sh/<topic>`); bare strings
+   are rejected by the gateway (`{"rejected":[...]}`). Per-install random
+   topic = a private bearer token (topic-as-password), not shared.
+
+**Working config (all three extras):**
+```bash
+--es pushkey https://ntfy.sh/<random-topic>          # routing: pushkey IS the topic URL
+--es pushsse https://ntfy.sh/<random-topic>/json     # ntfy raw JSON stream
+--es pushnotify https://ntfy.sh/_matrix/push/v1/notify
+```
+(`--es pushkey` added 2026-08-16; default stays a random UUID for gateway.py.)
+
+**Current install state (2026-08-17, DEPLOYED):** the LP3 runs the final
+auto-provisioning build — push is **on with zero setup** (install → launch →
+auto-provisions a private ntfy topic `chats-<32-hex>` → registers the pusher
+on Beeper → SSE). Live-verified on the emulator (install-and-go cycle:
+pushclear → relaunch → fresh topic → `?since=all` → push received →
+notification). **Beeper→ntfy delivery live-proven** (real counts-style POST
+landed on the topic; the phone's SSE consumed a synthetic POST in real
+time). Note-to-self pushes stay intermittent on Beeper's fork (state-update
+payloads); the reliable trigger is incoming bridged traffic. Lifecycle:
+config is static per install (prefs), regenerated only by `--es pushclear 1`
+(which now also clears the `?since` resume point). To re-test/cleanup:
+`--es pushclear 1`.
+
+**Caveats:** ntfy's gateway has a cold-topic rejection path (a push is
+rejected if the topic has no recent visitor AND the publish hits a storage
+error) — keep the SSE connected; it reconnects with backoff and stays warm.
+A silent SSE gap is caught by the 5-min fallback rounds (no data loss).
+`format=event_id_only` keeps message content off ntfy — a leaked topic leaks
+event/room ids only. The matrix-push path is receive-only, exactly like the
+gateway.
+
+**Cross-checked against canonical sources (2026-08-17)** — ntfy server
+`server_matrix.go`, ntfy-android `ApiService`/`JsonConnection`,
+unifiedpush.org gateway docs, docs.ntfy.sh §Matrix Gateway. Verdict: pipeline
+matches the canonical design — pushkey must start with the gateway base URL
+(`HasPrefix(pushkey, baseURL+"/")`) and IS the publish URL (topic = path);
+the gateway parses `notification.devices[].pushkey` (devices under
+notification — the shape Synapse/Beeper actually send) and uses only the
+first device; rejection only for non-prefixed pushkeys or a topic cold > 12 h
+(+ a 507). **The one gap found vs the canonical client — the `?since` resume
+param — is FIXED (2026-08-17):** `PushChannel` now persists the last ntfy
+message id (`push_last_msg_id`) and subscribes as `?since=<id>` (first ever
+connect: `since=all`), so a reconnect replays pushes published during the gap
+(ntfy caches ~12 h for exactly this, docs/subscribe/api.md §since). Verified
+on the emulator: message B sent while the app was stopped was replayed on
+relaunch (`SSE connected …?since=<A-id>` → `push received`). The 5-min
+polling fallback remains for the other gap class — Beeper not POSTing at all
+(their note-to-self intermittency) — which no `since` can fix.
+
+## Verdict (2026-08-16) — after Beeper acceptance test + LIVE end-to-end proof
+
+- ✅ **`matrix.beeper.com` accepts external HTTP pushers and DELIVERS to them
+  on real messages — live-proven 2026-08-16.** Full chain on the real account:
+  Beeper's pusher loop POSTed both event notifications (WhatsApp-bridge
+  messages: `room_id` + `event_id` + `sender` + `counts`, `prio=high`) and
+  counts-only payloads (read-receipt/unread updates with `com.beeper.*`
+  fields, no event id) → gateway → SSE → the phone's `PushChannel` logged
+  `push received` → wake `syncOnce` → `ChatNotifier`. Push-rule matching
+  applies as usual: a note-to-self **without** the user's name matched no
+  rule (no POST); with the name it did.
+- ✅ **Beeper's own push infra is not usable by an external client.** Their
+  sygnal instance (and upstream sygnal, incl. their fork) has **only
+  APNS + FCM/WebPush pushkins — no websocket channel**; the public hostname
+  404s everything. `bpns.beeper.com` is the "Beeper Push Notification
+  Service" — a server-side relay for *third-party network* credentials
+  (iMessage/Signal) that still wakes devices **via Google FCM** (their
+  Google-free desktop uses raw FCM/MCS, `beeper/push-receiver`). Beeper has
+  **no Beeper-owned push-to-device channel**. Private, undocumented, already
+  locked down — not a dependency.
+- ❌ **No websocket sync** on matrix.beeper.com (msc3883 absent) — but it does
+  advertise **simplified sliding sync** (`org.matrix.simplified_msc3575`),
+  a lever for cheaper polling.
+
+## Production architecture — who hosts the relay is the real question
+
+**Constraint (unchanged since the original design): the general public cannot
+be expected to run an always-on box.** That is exactly why the ntfy.sh path
+matters — and it WORKS (verified 2026-08-16, see the ntfy.sh section above):
+ntfy serves the exact `/_matrix/push/v1/notify` path as a Matrix Push
+Gateway that routes by the pushkey, so the no-box option is alive again. Two
+proven endpoint choices: the user's own box (gateway.py) or ntfy.sh's shared
+gateway.
+
+**Deployment 1 — the user's own box (works today, proven live):** the
+companion's own gateway (`gateway.py`) on an always-on box, reachable by
+Beeper over a **public tunnel**, and by the phone over LAN/tunnel/adb-reverse:
+
+- `pushnotify = https://<public-tunnel>/_matrix/push/v1/notify` (Beeper
+  POSTs here; the tunnel forwards to the local gateway).
+- `pushsse = http://<gateway-host>:8721/events` (whatever the phone can
+  reach — LAN IP at home, the same tunnel when away, `adb reverse` in dev).
+- Beeper POSTs → tunnel → gateway → SSE → one `syncOnce` → `ChatNotifier` →
+  idle. No FGS sync traffic between messages beyond the 5-min fallback rounds.
+- This is the natural deployment for users who DO have an always-on box
+  (this workspace's box is one). The tunnel is the only new infrastructure
+  (a named Cloudflare tunnel/Tailscale Funnel/VPS for stability). The pusher
+  is registered by the app at login; `--es pushclear 1` removes it.
+
+**Deployment 2 — a hosted relay for everyone (the general-public answer):**
+one public service serves `/_matrix/push/v1/notify` and routes each
+notification to the right phone **by the `pushkey` in the payload body**
+(the Matrix notify body carries `devices[].pushkey` — no per-user path
+secret needed, unlike ntfy). Each install registers its SSE channel with the
+relay under its pushkey at login; the phone holds the SSE, exactly as in
+Deployment 1, but pointed at the shared relay. This is the same shape as a
+Matrix push gateway with a websocket/SSE channel (upstream sygnal lacks
+one; a chats/community relay would fill it). Cost: the relay must be hosted
++ maintained — the same box run as a public service, or community infra.
+A UnifiedPush distributor app is the standard way devices register channels
+with such a relay (the README rejected it for v1 only as "an extra app on
+the LP3" in the box-owning context — it becomes the natural fit for a
+hosted relay).
+
+**No-box hosting for the relay (not built yet):** a Cloudflare Worker +
+Durable Object can host it on the free tier — the Worker serves
+`/_matrix/push/v1/notify` (any path is fine on a Worker route), each phone
+opens an SSE/WebSocket to `https://<worker>/channel/<pushkey>` backed by a
+Durable Object per pushkey, and the Worker forwards Beeper's POST (routed by
+the body's `pushkey`) to the object holding that phone's channel. ~150 lines
+of Worker code, no box, no tunnel, no cost — the concrete no-always-on-box
+production path.
+
+**Fallback: polling** (already built) — the only zero-third-party,
+zero-infrastructure option, works for everyone today. If Beeper's
+simplified sliding sync (`org.matrix.simplified_msc3575`) is usable, polling
+gets much cheaper.
+
+Trade-off vs the UP-standard path (distributor app + connector lib): the
+distributor's value is sharing ONE connection across many apps — with a
+single app it's pure overhead (an extra app on the LP3). If chats ever wants
+multi-app push sharing, the UP connector is a drop-in upgrade; the pusher
+registration doesn't change.
+
+## Encryption — no issue
+
+Push is a **wake-up signal only**: the notification payload (`event_id_only`)
+carries no message content and no keys. All megolm sessions stay on-device;
+the phone fetches the event through its own authenticated, encrypted `/sync`
+and decrypts locally. Exactly how E2EE messengers treat push everywhere.
+
+## What's next
+
+1. **✅ LIVE DELIVERY TEST PASSED (2026-08-16):** Beeper POSTs to an external
+   HTTP pusher on real messages — event-style AND counts-style payloads,
+   received end-to-end on the LP3 (`push received` → wake → `ChatNotifier`).
+   The test pusher was removed afterwards (`--es pushclear 1`).
+2. **✅ ntfy.sh IS THE PRODUCTION PATH (2026-08-16/17):** ntfy serves the exact
+   `/_matrix/push/v1/notify` path as a Matrix Push Gateway that routes by the
+   pushkey — no box, no tunnel. The LP3 runs the auto-provisioning build
+   (install → launch → private ntfy topic → pusher on Beeper → SSE, zero
+   setup). The self-hosted gateway/tunnel deployment (a named Cloudflare
+   tunnel `push.fenleon.com` built 2026-08-16, both legs verified) was
+   **torn down the same day** — ntfy makes it obsolete.
+3. Once running in production: the 5-min fallback rounds are proven redundant
+   — loosen `SLOW_SYNC_INTERVAL_MS` or drop the rounds entirely (O4 end
+   state), then an LP3 overnight `batterystats` for the real battery score.
+4. Transport notes from the test: adb-reverse (USB) is fine for dev but can
+   stall silently — the SSE `readTimeout(30s)` self-heals; the phone's wifi
+   path to the gateway LAN IP is the solid production route (host firewall
+   permitting).
+
+## What you can do to help (user actions, 2026-08-17)
+
+Push is **deployed on the LP3 with zero setup** (ntfy auto-provisioning —
+see "ntfy.sh WORKS" above; the earlier self-hosted tunnel experiment was
+torn down as obsolete). What's left is measurement:
+
+1. **Use the app normally for a day or two** and report: notification latency
+   with the screen off, and any missed messages (the 5-min fallback rounds
+   catch silent drops, so nothing is lost — that's their job).
+2. **Overnight `batterystats` on the push build** — the real battery score.
+   Same ritual as the polling audit: install, `batterystats --reset`, unplug,
+   screen off overnight, hand the phone back in the morning. Compare vs the
+   polling baseline (84.8 mAh, 17% of a core, 1.3%/h).
+3. **Optional: run the sliding-sync probe against the real account** — the
+   hook (`runSlidingSyncProbe`, `--es slidingsync 1`) is built and
+   emulator-verified against the local Synapse (R1-R4, scale, incremental
+   deltas all PASS — see WORKLOG top entry). What's unproven is Beeper's
+   side; one receive-only run tells us if polling gets ~10× cheaper and push
+   stops being urgent. (WORKLOG 2026-08-17.)
+
+## Safety boundary
+
+This rig only ever talks to the **local dev Synapse with throwaway users**.
+Real-account tests (the live delivery test, the sliding-sync probe) are
+receive-only — register a pusher / read an endpoint, never send or deliver
+anything to anyone; per user instruction they still require explicit go-ahead
+before touching the real account.

--- a/push/gateway.py
+++ b/push/gateway.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Chats push gateway — Matrix HTTP pusher endpoint + device delivery.
+
+Receives Matrix push notifications (POST /notify, the homeserver side) and
+delivers them to connected devices over two channels:
+
+  GET /wait   — HTTP long-poll: returns one queued notification, blocks up
+                to POLL_TIMEOUT s when the queue is empty. (Theory A: the
+                LP3 companion's laziest persistent channel — reconnect on
+                timeout.)
+  GET /events — SSE stream: one `data: <json>` line per notification, with
+                periodic heartbeats to keep NAT/proxies alive. (Theory B:
+                UnifiedPush-shape delivery — any UP-style client, e.g. a
+                future ntfy-style distributor app, subscribes here.)
+
+The same POST /notify endpoint is what a UnifiedPush gateway exposes to the
+Matrix homeserver, so one server covers both theories.
+
+Stdlib only. Run:  python3 gateway.py [port]   (default 8721)
+"""
+
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+HOST = os.environ.get("PUSH_GATEWAY_HOST", "0.0.0.0")
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8721
+POLL_TIMEOUT = 25  # s; keep under typical NAT idle limits
+
+# One queue per connected "device". Notifications are small; unbounded is fine
+# for a dev gateway. ponytail: single shared queue per process, split per
+# device only if a real deployment ever needs it.
+_notifications: "queue.Queue[dict]" = queue.Queue()
+_sses: set = set()
+_sses_lock = threading.Lock()
+
+
+def _handle_notify(body: dict) -> list:
+    """Accept a Matrix push notification. Returns rejected pushkeys."""
+    notif = (body or {}).get("notification")
+    if not isinstance(notif, dict):
+        return list((body or {}).get("rejected", []))
+    # Queue one copy for the long-poll channel...
+    _notifications.put(notif)
+    # ...and fan out to every live SSE subscriber.
+    event = "data: " + json.dumps(notif) + "\n\n"
+    with _sses_lock:
+        for sse in list(_sses):
+            try:
+                sse.put_nowait(event)
+            except queue.Full:
+                pass
+    return []
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "ChatsPushGateway/0.1"
+
+    # ---- helpers -----------------------------------------------------
+    def _log(self, line: str):
+        # Access log override: keep notify deliveries loud, they're the point.
+        print(f"[{time.strftime('%H:%M:%S')}] {line}", flush=True)
+
+    def _send(self, code: int, body: str = "", ctype: str = "application/json"):
+        payload = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    # ---- endpoints ---------------------------------------------------
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+        if self.path in ("/notify", "/_matrix/push/v1/notify"):
+            rejected = _handle_notify(body)
+            self._log(f"notify: {_short(body.get('notification'))} -> {len(_sses)} sse, queued")
+            self._log(f"notify payload: {json.dumps(body)[:400]}")
+            self._send(200, json.dumps({"rejected": rejected}))
+        else:
+            self._log(f"POST {self.path} 404")
+            self._send(404, json.dumps({"error": "not found"}))
+
+    def do_GET(self):
+        if self.path == "/wait":
+            self._log("wait: long-poll connected")
+            try:
+                notif = _notifications.get(timeout=POLL_TIMEOUT)
+            except queue.Empty:
+                notif = None
+            self._send(200, json.dumps({"notification": notif}))
+            self._log(f"wait: delivered {'notification' if notif else 'timeout'}")
+        elif self.path == "/events":
+            self._log("events: SSE connected")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            sse: "queue.Queue[str]" = queue.Queue(maxsize=64)
+            with _sses_lock:
+                _sses.add(sse)
+            try:
+                while True:
+                    try:
+                        event = sse.get(timeout=15)
+                    except queue.Empty:
+                        event = ": heartbeat\n\n"  # keep the socket alive
+                    self.wfile.write(event.encode())
+                    self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                with _sses_lock:
+                    _sses.discard(sse)
+                self._log("events: SSE disconnected")
+        else:
+            self._log(f"GET {self.path} 404")
+            self._send(404, json.dumps({"error": "not found"}))
+
+    def log_message(self, *args):  # silence BaseHTTPRequestHandler's stderr noise
+        pass
+
+
+def _short(notif) -> str:
+    if not isinstance(notif, dict):
+        return "<empty>"
+    n = notif.get("notification") or notif
+    return (f"room={n.get('room_id','?')[:16]} event={n.get('event_id','?')[:16]} "
+            f"sender={n.get('sender','?')} prio={n.get('prio','?')}")
+
+
+if __name__ == "__main__":
+    print(f"gateway on http://{HOST}:{PORT}  (notify /wait /events)", flush=True)
+    ThreadingHTTPServer((HOST, PORT), Handler).serve_forever()

--- a/push/test_local.py
+++ b/push/test_local.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""End-to-end Matrix push test against the local Synapse dev homeserver.
+
+Theory A proof: homeserver -> POST /notify -> gateway -> long-poll client.
+
+Flow (all dummy users on the LOCAL dev Synapse, nothing touches a real
+account):
+  alice registers a Matrix HTTP pusher whose data.url points at the gateway
+  bob sends a message to a room alice is in
+  the homeserver POSTs a notification to the gateway
+  the long-poll channel (/wait) returns it
+  alice does one /sync (the "push-wake" step) and sees the event
+
+Usage:  python3 test_local.py [gateway_port]   (default 8721)
+Requires: the local Synapse on 127.0.0.1:8008 and gateway.py running.
+"""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+HS = "http://127.0.0.1:8008"
+GATEWAY_PORT = int(sys.argv[1] if len(sys.argv) > 1 else 8721)
+CHANNEL = sys.argv[2] if len(sys.argv) > 2 else "longpoll"  # longpoll (Theory A) | sse (Theory B)
+GATEWAY = f"http://127.0.0.1:{GATEWAY_PORT}"
+USER = f"pushuser{int(time.time()) % 100000}"  # fresh user per run
+
+print(f"homeserver={HS} gateway={GATEWAY} user={USER} channel={CHANNEL}", flush=True)
+
+
+def req(method, url, body=None, token=None, timeout=30):
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    r = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=timeout) as resp:
+            raw = resp.read()
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, {"raw": raw.decode(errors="replace")}
+
+
+def register(user):
+    # Open registration on the dev server; retry with m.login.dummy if needed.
+    for attempt in range(6):
+        code, body = req("POST", f"{HS}/_matrix/client/v3/register",
+                         {"username": user, "password": "pw", "auth": {"type": "m.login.dummy"}})
+        if code == 401 and "flows" in body:
+            code, body = req("POST", f"{HS}/_matrix/client/v3/register",
+                             {"username": user, "password": "pw",
+                              "auth": {"type": "m.login.dummy", "session": body.get("session")}})
+        if code == 200:
+            return body["user_id"], body["access_token"]
+        if code == 429:  # dev Synapse rate-limits registrations
+            time.sleep(body.get("retry_after_ms", 1000) / 1000 + 0.5)
+            continue
+        assert False, f"register failed: {code} {body}"
+    assert False, f"register failed after retries: {code} {body}"
+
+
+def login(user):
+    code, body = req("POST", f"{HS}/_matrix/client/v3/login",
+                     {"type": "m.login.password",
+                      "identifier": {"type": "m.id.user", "user": user},
+                      "password": "pw"})
+    assert code == 200, f"login failed: {code} {body}"
+    return body["user_id"], body["access_token"]
+
+
+def main():
+    alice, at = register(f"{USER}a")
+    bob, bt = register(f"{USER}b")
+
+    code, room = req("POST", f"{HS}/_matrix/client/v3/createRoom", {
+        "name": "Push Test Room", "visibility": "public",
+        "preset": "public_chat",
+    }, token=at)
+    assert code == 200, f"createRoom failed: {code} {room}"
+    room_id = room["room_id"]
+    print(f"room: {room_id}", flush=True)
+
+    code, _ = req("POST", f"{HS}/_matrix/client/v3/join/{room_id}", {}, token=bt)
+    assert code == 200, f"join failed: {code}"
+
+    # alice registers the HTTP pusher -> the gateway. This Synapse serves the
+    # newer pushers/set API (flat body, no "pusher" wrapper) and requires the
+    # gateway URL to end in /_matrix/push/v1/notify.
+    code, body = req("POST", f"{HS}/_matrix/client/v3/pushers/set", {
+        "append": False,
+        "app_id": "com.lightphone.chats.test",
+        "pushkey": "test-pushkey-alice",
+        "kind": "http",
+        "app_display_name": "Chats test",
+        "device_display_name": "Chats test device",
+        "lang": "en",
+        "data": {"url": f"{GATEWAY}/_matrix/push/v1/notify"},
+    }, token=at)
+    assert code == 200, f"set pusher failed: {code} {body}"
+    print("pusher registered (app_id=com.lightphone.chats.test, pushkey=test-pushkey-alice)", flush=True)
+
+    # The delivery channel: what the LP3 companion (long-poll) or a UP-style
+    # distributor app (SSE) will hold open. Run it on a thread so we can send
+    # the message after; both channels tolerate the message arriving before
+    # the subscribe (long-poll queues, SSE replays nothing — so we subscribe
+    # first for SSE, same as a real device would).
+    import http.client
+    import socket
+    import threading
+    wait_result = {}
+
+    def longpoll_receive():
+        try:
+            wait_result["status"], wait_result["body"] = req(
+                "GET", f"{GATEWAY}/wait", timeout=35)
+        except Exception as e:  # noqa: BLE001 - report any transport failure
+            wait_result["error"] = repr(e)
+
+    def sse_receive():
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", GATEWAY_PORT)
+            conn.request("GET", "/events")
+            resp = conn.getresponse()
+            resp.fp.raw._sock.settimeout(35)
+            while True:
+                line = resp.readline().decode(errors="replace")
+                if not line:
+                    break
+                if line.startswith("data: "):
+                    wait_result["body"] = {"notification": json.loads(line[6:].strip())}
+                    conn.close()
+                    return
+            conn.close()
+            wait_result["body"] = {"notification": None}
+        except Exception as e:  # noqa: BLE001
+            wait_result["error"] = repr(e)
+
+    receive = longpoll_receive if CHANNEL == "longpoll" else sse_receive
+    t = threading.Thread(target=receive)
+    t.start()
+    time.sleep(1)  # ensure the channel is attached before the message lands
+
+    # bob sends the message -> Synapse evaluates push rules -> POSTs to gateway
+    code, sent = req("PUT",
+                     f"{HS}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/txn1",
+                     {"msgtype": "m.text", "body": f"push test from {bob}"}, token=bt)
+    assert code == 200, f"send failed: {code} {sent}"
+    event_id = sent["event_id"]
+    print(f"bob sent: {event_id}", flush=True)
+
+    t.join(timeout=40)
+    assert not t.is_alive(), "channel did not return within 35s — no push delivered"
+    assert "error" not in wait_result, f"channel failed: {wait_result['error']}"
+    notif = wait_result["body"].get("notification")
+    assert notif, f"empty notification: {wait_result['body']}"
+    print(f"PUSH DELIVERED ({CHANNEL}): room={notif.get('room_id')} event={notif.get('event_id')} "
+          f"sender={notif.get('sender')} body={notif.get('content', {}).get('body')!r}", flush=True)
+    assert notif.get("event_id") == event_id, "event_id mismatch"
+    assert notif.get("content", {}).get("body") == f"push test from {bob}", "body mismatch"
+
+    # The push-wake step: one short sync pulls the actual event into alice's store.
+    code, sync = req("GET", f"{HS}/_matrix/client/v3/sync?timeout=0", token=at)
+    timeline = sync.get("rooms", {}).get("join", {}).get(room_id, {}).get("timeline", {}).get("events", [])
+    ids = [e.get("event_id") for e in timeline]
+    assert event_id in ids, f"event {event_id} not in alice's sync: {ids}"
+    print(f"SYNC-WAKE OK: event present in alice's /sync (count={len(ids)})", flush=True)
+
+    # Cleanup: delete the pusher (leave the test users on the dev server).
+    code, body = req("POST", f"{HS}/_matrix/client/v3/pushers/set", {
+        "append": False, "app_id": "com.lightphone.chats.test",
+        "pushkey": "test-pushkey-alice", "kind": None,
+    }, token=at)
+    assert code == 200, f"delete pusher failed: {code} {body}"
+    print("pusher removed", flush=True)
+    print(f"THEORY {'B' if CHANNEL == 'sse' else 'A'}: PASS", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.os.IBinder
 import android.util.Log
 import net.folivo.trixnity.clientserverapi.client.SyncState
+import net.folivo.trixnity.core.model.events.m.Presence
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,13 +46,13 @@ class ChatSyncService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification(this))
         serviceScope.launch {
             val c = MatrixRepository.ensureClient() ?: return@launch
-            if (syncedClient !== c && !MatrixRepository.isInProcessSyncRunning) {
+            if (syncedClient !== c && !MatrixRepository.isInProcessSyncRunning && !MatrixRepository.isSlowSyncing) {
                 runCatching { syncedClient?.stopSync() }
-                c.startSync()
+                c.startSync(Presence.OFFLINE)
                 syncedClient = c
                 Log.d(TAG, "sync loop started for ${c.userId.full}")
             } else if (syncedClient !== c) {
-                Log.d(TAG, "in-process sync loop already running for ${c.userId.full} — service is keep-alive only")
+                Log.d(TAG, "in-process/slow sync loop already running for ${c.userId.full} — service is keep-alive only")
             }
             if (watchdogClient !== c) {
                 watchdogClient = c
@@ -72,6 +73,12 @@ class ChatSyncService : Service() {
     private suspend fun startSyncWatchdog(c: net.folivo.trixnity.client.MatrixClient) {
         var stuckSinceMs = 0L
         c.syncState.collect { state ->
+            // Slow sync owns sync while it runs (STOPPED between rounds) —
+            // never restart a long-poll then; MatrixRepository does on wake.
+            if (MatrixRepository.isSlowSyncing) {
+                stuckSinceMs = 0L
+                return@collect
+            }
             val running = state == SyncState.RUNNING || state == SyncState.STARTED ||
                 state == SyncState.INITIAL_SYNC
             val now = android.os.SystemClock.elapsedRealtime()
@@ -83,7 +90,7 @@ class ChatSyncService : Service() {
             if (syncedClient === c && now - stuckSinceMs >= SYNC_RESTART_AFTER_MS) {
                 Log.w(TAG, "sync stuck in $state for ${SYNC_RESTART_AFTER_MS / 1000}s — restarting sync loop")
                 runCatching { c.stopSync() }
-                c.startSync()
+                c.startSync(Presence.OFFLINE)
                 stuckSinceMs = 0L
             }
         }

--- a/server/src/main/kotlin/com/lightphone/chats/server/MainActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MainActivity.kt
@@ -63,6 +63,25 @@ class MainActivity : ComponentActivity() {
             getSharedPreferences("chats_account", MODE_PRIVATE).edit()
                 .putBoolean("debug_logging", it == "1" || it.equals("true", ignoreCase = true)).apply()
         }
+        // Dev-only push channel overrides (2026-08-16, chats/push/README.md):
+        // --es pushsse <url>    the SSE subscription URL (from the phone's side)
+        // --es pushnotify <url> the pusher data.url (from the homeserver's side)
+        // --es pushkey <url>    the pusher pushkey — ntfy routing needs it to
+        //                       be https://ntfy.sh/<topic>; default = random UUID.
+        // Unset: a private ntfy.sh channel is auto-provisioned on first start
+        // (PushChannel) — push works with zero setup after login.
+        intent?.getStringExtra("pushsse")?.let {
+            getSharedPreferences("chats_account", MODE_PRIVATE).edit()
+                .putString("push_sse_url", it).apply()
+        }
+        intent?.getStringExtra("pushnotify")?.let {
+            getSharedPreferences("chats_account", MODE_PRIVATE).edit()
+                .putString("push_notify_url", it).apply()
+        }
+        intent?.getStringExtra("pushkey")?.let {
+            getSharedPreferences("chats_account", MODE_PRIVATE).edit()
+                .putString("push_key", it).apply()
+        }
         MatrixRepository.init(this)
         setContent { DevScreen() }
     }
@@ -81,6 +100,7 @@ private fun DevScreen() {
     //   --es password alicepass [--es sendTo <roomId> --es sendBody <text>]
     // Runs even when a session is restored, so the send can use the existing client.
     val launchExtras = (LocalContext.current as? MainActivity)?.intent?.extras
+    val devContext = LocalContext.current
     LaunchedEffect(Unit) {
         if (launchExtras?.getString("homeserver") != null) {
             val result = MatrixRepository.login(

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -1,10 +1,14 @@
 package com.lightphone.chats.server
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.os.PowerManager
 import androidx.room.Room
 import com.lightphone.chats.server.MatrixRepository.ChatConnectionState
 import io.ktor.client.HttpClient
@@ -30,17 +34,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import net.folivo.trixnity.client.MatrixClient
 import net.folivo.trixnity.client.MatrixClientConfiguration
@@ -54,6 +64,7 @@ import net.folivo.trixnity.client.media.MediaService
 import net.folivo.trixnity.client.media.MediaStore
 import net.folivo.trixnity.client.media.okio.createOkioMediaStoreModule
 import net.folivo.trixnity.client.room
+import net.folivo.trixnity.client.room.GetTimelineEventConfig
 import net.folivo.trixnity.client.room.GetTimelineEventsConfig
 import net.folivo.trixnity.client.room.message.image
 import net.folivo.trixnity.client.room.message.reply
@@ -78,9 +89,11 @@ import net.folivo.trixnity.clientserverapi.model.authentication.IdentifierType
 import net.folivo.trixnity.clientserverapi.model.authentication.LoginType
 import net.folivo.trixnity.clientserverapi.model.rooms.GetEvents.Direction
 import net.folivo.trixnity.clientserverapi.model.rooms.GetEvents.Direction.BACKWARDS
+import net.folivo.trixnity.core.AuthRequired
 import net.folivo.trixnity.core.model.EventId
 import net.folivo.trixnity.core.model.RoomId
 import net.folivo.trixnity.core.model.UserId
+import net.folivo.trixnity.core.model.events.m.Presence
 import net.folivo.trixnity.core.model.events.m.ReceiptType
 import net.folivo.trixnity.core.model.events.m.RelatesTo
 import net.folivo.trixnity.core.model.events.m.key.verification.VerificationMethod
@@ -124,8 +137,11 @@ object MatrixRepository {
     private const val KEY_LOGIN_MODE = "login_mode"
     private const val KEY_BEEPER_REQUEST_ID = "beeper_request_id"
     private const val KEY_SYNC_ENABLED = "sync_enabled"
+    /** When the one-shot megolm restore scan last ran (daily gate, 2026-08-15). */
+    private const val KEY_RESTORE_LAST_RUN_MS = "restore_last_run_ms"
     private const val DB_NAME = "matrix_client"
     private const val MEDIA_DIR = "matrix_media"
+
 
     // PRIVATE Beeper integration — Beeper's private API (undocumented, unstable).
     // These endpoints and the API token stay in the companion only (the chats/
@@ -253,6 +269,65 @@ object MatrixRepository {
 
     val isSyncEnabled: Boolean get() = syncEnabled
 
+    /** Sync cadence. ACTIVE = continuous long-poll while the screen is on;
+     *  SLOW = periodic [net.folivo.trixnity.client.MatrixClient.syncOnce] once
+     *  the screen's been off for a while — the long-poll's per-response
+     *  parse/decrypt/store processing is the main standby cost on an
+     *  always-active bridged account (battery, 2026-08-14). */
+    enum class SyncMode { ACTIVE, SLOW }
+
+    @Volatile
+    private var syncMode = SyncMode.ACTIVE
+
+    /** True while the periodic slow-sync loop owns sync. The FGS/watchdog must
+     *  not restart a long-poll then (ChatSyncService reads this). */
+    val isSlowSyncing: Boolean get() = syncMode == SyncMode.SLOW
+
+    private var slowSyncJob: Job? = null
+    private var screenOffJob: Job? = null
+
+    /** Screen must stay off this long before dropping to slow sync. */
+    private const val SLOW_SYNC_GRACE_MS = 60_000L
+
+    /** Slow-sync cadence: one sync round every 5 min.
+     *  ponytail: 5 min is a session value — tighten if message latency feels
+     *  too high, loosen if battery still burns. */
+    private const val SLOW_SYNC_INTERVAL_MS = 300_000L
+
+    /**
+     * Slow-sync cadence while the push channel is connected (2026-08-17): the
+     * SSE wake delivers messages instantly (each push = one syncOnce), so the
+     * rounds are pure redundancy — stretch them to a 30-min safety net that
+     * still catches a silent SSE/Beeper failure. Without a live channel the
+     * 5-min cadence runs.
+     *  ponytail: 30 min is a session value — if push proves rock-solid over
+     *  nights, drop the net entirely (O4 end state).
+     */
+    private const val SLOW_SYNC_PUSH_NET_MS = 1_800_000L
+
+    /** Screen on/off → sync cadence. Registered on the app context in [init],
+     *  so it lives as long as the process (which the FGS keeps alive). */
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_ON -> {
+                    scope.launch { enterActiveSync() }
+                    // A thread was open when the screen went dark — resume
+                    // keeping its page fresh now that it's visible again.
+                    startActiveRoomRefresh()
+                }
+                Intent.ACTION_SCREEN_OFF -> {
+                    scheduleSlowSync()
+                    // Battery (2026-08-15 audit): the active-room refresh was
+                    // running 24/7 with no visibility coupling — every 2s a full
+                    // page rebuild (SQL chain walk + key-backup restore + API
+                    // re-reads). Nobody is looking while the screen is off.
+                    stopActiveRoomRefresh()
+                }
+            }
+        }
+    }
+
     /** Called once from [ServerApplication]; restores a stored session if there is one. */
     fun init(context: Context) {
         val app = context.applicationContext
@@ -262,6 +337,21 @@ object MatrixRepository {
         // no sync loop and no foreground service — the battery escape hatch.
         syncEnabled = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .getBoolean(KEY_SYNC_ENABLED, true)
+        // Screen-driven cadence: long-poll while the screen is on, periodic
+        // syncOnce after it's been off for a while (battery, 2026-08-14).
+        app.registerReceiver(
+            screenReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+            Context.RECEIVER_NOT_EXPORTED,
+        )
+        // Booted with the screen already dark: no SCREEN_OFF broadcast is
+        // coming — drop to slow sync after the grace instead of long-polling
+        // with nobody watching.
+        val power = app.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        if (power?.isInteractive == false) scheduleSlowSync()
         scope.launch {
             // Restore the session regardless of the sync toggle. GetAccountState
             // reads the live client, so a paused companion that skips the restore
@@ -272,6 +362,10 @@ object MatrixRepository {
             if (ensureClient() != null) {
                 if (syncEnabled) {
                     startSyncLoop(app)
+                    // Push wake-up channel (2026-08-16): register the Matrix
+                    // HTTP pusher + hold the SSE subscription so idle sync has
+                    // zero latency — see PushChannel.
+                    PushChannel.start(app, client!!)
                 } else {
                     _connectionState.value = ChatConnectionState.Offline("sync paused")
                     android.util.Log.d(TAG, "sync disabled by preference — session restored, no sync loop")
@@ -294,20 +388,127 @@ object MatrixRepository {
         syncEnabled = enabled
         val c = client
         if (!enabled) {
+            slowSyncJob?.cancel()
+            slowSyncJob = null
+            screenOffJob?.cancel()
+            screenOffJob = null
+            syncMode = SyncMode.ACTIVE
             runCatching { c?.stopSync() }
             inProcessSyncRunning = false
             activeRoomRefreshJob?.cancel()
             activeRoomRefreshJob = null
+            PushChannel.stop()
             ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
             _connectionState.value = ChatConnectionState.Offline("sync paused")
             android.util.Log.d(TAG, "sync paused by user")
         } else {
+            slowSyncJob?.cancel()
+            slowSyncJob = null
+            screenOffJob?.cancel()
+            screenOffJob = null
+            syncMode = SyncMode.ACTIVE
             if (c == null) {
                 if (ensureClient() != null) startSyncLoop(ctx)
             } else {
                 startSyncLoop(ctx)
             }
+            client?.let { PushChannel.start(ctx, it) }
             android.util.Log.d(TAG, "sync resumed by user")
+        }
+    }
+
+    /**
+     * Drops to the slow cadence once the screen has been dark for the grace
+     * period: stop the long-poll and run periodic [MatrixClient.syncOnce]
+     * rounds instead. The FGS stays (it keeps the process alive for the slow
+     * loop); the manual Settings → Sync toggle is the fully-off control.
+     */
+    private fun scheduleSlowSync() {
+        screenOffJob?.cancel()
+        screenOffJob = scope.launch {
+            delay(SLOW_SYNC_GRACE_MS)
+            // Screen came back on during the grace — [enterActiveSync] already
+            // cancelled this job; this is just paranoia.
+            val power = appContext?.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            if (power?.isInteractive == true) return@launch
+            enterSlowSync()
+        }
+    }
+
+    private suspend fun enterSlowSync() {
+        if (!syncEnabled || syncMode == SyncMode.SLOW) return
+        val c = client ?: return
+        syncMode = SyncMode.SLOW // gate first: the watchdog must not restart the long-poll
+        runCatching { c.stopSync() }
+        inProcessSyncRunning = false
+        slowSyncJob?.cancel()
+        slowSyncJob = startSlowSyncRounds(c)
+        android.util.Log.d(
+            TAG,
+            "sync mode: slow (syncOnce every ${SLOW_SYNC_INTERVAL_MS / 1000}s, " +
+                "push-gated ${SLOW_SYNC_PUSH_NET_MS / 1000}s when SSE connected)",
+        )
+    }
+
+    /** The periodic syncOnce rounds (also restarted by a push-wake — see [onPushDelivered]). */
+    private fun startSlowSyncRounds(c: MatrixClient): Job {
+        val job = scope.launch {
+            while (isActive) {
+                if (client !== c) return@launch // logged out / re-logged in under us
+                runCatching { c.syncOnce(Presence.OFFLINE) }
+                    .onFailure { android.util.Log.w(TAG, "slow sync round failed: ${it.message}") }
+                // Push-health-gated cadence (2026-08-17): while the SSE channel
+                // is connected, pushes deliver messages instantly (each wakes
+                // one syncOnce), so the rounds are pure redundancy — stretch to
+                // a 30-min safety net that still catches a silent SSE/Beeper
+                // failure. Without a live channel (no config, reconnecting,
+                // stopped) fall back to the 5-min cadence.
+                val cadenceMs = if (PushChannel.isConnected) SLOW_SYNC_PUSH_NET_MS else SLOW_SYNC_INTERVAL_MS
+                delay(cadenceMs)
+            }
+        }
+        return job
+    }
+
+    /** Back to the real-time long-poll (screen on, or any reason sync restarts). */
+    private suspend fun enterActiveSync() {
+        screenOffJob?.cancel()
+        screenOffJob = null
+        slowSyncJob?.cancel()
+        slowSyncJob = null
+        if (syncMode == SyncMode.ACTIVE) return
+        syncMode = SyncMode.ACTIVE
+        if (!syncEnabled) return
+        val ctx = appContext ?: return
+        if (client != null) {
+            startSyncLoop(ctx)
+            android.util.Log.d(TAG, "sync mode: active (long-poll)")
+        }
+    }
+
+    /**
+     * Push-wake (2026-08-16, see PushChannel): an SSE push notification
+     * arrived, so a message is waiting. While idle (slow sync, screen off)
+     * run ONE syncOnce round — the notification watcher then posts the local
+     * notification and the room flows update. While active the long-poll
+     * already delivers it, so the push is redundant and skipped. The slow-sync
+     * rounds are the fallback delivery (a silent SSE drop must not mean missed
+     * messages) — push-gated to a 30-min net while the SSE is connected
+     * (2026-08-17, see startSlowSyncRounds).
+     */
+    suspend fun onPushDelivered() {
+        val c = client ?: return
+        if (syncMode != SyncMode.SLOW) return
+        slowSyncJob?.cancel()
+        slowSyncJob = null
+        runCatching { c.syncOnce(Presence.OFFLINE) }
+            .onFailure { android.util.Log.w(TAG, "push-wake sync failed: ${it.message}") }
+        // Restart the fallback rounds. If the screen came back on mid-wake,
+        // enterActiveSync owns sync (its long-poll already delivers); only
+        // restart when it is still dark.
+        val power = appContext?.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        if (syncEnabled && power?.isInteractive == false) {
+            slowSyncJob = startSlowSyncRounds(c)
         }
     }
 
@@ -373,7 +574,7 @@ object MatrixRepository {
         val c = client ?: return
         if (inProcessSyncRunning) return
         inProcessSyncRunning = true
-        runCatching { c.startSync() }
+        runCatching { c.startSync(Presence.OFFLINE) }
             .onFailure { android.util.Log.w(TAG, "in-process sync failed to start: ${it.message}") }
         android.util.Log.d(TAG, "in-process sync loop started for ${c.userId.full}")
         var delayMs = 3_000L
@@ -396,6 +597,9 @@ object MatrixRepository {
                 runCatching { old.stopSync() }
                 client = null
             }
+            // The old client's loop is stopped; a stale flag would silently
+            // kill the new session's sync (re-login after restore/expiry).
+            inProcessSyncRunning = false
             _connectionState.value = ChatConnectionState.Connecting
 
             // Accept a bare domain ("matrix.org") or a full URL; .well-known
@@ -428,7 +632,13 @@ object MatrixRepository {
                 .putString(KEY_LOGIN_MODE, "homeserver")
                 .apply()
         }
+        slowSyncJob?.cancel()
+        slowSyncJob = null
+        screenOffJob?.cancel()
+        screenOffJob = null
+        syncMode = SyncMode.ACTIVE
         startSyncLoop(ctx)
+        PushChannel.start(ctx, client!!)
         client!!
     }
 
@@ -481,6 +691,7 @@ object MatrixRepository {
                 runCatching { old.stopSync() }
                 client = null
             }
+            inProcessSyncRunning = false
             _connectionState.value = ChatConnectionState.Connecting
 
             val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -533,7 +744,13 @@ object MatrixRepository {
                 .remove(KEY_BEEPER_REQUEST_ID)
                 .apply()
         }
+        slowSyncJob?.cancel()
+        slowSyncJob = null
+        screenOffJob?.cancel()
+        screenOffJob = null
+        syncMode = SyncMode.ACTIVE
         startSyncLoop(ctx)
+        PushChannel.start(ctx, client!!)
         client!!
     }
 
@@ -788,8 +1005,25 @@ object MatrixRepository {
      * After the device is verified, load every undecrypted event's megolm session
      * from the server-side key backup so the room store can decrypt it. Called on
      * verification success; loading a session decrypts what the session covers.
+     *
+     * Battery/UX (2026-08-15): gated to at most once per day and bounded tighter
+     * per room. Before, it ran on EVERY process start (reboot/install/force-stop)
+     * and could crawl for 20+ min at several cores, starving the tool's requests
+     * ("Loading messages…" / "…" account). The on-demand page path
+     * (collectRelevantTimelineEvents → restoreRoomSessions) still restores when a
+     * room is actually read, so the daily crawl is only the preemptive pass.
      */
     private suspend fun restoreMegolmSessions() {
+        val ctx = appContext ?: return
+        val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val lastRun = prefs.getLong(KEY_RESTORE_LAST_RUN_MS, 0L)
+        val now = System.currentTimeMillis()
+        if (now - lastRun < RESTORE_INTERVAL_MS) {
+            android.util.Log.d(TAG, "restore: skipped — last run ${(now - lastRun) / 60_000}m ago")
+            return
+        }
+        // Written on START: even a scan that dies mid-run won't re-run for a day.
+        prefs.edit().putLong(KEY_RESTORE_LAST_RUN_MS, now).apply()
         val c = client ?: return
         val keyBackup = runCatching {
             c.di.get<net.folivo.trixnity.client.key.KeyBackupService>(
@@ -815,8 +1049,8 @@ object MatrixRepository {
                 android.util.Log.d(TAG, "restore: $scanned/${rooms.size} rooms scanned, $roomsTouched with encrypted content")
             }
             val events = mutableListOf<TimelineEvent>()
-            val done = withTimeoutOrNull(MESSAGES_BUDGET_MS) {
-                c.room.getLastTimelineEvents(roomId) { maxSize = 100 }
+            val done = withTimeoutOrNull(RESTORE_ROOM_BUDGET_MS) {
+                c.room.getLastTimelineEvents(roomId) { maxSize = RESTORE_ROOM_EVENTS }
                     .filterNotNull().first()
                     .collect { eventFlow ->
                         eventFlow.filterNotNull().firstOrNull()?.let { events.add(it) }
@@ -841,6 +1075,11 @@ object MatrixRepository {
             manualLogout = true
             val old = client
             client = null
+            slowSyncJob?.cancel()
+            slowSyncJob = null
+            screenOffJob?.cancel()
+            screenOffJob = null
+            syncMode = SyncMode.ACTIVE
             inProcessSyncRunning = false
             observedClient = null
             resetVerification()
@@ -848,6 +1087,10 @@ object MatrixRepository {
             pendingNotifyRoomId = null
             stopAudioPlayback()
             resetRoomList()
+            // Drop the push subscription and remove the pusher from the account
+            // (best-effort — an unguessable ntfy topic is harmless if it fails).
+            PushChannel.stop()
+            old?.let { runCatching { PushChannel.unregister(ctx, it) } }
             ChatNotifier.clearAll(ctx)
             runCatching { old?.logout() } // API logout + clears Trixnity's store
             runCatching { old?.closeSuspending() }
@@ -863,6 +1106,7 @@ object MatrixRepository {
     }
 
     fun getClient(): MatrixClient? = client
+
 
     /**
      * Restores a session from the Room store, if one exists (idempotent).
@@ -968,6 +1212,26 @@ object MatrixRepository {
      */
     private val messagePageCache =
         java.util.concurrent.ConcurrentHashMap<String, MessagePageEntry>()
+
+    /** Rooms with a background page refresh currently in flight (battery
+     *  2026-08-15: the 2s ticker used to launch unbounded concurrent rebuilds). */
+    private val messagePageRefreshInFlight =
+        java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+
+    /** Room → its last event id at the previous refresh. An unchanged id means
+     *  nothing new arrived — the refresh skips the rebuild (one cheap read). */
+    private val lastRefreshedEventId = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** Room → elapsed-realtime timestamp until which the futile key-backup
+     *  restore is suppressed (battery 2026-08-15: pre-verification history
+     *  never gets its sessions back, yet every page build retried it). */
+    private val decryptRestoreCooldown = java.util.concurrent.ConcurrentHashMap<String, Long>()
+
+    /** True while the room's key-backup restore is in the futile cooldown. */
+    private fun inDecryptRestoreCooldown(matrixRoomId: RoomId): Boolean {
+        val until = decryptRestoreCooldown[matrixRoomId.full] ?: return false
+        return android.os.SystemClock.elapsedRealtime() < until
+    }
 
     /**
      * Display JPEGs served to the tool for image rows, keyed by
@@ -1113,15 +1377,32 @@ object MatrixRepository {
 
     /** Recomputes and re-stores a room's newest page in the background. */
     private fun refreshMessagePage(roomId: String, limit: Int = THREAD_PAGE_SIZE) {
+        // Battery (2026-08-15 audit): never pile up refreshes — a tick that
+        // finds one already in flight is a no-op (the 2s ticker used to launch
+        // unbounded concurrent rebuilds that saturated the CPU).
+        if (!messagePageRefreshInFlight.add(roomId)) return
         scope.launch {
-            runCatching {
-                val page = computeMessagesPage(roomId, null, limit)
-                messagePageCache[roomId] = MessagePageEntry(
-                    page,
-                    limit,
-                    android.os.SystemClock.elapsedRealtime(),
-                )
-                saveMessagePageToDisk(roomId, page)
+            try {
+                val c = client ?: return@launch
+                // Nothing new since the last refresh → keep the cached page; a
+                // quiet room costs one cheap last-event read per tick instead of
+                // a full chain walk + restore + re-reads.
+                val lastId = withTimeoutOrNull(ROOM_BUDGET_MS) {
+                    c.room.getById(RoomId(roomId)).firstOrNull()?.lastEventId?.full
+                } ?: return@launch
+                if (lastRefreshedEventId[roomId] == lastId) return@launch
+                runCatching {
+                    val page = computeMessagesPage(roomId, null, limit)
+                    messagePageCache[roomId] = MessagePageEntry(
+                        page,
+                        limit,
+                        android.os.SystemClock.elapsedRealtime(),
+                    )
+                    lastRefreshedEventId[roomId] = lastId
+                    saveMessagePageToDisk(roomId, page)
+                }
+            } finally {
+                messagePageRefreshInFlight.remove(roomId)
             }
         }
     }
@@ -1150,7 +1431,7 @@ object MatrixRepository {
                 cached.limit >= limit &&
                 android.os.SystemClock.elapsedRealtime() - cached.refreshedAtMs < MESSAGE_PAGE_TTL_MS
             ) {
-                return cached.page
+                return injectPendingEchoes(roomId, cached.page)
             }
             // Cold (TTL expired / fresh process): serve the persisted page at
             // once and recompute in the background — the next poll is fresh.
@@ -1161,7 +1442,7 @@ object MatrixRepository {
                     android.os.SystemClock.elapsedRealtime(),
                 )
                 refreshMessagePage(roomId, limit)
-                return disk
+                return injectPendingEchoes(roomId, disk)
             }
             return computeMessagesPage(roomId, null, limit, fast = true).also {
                 messagePageCache[roomId] = MessagePageEntry(
@@ -1173,6 +1454,53 @@ object MatrixRepository {
             }
         }
         return computeMessagesPage(roomId, beforeEventId, limit)
+    }
+
+    /**
+     * Appends the optimistic voice-note/text rows to a SERVED page (memory
+     * cache or disk). The send's sync echo can still be in the outbox when the
+     * page is read — and re-opening a thread served the stale cached page,
+     * so a just-sent message appeared missing until the background refresh
+     * landed (feedback 2026-08-15: "the voice note didn't appear, even after
+     * exiting and entering"). The rows dedup by their "local-…" id; the
+     * refresh's [computeMessagesPage] replaces them with the real echo.
+     */
+    private fun injectPendingEchoes(roomId: String, page: MessagesPage): MessagesPage {
+        val c = client ?: return page
+        if (pendingAudioEcho[roomId] == null && pendingTextEcho[roomId] == null) return page
+        val result = page.messages.toMutableList()
+        val existing = result.mapTo(HashSet()) { it.id }
+        fun addIfMissing(message: com.thelightphone.sdk.shared.LightServiceMethod.GetMessages.Message) {
+            if (existing.add(message.id)) result += message
+        }
+        pendingAudioEcho[roomId]?.let { pending ->
+            addIfMissing(
+                com.thelightphone.sdk.shared.LightServiceMethod.GetMessages.Message(
+                    id = "local-${pending.txnId}",
+                    sender = c.userId.full,
+                    senderName = "",
+                    body = "Voice note",
+                    timestampMs = pending.timestampMs,
+                    isMine = true,
+                    contentType = "audio",
+                    durationMs = pending.durationMs,
+                ),
+            )
+        }
+        pendingTextEcho[roomId]?.let { pending ->
+            addIfMissing(
+                com.thelightphone.sdk.shared.LightServiceMethod.GetMessages.Message(
+                    id = "local-${pending.txnId}",
+                    sender = c.userId.full,
+                    senderName = "",
+                    body = pending.body,
+                    timestampMs = pending.timestampMs,
+                    isMine = true,
+                ),
+            )
+        }
+        return if (result.size == page.messages.size) page
+        else MessagesPage(result, page.hasMore, page.encrypted)
     }
 
     // --- Bridge re-import ("ghost") detection (Phase 14.5) ------------------
@@ -1267,39 +1595,155 @@ object MatrixRepository {
 
     /**
      * Raw timeline events for a message page, with bridge re-import copies
-     * dropped (content dedup + flood fallback). The newest page (null cursor)
-     * grows its raw window — doubling until it holds [limit] + 1 real events or
-     * the timeline ends — so a 7am bridge flood is walked past instead of
-     * becoming the thread's newest messages. Older pages (cursor set) are
-     * filtered in place; the ghost region sits at the top of the timeline, so
-     * pagination never reaches it.
+     * dropped (content dedup + flood fallback), plus whether older events
+     * exist beyond the page (the caller's hasMore).
+     *
+     * Reads the room's timeline chain straight from the Room store (raw SQL
+     * over the stored previous-event links) — the handler's API reads
+     * (getTimelineEvents/getTimelineEvent) serve its in-memory view, which
+     * after a cold start holds a partial, fluctuating subset of the room's
+     * history and stops at sync-chunk boundaries ("hasGapBefore", never
+     * backfilled): the newest page came back short, hasMore flipped false, and
+     * older messages never loaded. The store rows are the only consistent
+     * truth. Falls back to a single windowed API fetch if the query fails.
      */
     private suspend fun collectRelevantTimelineEvents(
         c: MatrixClient,
         matrixRoomId: RoomId,
-        beforeEventId: String?,
+        startEventId: String?,
         limit: Int,
         fast: Boolean = false,
-    ): List<TimelineEvent> {
-        if (beforeEventId != null) {
-            val events = collectTimelineEvents(c, matrixRoomId, beforeEventId, limit + 1)
-            return filterGhosts(c, events)
+    ): Pair<List<TimelineEvent>, Boolean> {
+        if (startEventId == null) return emptyList<TimelineEvent>() to false
+        val fromDb = readTimelineChainFromDb(c, matrixRoomId, startEventId, limit + 1)
+        var events: List<TimelineEvent>
+        var hasMore: Boolean
+        if (fromDb != null) {
+            events = fromDb.first
+            hasMore = fromDb.second
+        } else {
+            val fallback = collectTimelineEvents(c, matrixRoomId, startEventId, limit + 1)
+            events = fallback
+            hasMore = fallback.size >= limit + 1
         }
-        // [fast] bounds the newest-page walk for the first (user-visible) poll:
-        // show the newest real messages quickly; the background refresher walks
-        // to [GHOST_WALK_MAX] and refines the page within a few seconds.
-        val walkMax = if (fast) FIRST_POLL_GHOST_WALK_MAX else GHOST_WALK_MAX
-        var window = limit + 1
-        var raw = collectTimelineEvents(c, matrixRoomId, null, window)
-        while (
-            filterGhosts(c, raw).size < limit + 1 &&
-            raw.size >= window &&
-            window < walkMax
-        ) {
-            window = (window * 2).coerceAtMost(walkMax)
-            raw = collectTimelineEvents(c, matrixRoomId, null, window)
+        // E2EE: a stored event's content can still be undecrypted (its megolm
+        // session wasn't in the local store at sync time). Restore the
+        // sessions from the key backup, then re-read those events once through
+        // the API — the read decrypts and re-persists them.
+        val undecrypted = events.filter { it.content?.isFailure == true }
+        if (undecrypted.isNotEmpty()) {
+            // Battery (2026-08-15 audit): events that can't decrypt (e.g.
+            // pre-verification history — the bridge never re-shares those
+            // sessions) made every page build / 2s refresh repeat a doomed
+            // key-backup restore + per-event API re-read. When a restore finds
+            // nothing to load, back off for a cooldown — the normal sync path
+            // decrypts in-band the moment real sessions do arrive.
+            val roomKey = matrixRoomId.full
+            val cooldownUntil = decryptRestoreCooldown[roomKey]
+            if (cooldownUntil == null || android.os.SystemClock.elapsedRealtime() >= cooldownUntil) {
+                val loaded = restoreRoomSessions(c, matrixRoomId, undecrypted)
+                if (loaded == 0) {
+                    decryptRestoreCooldown[roomKey] =
+                        android.os.SystemClock.elapsedRealtime() + DECRYPT_RESTORE_COOLDOWN_MS
+                }
+                val config: GetTimelineEventConfig.() -> Unit = {
+                    fetchTimeout = FETCH_TIMEOUT_SECONDS.seconds
+                    decryptionTimeout = FETCH_TIMEOUT_SECONDS.seconds
+                }
+                val resolved = HashMap<String, TimelineEvent>()
+                undecrypted.forEach { te ->
+                    withTimeoutOrNull(DECRYPT_WAIT_MS) {
+                        c.room.getTimelineEvent(matrixRoomId, te.event.id, config).firstOrNull()
+                            ?.takeIf { it.content?.getOrNull() != null }
+                    }?.let { resolved[te.event.id.full] = it }
+                }
+                if (resolved.isNotEmpty()) {
+                    events = events.map { resolved[it.event.id.full] ?: it }
+                }
+            }
         }
-        return filterGhosts(c, raw)
+        // Bridge re-import dedup (battery 2026-08-15 audit): the old
+        // filterGhosts heuristic (per-page signature + a 30-per-minute txn-id
+        // flood rule) was assumption-based and could drop real messages; the
+        // account's duplicates are exact re-imports, so keep the first
+        // occurrence of each content signature in the walked chain and drop
+        // the copies. Undecrypted events (no readable content) pass through.
+        // Ceiling: bounded by the walked window — a burst longer than the page
+        // still spills one copy per page (ingest-time dedup is the endgame).
+        return dedupeChain(c, events) to hasMore
+    }
+
+    /** First occurrence of each content signature in [raw] (chain order,
+     *  newest first). Events without readable content fall back to their
+     *  event id, so they pass through untouched. */
+    private fun dedupeChain(c: MatrixClient, raw: List<TimelineEvent>): List<TimelineEvent> {
+        val seen = HashSet<String>()
+        val out = ArrayList<TimelineEvent>(raw.size)
+        for (te in raw) {
+            if (seen.add(contentSignature(c, te) ?: te.event.id.full)) out += te
+        }
+        return out
+    }
+
+    /**
+     * The room's timeline chain (newest-first, [startEventId] inclusive)
+     * straight from the store via a recursive SQL walk over the stored
+     * previous-event links. Returns (events, hasMore) where hasMore says the
+     * deepest event has a further previous link; null when the store query
+     * isn't available (the caller falls back to the API). Bounded by
+     * [maxEvents].
+     */
+    private suspend fun readTimelineChainFromDb(
+        c: MatrixClient,
+        matrixRoomId: RoomId,
+        startEventId: String,
+        maxEvents: Int,
+    ): Pair<List<TimelineEvent>, Boolean>? {
+        val db = runCatching {
+            c.di.get<TrixnityRoomDatabase>(TrixnityRoomDatabase::class)
+        }.onFailure { e ->
+            android.util.Log.w(TAG, "readTimelineChainFromDb: TrixnityRoomDatabase not in DI — falling back to the API walk", e)
+        }.getOrNull() ?: return null
+        val json = runCatching { c.di.get<Json>() }.getOrNull() ?: return null
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                val sql = """
+                    WITH RECURSIVE chain(prev, value, n) AS (
+                        SELECT json_extract(value, '$.previousEventId'), value, 1
+                        FROM TimelineEvent WHERE roomId = ? AND eventId = ?
+                        UNION ALL
+                        SELECT json_extract(t.value, '$.previousEventId'), t.value, c.n + 1
+                        FROM TimelineEvent t JOIN chain c ON t.eventId = c.prev
+                        WHERE c.n < ?
+                    )
+                    SELECT value FROM chain ORDER BY n
+                """.trimIndent()
+                val events = ArrayList<TimelineEvent>()
+                var hasMore = false
+                db.openHelper.writableDatabase.query(
+                    sql,
+                    // maxEvents must bind as a number — a string makes SQLite's
+                    // `n < '21'` (INTEGER vs TEXT) compare true for every row.
+                    arrayOf<Any>(matrixRoomId.full, startEventId, maxEvents),
+                ).use { cursor ->
+                    while (cursor.moveToNext()) {
+                        val value = cursor.getString(0) ?: continue
+                        // The DI Json carries the store's serializers module,
+                        // which registers TimelineEvent's serializer — the
+                        // reified decode resolves it.
+                        events += json.decodeFromString<TimelineEvent>(value)
+                    }
+                }
+                if (events.isNotEmpty()) {
+                    // The deepest event's stored prev link decides hasMore.
+                    hasMore = events.last().previousEventId != null
+                }
+                android.util.Log.d(TAG, "readTimelineChainFromDb: $matrixRoomId from=$startEventId → ${events.size} events hasMore=$hasMore")
+                events to hasMore
+            }.onFailure { e ->
+                android.util.Log.w(TAG, "readTimelineChainFromDb: store query failed — falling back to the API walk", e)
+            }.getOrNull()
+        }
     }
 
     /**
@@ -1327,42 +1771,69 @@ object MatrixRepository {
             return MessagesPage(emptyList(), false, encrypted = true)
         }
 
-        // Lazy per-room decrypt, but seeded BEFORE the newest-page walk: the
-        // walk re-reads in growing windows and each read used to wait ~3 s for
-        // a decrypt that couldn't land until the megolm sessions were in the
-        // store (5-7 windows × 3 s ≈ the whole first load). One small seed read
-        // + session restore makes every walk read decrypt instantly.
-        val seed = collectTimelineEvents(c, matrixRoomId, beforeEventId, limit + 1)
-        val sessionsLoaded = restoreRoomSessions(c, matrixRoomId, seed)
-
-        // If no megolm session could be loaded (e.g. an unverified device with
-        // no key-backup access), the events stay encrypted no matter how often
-        // we re-read — return the ghost-filtered seed ("[Encrypted]" rows beat
-        // a 20 s dead walk).
-        var events = if (sessionsLoaded > 0) {
-            collectRelevantTimelineEvents(c, matrixRoomId, beforeEventId, limit, fast)
+        // The newest page (null cursor) pages BACKWARDS from the room's newest
+        // event instead of using getLastTimelineEvents' newest-page stream:
+        // that stream serves the handler's in-memory/cache view, which after a
+        // cold start holds a partial and fluctuating subset of the room's real
+        // history (observed: a 64-event room returned 9-17 events, hasMore
+        // flipped false, and pagination died — "older messages don't load").
+        // The Room store's lastEventId is the authoritative newest event, and
+        // [collectRelevantTimelineEvents] walks BACKWARDS from it, chaining
+        // across sync-chunk boundaries via the stored previous-event links.
+        // [keepCursor] keeps that event as the page's newest row; older pages
+        // drop their boundary cursor instead.
+        val keepCursor = beforeEventId == null
+        val pageCursor = if (keepCursor) {
+            withTimeoutOrNull(ROOM_BUDGET_MS) {
+                c.room.getById(matrixRoomId).firstOrNull()?.lastEventId?.full
+            }
         } else {
-            filterGhosts(c, seed)
+            beforeEventId
         }
-        repeat(DECRYPT_RETRIES) {
-            if (sessionsLoaded == 0) return@repeat
-            val stillEncrypted = events.any { it.content?.isFailure == true }
-            if (!stillEncrypted) return@repeat
-            kotlinx.coroutines.delay(DECRYPT_RETRY_DELAY_MS)
-            events = collectRelevantTimelineEvents(c, matrixRoomId, beforeEventId, limit, fast)
+        if (keepCursor && pageCursor == null) {
+            // No events in the room at all (the getById read is a cache hit —
+            // only an empty room misses).
+            return MessagesPage(emptyList(), false)
         }
 
-        // A full page (limit + 1, including the cursor event for older pages)
-        // means older messages exist beyond this one. Ghosts don't count — the
-        // newest-page walk guarantees this size when real history exists.
-        val hasMore = events.size >= limit + 1
+        // Lazy per-room decrypt, but seeded BEFORE the walk: the seed read
+        // triggers decryption of the page's events and restores the megolm
+        // sessions that are missing (a decrypt that can't land until the
+        // sessions are in the store made the first open slow). Skipped inside
+        // the futile-restore cooldown (battery 2026-08-15 audit).
+        val seed = collectTimelineEvents(c, matrixRoomId, pageCursor, limit + 1)
+        if (!inDecryptRestoreCooldown(matrixRoomId)) {
+            restoreRoomSessions(c, matrixRoomId, seed)
+        }
+
+        // The page comes from [collectRelevantTimelineEvents] — a straight
+        // store read (raw SQL over the previous-event links, per-event API
+        // re-reads for anything still undecrypted), so the page size and
+        // hasMore no longer depend on the handler's in-memory view.
+        var events: List<TimelineEvent>
+        var hasMore = false
+        val (e, h) = collectRelevantTimelineEvents(c, matrixRoomId, pageCursor, limit, fast)
+        events = e
+        hasMore = h
+        // The retries exist to catch a decrypt that lands a beat late. Inside
+        // the restore cooldown they can't succeed — skip them (battery audit).
+        if (!inDecryptRestoreCooldown(matrixRoomId)) {
+            repeat(DECRYPT_RETRIES) {
+                val stillEncrypted = events.any { it.content?.isFailure == true }
+                if (!stillEncrypted) return@repeat
+                kotlinx.coroutines.delay(DECRYPT_RETRY_DELAY_MS)
+                val (e2, h2) = collectRelevantTimelineEvents(c, matrixRoomId, pageCursor, limit, fast)
+                events = e2
+                hasMore = h2
+            }
+        }
         android.util.Log.d(
             TAG,
             "getMessages: room=$matrixRoomId before=$beforeEventId limit=$limit page=${events.size} hasMore=$hasMore",
         )
 
         val result = mutableListOf<com.thelightphone.sdk.shared.LightServiceMethod.GetMessages.Message>()
-        val startIndex = if (beforeEventId == null) 0 else 1 // drop the cursor event
+        val startIndex = if (keepCursor) 0 else 1 // drop the boundary cursor on older pages
         // Delivery status only matters for the newest page (what the user just
         // sent): the status events sit right after the message in the timeline.
         // Older pages don't get the marker (Phase 10, minimal scope).
@@ -1711,11 +2182,11 @@ object MatrixRepository {
         // 2026-08-14). The echo row survives leaving the thread; the sync
         // echo (matched by txn id) replaces it in [computeMessagesPage].
         pendingTextEcho[matrixRoomId.full] = PendingTextSend(txnId, System.currentTimeMillis(), body)
-        // The cached newest page is stale now; the active-room refresher (or
-        // the tool's next poll) recomputes it once the echo lands. The disk
-        // page is dropped too, so a cold re-open can't serve a pre-send page.
-        messagePageCache.remove(matrixRoomId.full)
-        messagePageCacheFile(matrixRoomId.full)?.delete()
+        // Keep the cached/disk newest page — re-opening the thread serves it
+        // instantly with the optimistic row injected ([injectPendingEchoes]),
+        // and the active-room refresher (or the next poll) recomputes the page
+        // once the sync echo lands (feedback 2026-08-15: re-open showed
+        // "Loading messages…" because the send had dropped the cache).
         roomListDirty = true // the room's preview/unread change once the echo lands
         android.util.Log.d(TAG, "SendMessage: room=$roomId txn=$txnId body=$body")
         return com.thelightphone.sdk.shared.LightServiceMethod.SendMessage.Response(
@@ -1805,9 +2276,19 @@ object MatrixRepository {
         val matrixRoomId = RoomId(roomId)
         val te = withTimeoutOrNull(MEDIA_BUDGET_MS) {
             var event: TimelineEvent? = null
+            var restored = false
             repeat(MEDIA_CONTENT_RETRIES) {
                 event = c.room.getTimelineEvent(matrixRoomId, EventId(eventId)).firstOrNull()
                 if (event?.content?.getOrNull() != null) return@withTimeoutOrNull event
+                // An older note's megolm session is often not in the local
+                // store (sessions load lazily per room, mostly via getMessages)
+                // — the content stays encrypted and the note silently "doesn't
+                // play" (feedback 2026-08-14). Pull the session from the key
+                // backup once, then re-read so decryption can land.
+                if (event?.content?.isFailure == true && !restored) {
+                    restored = true
+                    restoreRoomSessions(c, matrixRoomId, listOf(event))
+                }
                 delay(MEDIA_CONTENT_RETRY_DELAY_MS)
             }
             event
@@ -1916,7 +2397,8 @@ object MatrixRepository {
      * Records the room a voice-note send should land in and returns the
      * flattened component name of the companion's recording activity, which
      * the tool launches via `SimpleLightScreen.startServerActivity` (same
-     * pattern as [startPhotoSend]). The activity records an m4a and sends it.
+     * pattern as [startPhotoSend]). The activity records an ogg/Opus note and
+     * sends it.
      */
     fun startVoiceNoteSend(roomId: String): String {
         VoiceNoteActivity.register(roomId)
@@ -1924,7 +2406,7 @@ object MatrixRepository {
     }
 
     /**
-     * Uploads and sends a recorded voice note (an m4a file) to the room —
+     * Uploads and sends a recorded voice note (an ogg/Opus file) to the room —
      * encrypted media when the room is end-to-end encrypted (WhatsApp/Beeper),
      * plain otherwise. The content is hand-built as an
      * [RoomMessageEventContent.Unknown] (whose raw JSON is sent verbatim) so
@@ -1933,6 +2415,10 @@ object MatrixRepository {
      * present, otherwise WhatsApp shows a plain audio file (feedback
      * 2026-08-14). Trixnity's typed audio DSL has no extension slot, so the
      * upload is done here (same encrypted/plain split the DSL performs).
+     * `audio/ogg; codecs=opus` is the MSC3245 canonical voice-message
+     * mimetype — every Matrix client and the mautrix bridges treat it as a
+     * voice message, and it is ~2-3× smaller than the old AAC/m4a notes
+     * (2026-08-15 switch).
      * @return true when the send was enqueued.
      */
     suspend fun sendVoiceNote(roomId: String, file: java.io.File): Boolean {
@@ -1956,7 +2442,7 @@ object MatrixRepository {
             ms
         }.getOrNull()
         val mediaService = c.di.get<MediaService>(MediaService::class)
-        val mimeType = "audio/mp4"
+        val mimeType = "audio/ogg; codecs=opus"
         val isEncryptedRoom = withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getById(matrixRoomId).first()?.encrypted
         } == true
@@ -1966,7 +2452,7 @@ object MatrixRepository {
             buildJsonObject {
                 put("msgtype", "m.audio")
                 put("body", "")
-                put("filename", "voice.m4a")
+                put("filename", "voice.ogg")
                 putJsonObject("info") {
                     put("mimetype", mimeType)
                     put("size", bytes.size)
@@ -1983,7 +2469,7 @@ object MatrixRepository {
             buildJsonObject {
                 put("msgtype", "m.audio")
                 put("body", "")
-                put("filename", "voice.m4a")
+                put("filename", "voice.ogg")
                 putJsonObject("info") {
                     put("mimetype", mimeType)
                     put("size", bytes.size)
@@ -2007,10 +2493,12 @@ object MatrixRepository {
             }
         }.getOrNull() ?: return false
         android.util.Log.d(TAG, "SendVoiceNote: room=$roomId txn=$txnId bytes=${bytes.size} duration=${durationMs}ms voice=m.audio+msc3245")
-        // Invalidate the page caches so the thread doesn't serve the pre-send
-        // page, and show an optimistic "Voice note" row until the sync echo lands.
-        messagePageCache.remove(matrixRoomId.full)
-        messagePageCacheFile(matrixRoomId.full)?.delete()
+        // Keep the cached/disk newest page — re-opening serves it instantly
+        // with the optimistic "Voice note" row injected ([injectPendingEchoes])
+        // until the sync echo lands (the refresher then replaces it with the
+        // real event). The send previously dropped the cache, so a re-open
+        // recomputed from scratch (slow — "Loading messages…") and could show
+        // the note as missing (feedback 2026-08-15).
         pendingAudioEcho[matrixRoomId.full] = PendingAudioSend(txnId, System.currentTimeMillis(), durationMs)
         return true
     }
@@ -2133,7 +2621,21 @@ object MatrixRepository {
         )
         // Opening the thread makes the room's notification moot.
         appContext?.let { ChatNotifier.cancelRoom(it, roomId) }
-        roomListDirty = true // the room's unread count changed
+        // Optimistically clear the room's unread in the served list — the
+        // store's unreadMessageCount only drops after the read-marker echo
+        // round-trips through sync (a full tick on a big account), which used
+        // to leave the badge up long after the thread was opened. The
+        // resolver keeps serving 0 until the echo confirms or a newer event
+        // arrives ([servedUnread]).
+        pendingReadClear[roomId] = eventId
+        roomListCache[roomId]?.let { entry ->
+            if (entry.room.unreadCount > 0) {
+                val cleared = entry.copy(room = entry.room.copy(unreadCount = 0))
+                roomListCache[roomId] = cleared
+                _roomList.value = _roomList.value.map { if (it.id == roomId) cleared.room else it }
+            }
+        }
+        roomListDirty = true
     }
 
     suspend fun setTyping(roomId: String, active: Boolean) {
@@ -2158,22 +2660,40 @@ object MatrixRepository {
         activeRoomId = roomId
         // While a thread is open, keep its cached newest page fresh in the
         // background — sync echoes and Beeper send-status events then reach the
-        // tool's next poll without it blocking on a compute.
-        activeRoomRefreshJob?.cancel()
-        activeRoomRefreshJob = if (roomId != null) {
-            scope.launch {
-                while (true) {
-                    delay(ACTIVE_ROOM_REFRESH_MS)
-                    if (activeRoomId != roomId) break
-                    refreshMessagePage(roomId)
-                }
-            }
-        } else {
-            null
-        }
+        // tool's next poll without it blocking on a compute. Stops on thread
+        // close, navigation, SCREEN_OFF and sync-pause (battery 2026-08-15).
+        stopActiveRoomRefresh()
+        if (roomId != null) startActiveRoomRefresh()
         val ctx = appContext ?: return
         if (roomId != null) ChatNotifier.cancelRoom(ctx, roomId)
     }
+
+    /** The active-room page refresh: rebuild the room's newest page cache every
+     *  [ACTIVE_ROOM_REFRESH_MS] while the screen is on and a thread is open.
+     *  [refreshMessagePage] itself skips rooms that haven't changed and never
+     *  piles up, so a quiet room costs one cheap last-event read per tick. */
+    private fun startActiveRoomRefresh() {
+        val roomId = activeRoomId ?: return
+        stopActiveRoomRefresh()
+        activeRoomRefreshJob = scope.launch {
+            while (true) {
+                delay(ACTIVE_ROOM_REFRESH_MS)
+                if (activeRoomId != roomId) break
+                refreshMessagePage(roomId)
+            }
+        }
+    }
+
+    private fun stopActiveRoomRefresh() {
+        activeRoomRefreshJob?.cancel()
+        activeRoomRefreshJob = null
+    }
+
+    /** Screen truth for the speculative-work gates (battery 2026-08-15: eager
+     *  page pre-computes and resolver passes are wasted while the screen is
+     *  dark — nobody reads them until the next wake). */
+    private fun isScreenInteractive(): Boolean =
+        (appContext?.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isInteractive == true
 
     /**
      * One-shot read of the room a posted notification belongs to (set by
@@ -2379,6 +2899,12 @@ object MatrixRepository {
     /** Last-seen room signatures, maintained by [observeNotifications] — a
      *  difference sets [roomListDirty] (the resolver's skip gate, audit 2026-08-14). */
     private val roomSigSeen = java.util.concurrent.ConcurrentHashMap<String, RoomSig>()
+    /** Room ids the user has opened (MarkRead fired) → the event id marked
+     *  read. The store's unreadMessageCount only drops after the read-marker
+     *  echo round-trips through sync (a full tick on a big account), so the
+     *  served list shows 0 until the echo confirms or a newer event arrives
+     *  (feedback 2026-08-15: the badge lingered after viewing). */
+    private val pendingReadClear = java.util.concurrent.ConcurrentHashMap<String, String>()
     private val _roomList = MutableStateFlow<List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room>>(emptyList())
 
     @Volatile
@@ -2400,9 +2926,24 @@ object MatrixRepository {
         val membership: String?,
     )
 
+    /** Unread count to show in the list. While a MarkRead is pending (the
+     *  store hasn't echoed it yet — see [pendingReadClear]) the count reads 0;
+     *  the suppression lifts when the echo confirms (store unread 0) or a
+     *  newer event than the one marked read arrives (real unread again). */
+    private fun servedUnread(roomId: String, markedAt: String?, newestId: String?, storeUnread: Long): Long {
+        if (markedAt == null) return storeUnread
+        return if (storeUnread == 0L || (newestId != null && newestId != markedAt)) {
+            pendingReadClear.remove(roomId)
+            storeUnread
+        } else {
+            0
+        }
+    }
+
     private fun resetRoomList() {
         roomListCache.clear()
         roomSigSeen.clear()
+        pendingReadClear.clear()
         effectiveLastCache.clear()
         ghostResolveInFlight.clear()
         _roomList.value = emptyList()
@@ -2509,31 +3050,46 @@ object MatrixRepository {
                     // newest pages are computed in the background so opening a
                     // thread is a cache hit instead of a cold walk. A few per
                     // pass; rooms with a fresh page (memory or disk) are skipped.
-                    var precomputed = 0
-                    for ((roomId, _) in loaded) {
-                        if (precomputed >= EAGER_PAGES_PER_PASS) break
-                        if (android.os.SystemClock.elapsedRealtime() >= passDeadline) break
-                        val key = roomId.full
-                        val now = android.os.SystemClock.elapsedRealtime()
-                        val cached = messagePageCache[key]
-                        if (cached != null && now - cached.refreshedAtMs < MESSAGE_PAGE_TTL_MS) continue
-                        if (loadMessagePageFromDisk(key) != null) continue
-                        val page = runCatching {
-                            computeMessagesPage(key, null, THREAD_PAGE_SIZE, fast = true)
-                        }.getOrNull()
-                        if (page != null) {
-                            messagePageCache[key] = MessagePageEntry(
-                                page, THREAD_PAGE_SIZE, android.os.SystemClock.elapsedRealtime(),
-                            )
-                            saveMessagePageToDisk(key, page)
-                            precomputed++
+                    // Battery (2026-08-15): screen-gated — the slow-sync rounds
+                    // kept the list dirty on the live account, so the resolver
+                    // was rebuilding the hottest room's page on every pass,
+                    // 24/7, screen off or not (the second speculative-work loop
+                    // after the active-room refresh). Nobody opens a thread
+                    // while the screen is dark; the refresh re-arms on wake.
+                    if (isScreenInteractive()) {
+                        var precomputed = 0
+                        for ((roomId, _) in loaded) {
+                            if (precomputed >= EAGER_PAGES_PER_PASS) break
+                            if (android.os.SystemClock.elapsedRealtime() >= passDeadline) break
+                            val key = roomId.full
+                            val now = android.os.SystemClock.elapsedRealtime()
+                            val cached = messagePageCache[key]
+                            if (cached != null && now - cached.refreshedAtMs < MESSAGE_PAGE_TTL_MS) continue
+                            if (loadMessagePageFromDisk(key) != null) continue
+                            val page = runCatching {
+                                computeMessagesPage(key, null, THREAD_PAGE_SIZE, fast = true)
+                            }.getOrNull()
+                            if (page != null) {
+                                messagePageCache[key] = MessagePageEntry(
+                                    page, THREAD_PAGE_SIZE, android.os.SystemClock.elapsedRealtime(),
+                                )
+                                saveMessagePageToDisk(key, page)
+                                precomputed++
+                            }
                         }
                     }
                     publishRoomList()
                 } catch (e: Exception) {
                     android.util.Log.w(TAG, "room list resolver pass failed: ${e.message}")
                 }
-                kotlinx.coroutines.delay(ROOM_LIST_REFRESH_DELAY_MS)
+                // Battery (2026-08-15): while the screen is off, coalesce the
+                // resolver's dirty-loop — the room list only needs to be fresh
+                // for the next wake, not sub-minute (the slow-sync rounds kept
+                // it dirty on the live account, so the old 2s breather meant
+                // near-continuous passes).
+                kotlinx.coroutines.delay(
+                    if (isScreenInteractive()) ROOM_LIST_REFRESH_DELAY_MS else SLOW_RESOLVER_DELAY_MS
+                )
             }
         }
     }
@@ -2556,7 +3112,12 @@ object MatrixRepository {
                     lastMessage = "",
                     // An unverified device can't decrypt — suppress unread for
                     // encrypted rooms only; unencrypted ones stay readable.
-                    unreadCount = if (verified || !room.encrypted) room.unreadMessageCount else 0,
+                    unreadCount = servedUnread(
+                        key,
+                        pendingReadClear[key],
+                        room.lastRelevantEventId?.full,
+                        if (verified || !room.encrypted) room.unreadMessageCount else 0,
+                    ),
                     lastTimestampMs = room.lastRelevantEventTimestamp?.toEpochMilliseconds() ?: 0L,
                     lastEventId = room.lastRelevantEventId?.full,
                     isDirect = room.isDirect,
@@ -2603,7 +3164,8 @@ object MatrixRepository {
         val (lastEventId, ts) = effectiveLastEvent(c, roomId, serverLastId, serverTs)
         // An unverified device can't decrypt — suppress unread for encrypted
         // rooms only; unencrypted ones stay readable.
-        val unread = if (verified || !room.encrypted) room.unreadMessageCount else 0
+        val storeUnread = if (verified || !room.encrypted) room.unreadMessageCount else 0
+        val unread = servedUnread(key, pendingReadClear[key], room.lastRelevantEventId?.full, storeUnread)
         val stateChanged = prev == null ||
             prev.room.lastEventId != lastEventId ||
             prev.room.unreadCount != unread ||
@@ -3055,6 +3617,10 @@ object MatrixRepository {
                     SyncState.STARTED, SyncState.RUNNING -> ChatConnectionState.Syncing
                     SyncState.ERROR, SyncState.TIMEOUT -> ChatConnectionState.Offline("sync $state")
                     SyncState.STOPPED -> when {
+                        // Slow sync (screen off) stops the long-poll between
+                        // periodic syncOnce rounds — that's still "syncing",
+                        // not an outage.
+                        isSlowSyncing -> ChatConnectionState.Syncing
                         // The sync toggle is the source of truth while paused —
                         // the restored client reports STOPPED until resumed, and
                         // that must read as "paused", not "stopped" (or, worse,
@@ -3091,6 +3657,7 @@ object MatrixRepository {
                 }
                 if (!sawLoggedIn || manualLogout || sessionExpired) return@collect
                 sessionExpired = true
+                PushChannel.stop()
                 android.util.Log.w(TAG, "session no longer logged in ($state) — treating as expired")
                 _connectionState.value = ChatConnectionState.Offline("session expired — sign in again")
                 scheduleSyncStop()
@@ -3217,16 +3784,32 @@ object MatrixRepository {
     private const val ROOMS_BUDGET_MS = 15_000L
     private const val ROOM_BUDGET_MS = 3_000L
     private const val MESSAGES_BUDGET_MS = 15_000L
+    /** Restore-scan cadence: at most one full crawl per day (battery/UX
+     *  2026-08-15 — it used to run on every process start and starve the app
+     *  for 20+ min on the bridged account; the on-demand page path still
+     *  restores when a room is actually read). */
+    private const val RESTORE_INTERVAL_MS = 86_400_000L
+    /** Per-room budget + window for the restore scan (the shared
+     *  [MESSAGES_BUDGET_MS] / 100-event window is fine for reads, wasteful for
+     *  the preemptive crawl). */
+    private const val RESTORE_ROOM_BUDGET_MS = 6_000L
+    private const val RESTORE_ROOM_EVENTS = 40L
     private const val FETCH_TIMEOUT_SECONDS = 5L
     /** The thread's page size (matches the tool's PAGE_SIZE). */
     private const val THREAD_PAGE_SIZE = 20
     /** Serve a cached newest page within this window (feedback pass). */
     private const val MESSAGE_PAGE_TTL_MS = 5_000L
-    /** Recompute the active room's cached newest page at this cadence. */
-    private const val ACTIVE_ROOM_REFRESH_MS = 2_000L
+    /** Recompute the active room's cached newest page at this cadence. The
+     *  tool's own poll (3s) hits the cache, so 30s is invisible — and the
+     *  refresh skips unchanged rooms entirely (battery audit 2026-08-15: was
+     *  2s, running 24/7 with no screen coupling — the drain's engine). */
+    private const val ACTIVE_ROOM_REFRESH_MS = 30_000L
     private const val TYPING_TIMEOUT_MS = 30_000L
     private const val DECRYPT_RETRIES = 3
     private const val DECRYPT_RETRY_DELAY_MS = 1_500L
+    /** How long to stop retrying a room's key-backup restore after it found
+     *  nothing to load (battery 2026-08-15 audit). */
+    private const val DECRYPT_RESTORE_COOLDOWN_MS = 600_000L
     private const val DECRYPT_WAIT_MS = 3_000L
     /** Peek budget for events after the first one failed to decrypt. */
     private const val QUICK_DECRYPT_WAIT_MS = 100L
@@ -3237,6 +3820,11 @@ object MatrixRepository {
     private const val ROOM_LIST_PASS_BUDGET_MS = 12_000L
     /** Breather between passes; a settled pass itself takes milliseconds. */
     private const val ROOM_LIST_REFRESH_DELAY_MS = 2_000L
+    /** Resolver breather while the screen is off (battery 2026-08-15): the
+     *  live bridged account keeps the list dirty, so the 2s breather meant
+     *  near-continuous passes overnight; the list only needs freshness for
+     *  the next wake. */
+    private const val SLOW_RESOLVER_DELAY_MS = 60_000L
     /** A "[Encrypted]" preview is retried no sooner than this. */
     private const val ROOM_LIST_ENCRYPTED_RETRY_MS = 60_000L
     /** Bounded decrypt-wait per room preview. */

--- a/server/src/main/kotlin/com/lightphone/chats/server/PushChannel.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/PushChannel.kt
@@ -1,0 +1,320 @@
+package com.lightphone.chats.server
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import net.folivo.trixnity.clientserverapi.model.push.PusherData
+import net.folivo.trixnity.clientserverapi.model.push.SetPushers
+import net.folivo.trixnity.client.MatrixClient
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Push-based wake-up for the companion (2026-08-16, chats/push/README.md).
+ *
+ * The sync loop is the delivery mechanism for notifications, but only as
+ * often as it polls. Matrix HTTP pushers fix the latency: the homeserver
+ * gets a pusher whose `data.url` is an endpoint that serves the exact path
+ * `/_matrix/push/v1/notify` (both Synapse and Beeper validate the path
+ * exactly). Two endpoint options: the user's own gateway
+ * (chats/push/gateway.py), reachable from the homeserver over a public
+ * tunnel — or ntfy.sh, whose Matrix Push Gateway serves that exact path
+ * and routes to the topic named in the pusher's pushkey
+ * (`https://ntfy.sh/<topic>`), which the SSE side then subscribes to (no
+ * tunnel; the topic is a per-install bearer token). The homeserver POSTs a
+ * small event-id-only payload on every new message; this object holds an
+ * SSE subscription and turns each notification into one
+ * [MatrixRepository.onPushDelivered] — a single syncOnce round while idle,
+ * which the existing notification watcher turns into the local
+ * notification.
+ *
+ * No tokens leave the phone: the payload carries no message content or keys —
+ * push is a wake-up signal only.
+ *
+ * Two URLs are stored separately because one side sees the gateway from the
+ * phone and the other from the homeserver: the notify URL must be public
+ * (Beeper POSTs from their servers), while the SSE URL is whatever the phone
+ * can reach (LAN IP, tunnel, or adb-reverse loopback in dev). With no config
+ * a private ntfy.sh channel is auto-provisioned on first start (see [start]);
+ * the `--es pushsse` / `--es pushnotify` / `--es pushkey` dev extras override
+ * for a self-hosted gateway.
+ */
+object PushChannel {
+
+    private const val PREFS = "chats_account"
+    private const val KEY_SSE_URL = "push_sse_url"
+    private const val KEY_NOTIFY_URL = "push_notify_url"
+    private const val KEY_PUSHKEY = "push_key"
+    private const val KEY_LAST_MSG_ID = "push_last_msg_id"
+    private const val APP_ID = "com.lightphone.chats"
+
+    private const val TAG = "PushChannel"
+
+    /** Reconnect backoff for a dropped SSE stream (NAT, radio, gateway down). */
+    private const val RECONNECT_BASE_MS = 5_000L
+    private const val RECONNECT_MAX_MS = 60_000L
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile
+    private var job: Job? = null
+
+    /** The in-flight SSE call; cancelled to interrupt a blocked read on stop. */
+    @Volatile
+    private var currentCall: Call? = null
+
+    /** True while an SSE stream is actually open — i.e. push is delivering right now. */
+    @Volatile
+    var isConnected: Boolean = false
+        private set
+
+    @Volatile
+    private var pushkey: String? = null
+
+    /** Last ntfy message id seen (resume point for `?since=`, see [resumeUrl]). */
+    @Volatile
+    private var lastMessageId: String? = null
+
+    /** Application context for persisting the resume point (set in [start]). */
+    @Volatile
+    private var appContext: Context? = null
+
+    /** The client the current channel was started for (re-login restarts it). */
+    @Volatile
+    private var startedFor: MatrixClient? = null
+
+    // ---- lifecycle -----------------------------------------------------
+
+    /**
+     * Registers the pusher (idempotent) and holds the SSE subscription. Safe
+     * to call repeatedly; synchronized because init runs from both the
+     * Application and the dev MainActivity and two concurrent starts would
+     * both pass the null-job guard and open two connections. With no
+     * configured URLs a private ntfy.sh channel is auto-provisioned (one
+     * random topic derives pushkey + SSE + notify URLs) — push works with
+     * zero setup after login; the `--es pushsse/pushnotify/pushkey` extras
+     * override for a self-hosted gateway instead.
+     */
+    @Synchronized
+    fun start(context: Context, c: MatrixClient) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        var sseUrl = prefs.getString(KEY_SSE_URL, null)
+        var notifyUrl = prefs.getString(KEY_NOTIFY_URL, null)
+        var key = prefs.getString(KEY_PUSHKEY, null)
+        if (sseUrl == null || notifyUrl == null || key == null) {
+            // Auto-provision an ntfy.sh channel (2026-08-17): one random
+            // topic derives the pushkey (ntfy routes by it), the SSE stream
+            // the phone holds, and the notify URL (ntfy's Matrix gateway
+            // serves the required path). The topic is a per-install bearer
+            // token — unguessable, so the channel is private.
+            val topic = "chats-" + java.util.UUID.randomUUID().toString().replace("-", "")
+            key = "https://ntfy.sh/$topic"
+            sseUrl = "https://ntfy.sh/$topic/json"
+            notifyUrl = "https://ntfy.sh/_matrix/push/v1/notify"
+            prefs.edit()
+                .putString(KEY_SSE_URL, sseUrl)
+                .putString(KEY_NOTIFY_URL, notifyUrl)
+                .putString(KEY_PUSHKEY, key)
+                .apply()
+            Log.i(TAG, "auto-provisioned ntfy channel: $sseUrl")
+        }
+        if (job?.isActive == true && startedFor === c) return
+        stop() // re-login under the same topic: re-register for the new session
+        startedFor = c
+        lastMessageId = prefs.getString(KEY_LAST_MSG_ID, null)
+        appContext = context.applicationContext
+        pushkey = key
+        job = scope.launch {
+            register(c, notifyUrl)
+            connect(sseUrl)
+        }
+    }
+
+    /** Stops the subscription and drops the socket (logout, sync pause, session expiry). */
+    fun stop() {
+        currentCall?.cancel()
+        currentCall = null
+        job?.cancel()
+        job = null
+    }
+
+    /** Best-effort removal of the pusher from the account (logout). */
+    suspend fun unregister(context: Context, c: MatrixClient) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val key = prefs.getString(KEY_PUSHKEY, null) ?: return
+        runCatching {
+            c.api.push.setPushers(SetPushers.Request.Remove(APP_ID, key)).getOrThrow()
+        }
+            .onSuccess { Log.i(TAG, "pusher removed from account") }
+            .onFailure { Log.w(TAG, "pusher removal failed (best-effort): ${it.message}") }
+    }
+
+    /**
+     * Dev/cleanup hook (`--es pushclear 1`): stops the channel, removes the
+     * pusher from the account, and forgets the config — leaves no dead
+     * pusher behind after a test with a transient tunnel URL.
+     */
+    suspend fun clear(context: Context, c: MatrixClient) {
+        stop()
+        unregister(context, c)
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+            .remove(KEY_SSE_URL).remove(KEY_NOTIFY_URL).remove(KEY_PUSHKEY)
+            .remove(KEY_LAST_MSG_ID).apply()
+        lastMessageId = null
+        Log.i(TAG, "push config cleared")
+    }
+
+    // ---- internals -----------------------------------------------------
+
+    /**
+     * Registers/refreshes the HTTP pusher on the homeserver. Idempotent
+     * (app_id + pushkey identify the pusher; re-registering replaces it), so
+     * calling it on every start keeps a changed URL in sync.
+     */
+    private suspend fun register(c: MatrixClient, notifyUrl: String) {
+        val data = PusherData(
+            format = "event_id_only", // no content/keys on the wire — wake-up only
+            url = notifyUrl,
+            customFields = buildJsonObject {},
+        )
+        val set = SetPushers.Request.Set(
+            appId = APP_ID,
+            pushkey = pushkey!!,
+            kind = "http",
+            appDisplayName = "Chats",
+            deviceDisplayName = "LP3",
+            lang = "en",
+            data = data,
+            append = false,
+            profileTag = "",
+        )
+        runCatching { c.api.push.setPushers(set).getOrThrow() }
+            .onSuccess { Log.i(TAG, "pusher registered -> $notifyUrl") }
+            .onFailure { Log.w(TAG, "pusher registration failed (retried next start): ${it.message}") }
+    }
+
+    /**
+     * The SSE subscription loop. Reads `data:` lines off a streaming OkHttp
+     * response; anything else (heartbeats, reconnects) is ignored. On drop,
+     * reconnect with backoff — delivery is async on the homeserver side
+     * (retries with backoff), so a gap here is not data loss.
+     */
+    private suspend fun CoroutineScope.connect(sseUrl: String) {
+        val client = OkHttpClient.Builder()
+            // Bounded read so a half-open socket (broken tunnel, dead NAT)
+            // is detected instead of blocking forever: the dev gateway
+            // heartbeats every 15s and ntfy's JSON stream keeps a ~45s
+            // keepalive, so 90s of silence = dead. Forces a reconnect.
+            .readTimeout(90, TimeUnit.SECONDS)
+            .build()
+        var delayMs = RECONNECT_BASE_MS
+        while (isActive) {
+            val url = resumeUrl(sseUrl)
+            val call = client.newCall(Request.Builder().url(url).build())
+            currentCall = call
+            try {
+                call.execute().use { resp ->
+                    if (!resp.isSuccessful) throw IOException("SSE HTTP ${resp.code}")
+                    Log.i(TAG, "SSE connected: $url")
+                    delayMs = RECONNECT_BASE_MS
+                    val source = resp.body?.source() ?: throw IOException("SSE empty body")
+                    while (isActive) {
+                        val line = source.readUtf8Line() ?: break // EOF = server closed
+                        val trimmed = line.trim()
+                        if (trimmed.isEmpty()) continue // keepalive/heartbeat
+                        // Both wire formats carry one event per line: the dev
+                        // gateway's SSE frames ("data: {…}") and ntfy's raw
+                        // JSON stream ("{…}").
+                        val payload =
+                            if (trimmed.startsWith("data: ")) trimmed.removePrefix("data: ").trim()
+                            else trimmed
+                        if (payload.startsWith("{")) onNotification(payload)
+                    }
+                }
+            } catch (e: Exception) {
+                if (isActive) Log.w(TAG, "SSE stream dropped: ${e.message}")
+            }
+            currentCall = null
+            if (!isActive) break
+            delay(delayMs)
+            delayMs = (delayMs * 2).coerceAtMost(RECONNECT_MAX_MS)
+        }
+    }
+
+    /**
+     * ntfy's JSON stream resumes from the last seen message (`?since=<id>`,
+     * or `all` on the first ever connect) so a reconnect replays pushes
+     * published during the gap — the canonical ntfy client does the same
+     * (docs/subscribe/api.md §since; the server caches ~12h precisely for
+     * network interruptions). The dev gateway's `/events` stream has no
+     * cache and no since support, so only ntfy URLs (ending in `/json`) get
+     * the parameter.
+     */
+    private fun resumeUrl(sseUrl: String): String {
+        if (!sseUrl.endsWith("/json")) return sseUrl
+        val since = lastMessageId ?: "all"
+        return if (sseUrl.contains("?")) "$sseUrl&since=$since" else "$sseUrl?since=$since"
+    }
+
+    /**
+     * A push notification arrived over SSE. ntfy wraps the homeserver POST
+     * in its own envelope (`data.message` = the JSON body as a string); the
+     * dev gateway relays the notification verbatim. Either shape unwraps to
+     * the Matrix notification. The wake is unconditional once a notification
+     * payload is recognized: Beeper has been observed POSTing counts-style
+     * payloads WITHOUT room_id/event_id (2026-08-16 live test) — push means
+     * "something happened, sync once", and the sync is what decides.
+     */
+    private suspend fun onNotification(json: String) {
+        val outer = runCatching { Json { ignoreUnknownKeys = true }.parseToJsonElement(json).jsonObject }
+            .getOrNull() ?: run {
+                Log.w(TAG, "push payload not JSON: ${json.take(120)}")
+                return
+            }
+        // Remember the last ntfy message id (event=="message") so a reconnect
+        // resumes the stream from here instead of missing the gap.
+        if (outer["event"]?.jsonPrimitive?.contentOrNull == "message") {
+            outer["id"]?.jsonPrimitive?.contentOrNull?.let { id ->
+                if (id != lastMessageId) {
+                    lastMessageId = id
+                    appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                        ?.edit()?.putString(KEY_LAST_MSG_ID, id)?.apply()
+                }
+            }
+        }
+        // ntfy stream envelope events that carry no notification
+        // (open / keepalive) must not wake a sync.
+        if (outer["event"]?.jsonPrimitive?.contentOrNull in setOf("open", "keepalive")) return
+        val notifJson = outer["notification"]?.toString()
+            ?: outer["message"]?.jsonPrimitive?.contentOrNull
+            ?: json // the dev gateway relays the notification object verbatim
+        val notif = runCatching { Json.parseToJsonElement(notifJson).jsonObject }.getOrNull()
+            ?: run { Log.w(TAG, "push payload without notification object: ${json.take(120)}"); return }
+        // ntfy's "message" carries the matrix body, which wraps the
+        // notification again under "notification" — unwrap for the ids.
+        val n = notif["notification"]?.jsonObject ?: notif
+        val eventId = n["event_id"]?.jsonPrimitive?.contentOrNull
+        val roomId = n["room_id"]?.jsonPrimitive?.contentOrNull
+        if (eventId != null || roomId != null) {
+            Log.i(TAG, "push received: room=$roomId event=$eventId -> waking one sync")
+        } else {
+            // Beeper counts-only payload (no event/room ids) — still a wake.
+            Log.i(TAG, "push received (counts-style, no ids) -> waking one sync")
+        }
+        MatrixRepository.onPushDelivered()
+    }
+}

--- a/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
@@ -47,9 +47,11 @@ import java.io.File
  * startActivity and the companion can't launch activities from the background,
  * so the tool calls `StartVoiceNoteSend` (which records the room) and then
  * starts this activity via `SimpleLightScreen.startServerActivity` — the same
- * pattern as [PhotoSendActivity]. Tap the mic to record (AAC in an m4a
- * container), tap again to stop; the recording is uploaded to Matrix as an
- * m.audio message and sent in the recorded room. RECORD_AUDIO is requested at
+ * pattern as [PhotoSendActivity]. Tap the mic to record (Opus in an ogg
+ * container — the MSC3245 canonical voice-message format, ~2-3× smaller than
+ * the old AAC/m4a at speech bitrates), tap again to stop; the recording is
+ * uploaded to Matrix as an m.audio message and sent in the recorded room.
+ * RECORD_AUDIO is requested at
  * runtime (the manifest declares it; the launcher activity grants it on
  * install, but the companion's own install may not carry the grant).
  */
@@ -181,14 +183,18 @@ class VoiceNoteActivity : ComponentActivity() {
     }
 
     private fun startRecording() {
-        val file = File(cacheDir, "voice_${System.currentTimeMillis()}.m4a")
+        val file = File(cacheDir, "voice_${System.currentTimeMillis()}.ogg")
         val r = runCatching {
             MediaRecorder().apply {
                 setAudioSource(MediaRecorder.AudioSource.MIC)
-                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-                setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-                setAudioEncodingBitRate(64_000)
-                setAudioSamplingRate(44_100)
+                // Opus in an ogg container (MSC3245 voice messages). Opus
+                // native sample rates are 8/12/16/24/48 kHz — the old 44.1 kHz
+                // is not valid; 48 kHz is the default. 32 kbps is transparent
+                // for speech and ~2× smaller than the old 64 kbps AAC.
+                setOutputFormat(MediaRecorder.OutputFormat.OGG)
+                setAudioEncoder(MediaRecorder.AudioEncoder.OPUS)
+                setAudioEncodingBitRate(32_000)
+                setAudioSamplingRate(48_000)
                 setOutputFile(file.absolutePath)
                 prepare()
                 start()


### PR DESCRIPTION
## What

Push notifications for the Chats companion — Matrix HTTP pusher via ntfy.sh's gateway + an SSE wake channel — plus the battery follow-up: the slow-sync fallback cadence is now gated on push health.

## Changes

- **`PushChannel.kt`** (new): registers a Matrix HTTP pusher (`app_id com.lightphone.chats`, `format=event_id_only` — no content/keys on the wire, wake-up only) against ntfy.sh's Matrix Push Gateway (`/_matrix/push/v1/notify`, routing by pushkey), and holds an SSE subscription to the same topic. Each notification wakes one `syncOnce` while idle; the existing notification watcher posts the local notification. A private ntfy channel is auto-provisioned per install (zero setup); `--es pushsse`/`--es pushnotify`/`--es pushkey` override for a self-hosted gateway (see `push/`).
- **Push-gated slow-sync cadence**: while the SSE channel is connected, the screen-off fallback rounds stretch from 5 min to a 30-min safety net (pushes deliver instantly); the 5-min cadence resumes automatically when push is dead or unconfigured. Battery: the 5-min rounds were the measured residual drain (overnight audit, ~17% of one core); this cuts ~72 rounds/night to ~12 while push is healthy.
- **Voice notes** (`VoiceNoteActivity.kt`), **thread scrollbar** (`ThreadScrollBar.kt`), and chat-list/thread fixes.
- **`push/`**: gateway.py + test rig + README for the self-hosted push option.

## Verification

- Emulator e2e against a local Synapse: fresh login → pusher registered → message → gateway → SSE → notification.
- Live LP3 test: Beeper POSTs real-message notifications to the external pusher; full chain verified (push → syncOnce → local notification).
- Battery measurement on this build pending (overnight batterystats).