### PR TITLE
Composer: keep the clear-draft X above the system IME

### DIFF
--- a/app/src/main/kotlin/com/lightphone/chats/screens/ComposerScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ComposerScreen.kt
@@ -3,6 +3,7 @@ package com.lightphone.chats.screens
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
@@ -173,6 +174,10 @@ class ComposerScreen(
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
+                        // Keeps the X above the keyboard when the system IME
+                        // is in use (no-op with the embedded keyboard — the
+                        // IME never shows, so imePadding is 0).
+                        .imePadding()
                         .padding(end = 1f.gridUnitsAsDp(), bottom = 1f.gridUnitsAsDp())
                         .lightClickable {
                             textState.edit { replace(0, length, "") }


### PR DESCRIPTION
Companion to fenleon/light-sdk#1, which makes `LightTextInputEditor` prefer the system IME when one is enabled (and fall back to the embedded LP3 keyboard when none is — stock LightOS).

The composer positions its clear-draft X at the screen's bottom edge. With a system IME up, the keyboard window slides over it. One `imePadding()` lifts the X above the IME; when the embedded keyboard is in use the IME never shows, so the padding is 0 and the layout is pixel-identical to before.

Verified on LP3 with both keyboard paths (system Light keyboard and embedded fallback).