### PR TITLE
Notifications: request POST_NOTIFICATIONS at runtime

### DIFF
--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -61,6 +61,21 @@ private const val REVEAL_THRESHOLD = 4
  */
 private const val EXTRA_NOTIFY_ROOM = "chats.notifyRoomId"
 
+/**
+ * Flattened component of the companion's POST_NOTIFICATIONS trampoline
+ * activity (matches its manifest entry; the app cannot reference the server's
+ * classes — same constraint as [EXTRA_NOTIFY_ROOM]).
+ */
+private const val NOTIFICATION_PERMISSION_ACTIVITY =
+    "com.lightphone.chats/.server.NotificationPermissionActivity"
+
+/**
+ * Process-wide "prompt already issued" latch: the ViewModel is recreated on
+ * navigation (each show is a fresh screen), so a per-screen flag would
+ * re-prompt on every return to the list.
+ */
+private var notificationPermissionPrompted = false
+
 class ChatListViewModel : LightViewModel<Unit>() {
 
     val rooms = MutableStateFlow<List<LightServiceMethod.GetRooms.Room>>(emptyList())
@@ -86,6 +101,18 @@ class ChatListViewModel : LightViewModel<Unit>() {
     var pendingNotifyRoomId: String? = null
     /** Selected bridged-network label (Phase 7); null = all networks. */
     val networkFilter = MutableStateFlow<String?>(null)
+
+    /**
+     * One-shot launch request for the companion's POST_NOTIFICATIONS
+     * trampoline (the attach-photo/voice-note startServerActivity pattern):
+     * set by [refresh] on the first settled logged-in account, consumed by
+     * the screen once the activity is started.
+     */
+    val notificationPermissionComponent = MutableStateFlow<String?>(null)
+
+    fun consumeNotificationPermissionComponent() {
+        notificationPermissionComponent.value = null
+    }
 
     /**
      * Room-list scroll position, persisted across navigation so a thread exit
@@ -186,6 +213,16 @@ class ChatListViewModel : LightViewModel<Unit>() {
                 this@ChatListViewModel.account.value = account
                 rooms.value = result
                 this@ChatListViewModel.connection.value = connection
+                // POST_NOTIFICATIONS stays denied until requested at runtime
+                // (targetSdk 33+ — a fresh install never prompts on its own),
+                // and the tool runtime forbids permission requests, so the
+                // first settled logged-in account launches the companion's
+                // trampoline, once per process. Prompting while logged out
+                // would ask a user who has no account yet.
+                if (!notificationPermissionPrompted && account?.loggedIn == true) {
+                    notificationPermissionPrompted = true
+                    notificationPermissionComponent.value = NOTIFICATION_PERMISSION_ACTIVITY
+                }
                 // A notification tap asked for a thread; open it once its room is
                 // loaded (a cold start may have to wait for the first room-list pass).
                 consumeNotifyRoom(result)
@@ -262,6 +299,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
         val connection by viewModel.connection.collectAsState()
         val visibleCount by viewModel.visibleCount.collectAsState()
         val pendingRoom by viewModel.openRoom.collectAsState()
+        val permissionComponent by viewModel.notificationPermissionComponent.collectAsState()
         val networkFilter by viewModel.networkFilter.collectAsState()
         val themeColors by LightThemeController.colors.collectAsState()
         // The saved position seeds the list state directly (feedback
@@ -294,6 +332,16 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
             val room = pendingRoom ?: return@LaunchedEffect
             viewModel.openRoom.value = null
             openThread(room)
+        }
+
+        // Notification-permission handoff (same startServerActivity pattern
+        // as the attach-photo/voice-note components on the thread screen):
+        // the first settled logged-in load asks the companion's trampoline to
+        // request POST_NOTIFICATIONS.
+        LaunchedEffect(permissionComponent) {
+            val component = permissionComponent ?: return@LaunchedEffect
+            startServerActivity(component)
+            viewModel.consumeNotificationPermissionComponent()
         }
 
         // Reveal more rooms when the user scrolls near the end of the current

--- a/server/src/main/AndroidManifest.xml
+++ b/server/src/main/AndroidManifest.xml
@@ -56,6 +56,19 @@
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:configChanges="orientation|screenSize|keyboardHidden" />
 
+        <!-- Requests POST_NOTIFICATIONS at runtime — declaring it in the
+             manifest is not enough on targetSdk 33+ (it stays denied until
+             requested, so message notifications were silently blocked on
+             fresh installs). Started by the tool from the chat list via
+             startServerActivity; finishes immediately once granted. -->
+        <activity
+            android:name=".NotificationPermissionActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:screenOrientation="portrait"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:configChanges="orientation|screenSize|keyboardHidden" />
+
         <!-- Records a voice note (AAC/m4a) and sends it as an m.audio message;
              started by the tool via StartVoiceNoteSend + startServerActivity. -->
         <activity

--- a/server/src/main/kotlin/com/lightphone/chats/server/NotificationPermissionActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/NotificationPermissionActivity.kt
@@ -1,0 +1,42 @@
+package com.lightphone.chats.server
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+/**
+ * Permission trampoline for POST_NOTIFICATIONS (2026-08-22): with
+ * targetSdk 33+ declaring the permission in the manifest is not enough — it
+ * stays denied (and `NotificationManager.areNotificationsEnabled()` false)
+ * until something requests it at runtime, and nothing did: message
+ * notifications were silently blocked on every fresh install ("I do not
+ * receive notifications"). The tool runtime forbids permission requests (same
+ * ban as startActivity — see [VoiceNoteActivity]), so the tool starts this
+ * translucent activity via `startServerActivity` the first time the chat list
+ * shows with a logged-in account. Finishes immediately when the permission is
+ * already granted (invisible re-entry) and on either dialog result — a denial
+ * needs no error surface, ChatNotifier already skips posting while
+ * notifications are off, and Android itself stops re-prompting after repeated
+ * denials.
+ */
+class NotificationPermissionActivity : ComponentActivity() {
+
+    private val requestPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { finish() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            finish()
+            return
+        }
+        requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+}

--- a/server/src/main/kotlin/com/lightphone/chats/server/NotificationPermissionActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/NotificationPermissionActivity.kt
@@ -2,7 +2,6 @@ package com.lightphone.chats.server
 
 import android.Manifest
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,8 +29,7 @@ class NotificationPermissionActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
-            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
             PackageManager.PERMISSION_GRANTED
         ) {
             finish()


### PR DESCRIPTION
Every fresh install on targetSdk 33+ gets **zero notifications**, even though the whole push pipeline (ntfy pusher, SSE, sync-on-push, `ChatNotifier`) works perfectly.

## Root cause

`POST_NOTIFICATIONS` is declared in the manifest but **never requested at runtime**. On targetSdk 33+ that leaves it permanently denied with no dialog ever shown. `ChatNotifier.notifyMessage` then returns early at its `areNotificationsEnabled()` gate before `ensureChannel` runs — which is why the `chats_messages` channel never exists and `dumpsys` shows `importance=NONE` / growing `numBlocked`.

## Fix

Follows the app's existing companion-activity pattern (PhotoSendActivity/VoiceNoteActivity):

- **`NotificationPermissionActivity`** (:server) — translucent trampoline that requests `POST_NOTIFICATIONS` via the Activity Result API and finishes on any result; finishes instantly without UI if already granted or pre-API 33.
- **Launch hook** (:app `ChatListScreen`) — fires `startServerActivity` on the first load where `account.loggedIn` settles `true`, once per process (file-level latch, since the VM is recreated on navigation). Gated on login so logged-out users are never prompted.

Additive only — no changes to `PushChannel`, `ChatSyncService`, `ChatNotifier`, or sync logic.

## Verified on LP3

`pm revoke` to simulate fresh install → cold start → system permission dialog → Allow → incoming bridged text: `push received ... waking one sync` → `ChatNotifier: notify ...` → notification visibly posted.