### PR TITLE
Titles: exclude bridge bots from generated chat names

### DIFF
--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -4164,7 +4164,7 @@ object MatrixRepository {
         nameMemo: MutableMap<String, String>,
     ): String {
         room.name?.explicitName?.takeIf { it.isNotBlank() }?.let { return it }
-        val heroes = room.name?.heroes.orEmpty()
+        val heroes = titleHeroesOf(c, roomId, room)
         if (heroes.isNotEmpty()) {
             val names = heroes.mapNotNull { hero ->
                 nameMemo.getOrPut(hero.full) {
@@ -4176,6 +4176,33 @@ object MatrixRepository {
             if (names.isNotEmpty()) return names.joinToString(", ")
         }
         return "Chat"
+    }
+
+    /**
+     * Heroes that deserve a spot in a generated title. Self-hosted bridges
+     * (BlueBubbles/OpenBubbles, mautrix, …) add their bridge bot as a hero,
+     * which would glue e.g. "imessagebot" onto the contact names. Exact match
+     * first: the bridge's declared bot ([bridgeBotOf], m.bridge state) is a
+     * user id — remove just it, so a human whose name ends in "bot" keeps
+     * their spot. Bridges that declare nothing (and bots not in the heroes)
+     * fall back to contactIdOf's suffix heuristic. Bots stay only when every
+     * hero is one, so an all-bot room doesn't fall through to "Chat".
+     */
+    private suspend fun titleHeroesOf(c: MatrixClient, roomId: RoomId, room: MatrixRoom): List<UserId> {
+        val heroes = room.name?.heroes.orEmpty()
+        if (heroes.isEmpty()) return heroes
+        // Cache-hit avoids a store transaction on steady-state room passes;
+        // the cold read owns its own scope like readReceiptsByEvent does.
+        val declared = bridgeBotByRoom[roomId.full] ?: withTimeoutOrNull(ROOM_BUDGET_MS) {
+            val txManager = c.di.get<RepositoryTransactionManager>(RepositoryTransactionManager::class)
+            txManager.readTransaction { bridgeBotOf(c, roomId) }
+        }.orEmpty()
+        val humans = if (declared.isNotEmpty()) {
+            heroes.filterNot { it.full == declared }
+        } else {
+            heroes.filterNot { it.localpart.endsWith("bot", ignoreCase = true) }
+        }
+        return humans.ifEmpty { heroes }
     }
 
     /**
@@ -4626,7 +4653,7 @@ object MatrixRepository {
 
     private suspend fun roomDisplayName(c: MatrixClient, roomId: RoomId, room: MatrixRoom): String {
         room.name?.explicitName?.takeIf { it.isNotBlank() }?.let { return it }
-        val heroes = room.name?.heroes.orEmpty()
+        val heroes = titleHeroesOf(c, roomId, room)
         if (heroes.isNotEmpty()) {
             val names = heroes.mapNotNull { hero ->
                 withTimeoutOrNull(ROOM_BUDGET_MS) {


### PR DESCRIPTION
## Problem

Self-hosted bridges (BlueBubbles/OpenBubbles, mautrix, …) join their bridge bot as a room hero. For a bridged 1:1 with no explicit room name, the generated title then includes the bot:

> John Smith, imessagebot

instead of just:

> John Smith

This shows up in both the chat list and notification titles. Beeper-hosted chats don't hit this as visibly because their DMs list only the contact as the (single) hero — self-hosted bridges tend to add the bot alongside the contact.

## Fix

New `titleHeroesOf()` in `MatrixRepository`, used by both title generators (`resolveRoomName` for the chat list, `roomDisplayName` for notifications). Two tiers:

1. **Exact match** — remove the room's declared bridge bot via `bridgeBotOf()` (`m.bridge` / `uk.half-shot.bridge` / `functional_members` state, already used for read receipts). Removing by exact user id means a human hero whose name happens to end in `bot` keeps their spot.
2. **Suffix fallback** — if the bridge declares nothing (or the lookup times out), fall back to the `endsWith("bot")` heuristic that `contactIdOf()` and `isAccountSpace()` already use, so the behavior at worst matches the codebase's existing convention.

Guard preserved: if every hero is a bot, the original list is kept so the room doesn't fall through to "Chat".

The room-list path reads the `bridgeBotByRoom` cache first, so steady-state name resolution opens no store transaction; the cold read (once per room per session) opens its own `readTransaction`, mirroring `readReceiptsByEvent`.

## Verification

`:server:compileDebugKotlin` and `:app:compileDebugKotlin` build clean. The repo has no test suite, so this is compile-verified only — happy to exercise it against a live self-hosted BlueBubbles/OpenBubbles iMessage bridge and adjust if review finds edge cases.