### PR TITLE
Audit cuts + 0.17.0 — send latency, unread cursor, battery-saver rework

### DIFF
--- a/app/lighttool.toml
+++ b/app/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.lightphone.chats"
 label = "Chats"
-versionCode = 75
-versionName = "0.15.0"
+versionCode = 76
+versionName = "0.16.0"
 permissions = ["android.permission.INTERNET", "android.permission.POST_NOTIFICATIONS"]
 # Single-APK build (2026-08-19): the former :server companion is a library
 # merged into this APK, which hosts its own LightSdkService + the persistent

--- a/app/lighttool.toml
+++ b/app/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.lightphone.chats"
 label = "Chats"
-versionCode = 74
-versionName = "0.14.0"
+versionCode = 75
+versionName = "0.15.0"
 permissions = ["android.permission.INTERNET", "android.permission.POST_NOTIFICATIONS"]
 # Single-APK build (2026-08-19): the former :server companion is a library
 # merged into this APK, which hosts its own LightSdkService + the persistent

--- a/app/lighttool.toml
+++ b/app/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.lightphone.chats"
 label = "Chats"
-versionCode = 73
-versionName = "0.13.0"
+versionCode = 74
+versionName = "0.14.0"
 permissions = ["android.permission.INTERNET", "android.permission.POST_NOTIFICATIONS"]
 # Single-APK build (2026-08-19): the former :server companion is a library
 # merged into this APK, which hosts its own LightSdkService + the persistent

--- a/app/lighttool.toml
+++ b/app/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.lightphone.chats"
 label = "Chats"
-versionCode = 76
-versionName = "0.16.0"
+versionCode = 77
+versionName = "0.17.0"
 permissions = ["android.permission.INTERNET", "android.permission.POST_NOTIFICATIONS"]
 # Single-APK build (2026-08-19): the former :server companion is a library
 # merged into this APK, which hosts its own LightSdkService + the persistent

--- a/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
@@ -1,6 +1,7 @@
 package com.lightphone.chats
 
 import com.thelightphone.sdk.callRemoteServiceMethod
+import android.util.Log
 import com.thelightphone.sdk.shared.LightResult
 import com.thelightphone.sdk.shared.LightServiceMethod
 import com.thelightphone.sdk.shared.error
@@ -222,10 +223,13 @@ object ChatClient {
         ) is LightResult.Success
 
     suspend fun markRead(roomId: String, eventId: String) {
-        callRemoteServiceMethod(
+        val result = callRemoteServiceMethod(
             LightServiceMethod.MarkRead,
             LightServiceMethod.MarkRead.Request(roomId, eventId),
         )
+        if (result !is LightResult.Success) {
+            Log.d("ChatsDebug", "markRead: FAILED room=$roomId at=$eventId result=$result")
+        }
     }
 
     suspend fun setTyping(roomId: String, active: Boolean) {

--- a/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
@@ -124,6 +124,30 @@ object ChatClient {
         ).getOrNull()?.revision ?: lastSeen
 
     /**
+     * Long-poll wait for the room-flags revision (Phase C, 2026-09-06): the
+     * companion bumps it wherever a flag fact commits (own optimistic toggles,
+     * store-fresh rebuilds after a Beeper-side change). The thread/contact-
+     * panel flag loops refetch [getRoomFlags] on movement instead of polling.
+     */
+    suspend fun waitForFlagChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
+        callRemoteServiceMethod(
+            LightServiceMethod.WaitForChange,
+            LightServiceMethod.WaitForChange.Request("flags", null, lastSeen, timeoutMs),
+        ).getOrNull()?.revision ?: lastSeen
+
+    /**
+     * Long-poll wait for the status revision (Phase C, 2026-09-06): the
+     * companion bumps it wherever a connection-state or verification-state
+     * fact commits. The Account/Verification/Settings screens refetch their
+     * status on movement instead of polling.
+     */
+    suspend fun waitForStatusChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
+        callRemoteServiceMethod(
+            LightServiceMethod.WaitForChange,
+            LightServiceMethod.WaitForChange.Request("status", null, lastSeen, timeoutMs),
+        ).getOrNull()?.revision ?: lastSeen
+
+    /**
      * Sends [body] to [roomId]. The response carries the outbox transaction id
      * plus the timeline event id once the homeserver acked (null until then) —
      * the thread uses it for an optimistic row the sync echo replaces.

--- a/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
@@ -1,7 +1,6 @@
 package com.lightphone.chats
 
 import com.thelightphone.sdk.callRemoteServiceMethod
-import android.util.Log
 import com.thelightphone.sdk.shared.LightResult
 import com.thelightphone.sdk.shared.LightServiceMethod
 import com.thelightphone.sdk.shared.error
@@ -14,10 +13,6 @@ import com.thelightphone.sdk.shared.getOrNull
  * binder.
  */
 object ChatClient {
-
-    /** Round-trips a binder call to the companion; true when the call succeeds. */
-    suspend fun ping(): Boolean =
-        callRemoteServiceMethod(LightServiceMethod.ChatPing, Unit) is LightResult.Success
 
     suspend fun setAccount(
         homeserver: String,
@@ -156,20 +151,11 @@ object ChatClient {
     suspend fun sendMessage(
         roomId: String,
         body: String,
-        replyToEventId: String? = null,
-    ): LightServiceMethod.SendMessage.Response? {
-        // Send-RPC timing (2026-09-03), tool-side half of the server dispatch line.
-        val t0 = android.os.SystemClock.elapsedRealtime()
-        return callRemoteServiceMethod(
+    ): LightServiceMethod.SendMessage.Response? =
+        callRemoteServiceMethod(
             LightServiceMethod.SendMessage,
-            LightServiceMethod.SendMessage.Request(roomId, body, replyToEventId),
-        ).getOrNull().also {
-            android.util.Log.d(
-                "ChatClient",
-                "sendMessage RPC took ${android.os.SystemClock.elapsedRealtime() - t0}ms",
-            )
-        }
-    }
+            LightServiceMethod.SendMessage.Request(roomId, body),
+        ).getOrNull()
 
     /**
      * Re-sends a locally-failed message: the companion clears the outbox error
@@ -223,13 +209,10 @@ object ChatClient {
         ) is LightResult.Success
 
     suspend fun markRead(roomId: String, eventId: String) {
-        val result = callRemoteServiceMethod(
+        callRemoteServiceMethod(
             LightServiceMethod.MarkRead,
             LightServiceMethod.MarkRead.Request(roomId, eventId),
         )
-        if (result !is LightResult.Success) {
-            Log.d("ChatsDebug", "markRead: FAILED room=$roomId at=$eventId result=$result")
-        }
     }
 
     suspend fun setTyping(roomId: String, active: Boolean) {

--- a/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/ChatClient.kt
@@ -1,16 +1,17 @@
 package com.lightphone.chats
 
+import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.callRemoteServiceMethod
-import com.thelightphone.sdk.shared.LightResult
 import com.thelightphone.sdk.shared.LightServiceMethod
-import com.thelightphone.sdk.shared.error
 import com.thelightphone.sdk.shared.getOrNull
 
 /**
- * Thin RPC client for the Chats companion methods. Everything privileged — the
- * persistent Matrix connection, sync loop, storage, notifications — lives in
- * the companion (:server); the tool only renders state fetched over the SDK
- * binder.
+ * The app-side API over [MatrixRepository]. Chats is single-APK/single-process
+ * (2026-08-19), so the UI calls the repository directly — no binder round
+ * trip, no serialized dispatch (NO-SEAM, 2026-09-07). The [LightServiceMethod]
+ * handlers in :server stay compiled for the vetted-tools contract (MainActivity
+ * adb control, emulator pipeline); only the activity-launching flows and the
+ * SDK-level volume read still ride the binder here.
  */
 object ChatClient {
 
@@ -20,58 +21,47 @@ object ChatClient {
         passwordOrToken: String,
         tokenLogin: Boolean = false,
     ): LightServiceMethod.SetAccount.Response? =
-        callRemoteServiceMethod(
-            LightServiceMethod.SetAccount,
-            LightServiceMethod.SetAccount.Request(homeserver, user, passwordOrToken, tokenLogin),
-        ).getOrNull()
+        runCatching {
+            MatrixRepository.loginAsUnit(homeserver, user, passwordOrToken, tokenLogin).getOrThrow()
+            LightServiceMethod.SetAccount.Response(
+                userId = MatrixRepository.lastLoginUserId ?: "",
+                deviceId = MatrixRepository.lastLoginDeviceId ?: "",
+                needsVerification = MatrixRepository.lastLoginNeedsVerification,
+            )
+        }.getOrNull()
 
-    /** Beeper login, step 1: emails a 6-digit code to [email]. @return null on success, else the companion's error message. */
+    /** Beeper login, step 1: emails a 6-digit code to [email]. @return null on success, else the error message. */
     suspend fun beeperRequestCode(email: String): String? =
-        callRemoteServiceMethod(
-            LightServiceMethod.BeeperRequestCode,
-            LightServiceMethod.BeeperRequestCode.Request(email),
-        ).error?.extra
+        MatrixRepository.beeperRequestCode(email).exceptionOrNull()?.message
 
     /**
      * Beeper login, step 2: completes the login with the emailed [code]. The
      * response carries [LightServiceMethod.SetBeeperAccount.Response.needsVerification].
-     * @return the response on success, else the companion's error message.
+     * @return the response on success, else the error message.
      */
     suspend fun beeperLogin(email: String, code: String): Result<LightServiceMethod.SetBeeperAccount.Response> =
-        when (val result = callRemoteServiceMethod(
-            LightServiceMethod.SetBeeperAccount,
-            LightServiceMethod.SetBeeperAccount.Request(email, code),
-        )) {
-            is LightResult.Success -> Result.success(result.data)
-            is LightResult.Error -> Result.failure(Exception(result.extra ?: "beeper login failed"))
+        MatrixRepository.beeperLoginAsUnit(email, code).mapCatching { _ ->
+            LightServiceMethod.SetBeeperAccount.Response(
+                userId = MatrixRepository.lastLoginUserId ?: "",
+                deviceId = MatrixRepository.lastLoginDeviceId ?: "",
+                needsVerification = MatrixRepository.lastLoginNeedsVerification,
+            )
         }
 
     suspend fun accountState(): LightServiceMethod.GetAccountState.Response? =
-        callRemoteServiceMethod(LightServiceMethod.GetAccountState, Unit).getOrNull()
+        runCatching { MatrixRepository.accountState() }.getOrNull()
 
     suspend fun logout() {
-        callRemoteServiceMethod(LightServiceMethod.Logout, Unit)
+        runCatching { MatrixRepository.logout() }
     }
 
     suspend fun getRooms(): List<LightServiceMethod.GetRooms.Room> =
-        callRemoteServiceMethod(LightServiceMethod.GetRooms, Unit)
-            .getOrNull()?.rooms.orEmpty()
+        MatrixRepository.getRooms()
 
-    /**
-     * The room list's current revision — the list poll's cheap gate: when it
-     * hasn't moved since the last [getRooms], the full 400-room payload stays
-     * on the server (2026-09-01, the Beeper comparison). 0 = nothing published
-     * yet (cold start) — the show-time refresh + retries handle that.
-     */
-    suspend fun roomListRevision(): Long =
-        callRemoteServiceMethod(LightServiceMethod.GetRoomListRevision, Unit)
-            .getOrNull()?.revision ?: 0L
-
-    /** Every room the companion knows (full census, trimmed rows — no preview
+    /** Every room the repository knows (full census, trimmed rows — no preview
      *  or unread). The contacts list + search need any room, old or quiet. */
     suspend fun getAllRooms(): List<LightServiceMethod.GetRooms.Room> =
-        callRemoteServiceMethod(LightServiceMethod.GetAllRooms, Unit)
-            .getOrNull()?.rooms.orEmpty()
+        MatrixRepository.getAllRooms()
 
     /**
      * A page of messages, oldest first; [beforeEventId] pages further back.
@@ -84,64 +74,16 @@ object ChatClient {
         beforeEventId: String? = null,
         limit: Int = 30,
     ): LightServiceMethod.GetMessages.Response? =
-        callRemoteServiceMethod(
-            LightServiceMethod.GetMessages,
-            LightServiceMethod.GetMessages.Request(roomId, beforeEventId, limit),
-        ).getOrNull()
-
-    /**
-     * The room's cached newest-page revision — the thread poll's cheap gate:
-     * when it hasn't moved since the last [getMessages], the page round trip
-     * is skipped (2026-09-01, the Beeper comparison). 0 = page not computed.
-     */
-    suspend fun messagePageRevision(roomId: String): Long =
-        callRemoteServiceMethod(
-            LightServiceMethod.GetMessagePageRevision,
-            LightServiceMethod.GetMessagePageRevision.Request(roomId),
-        ).getOrNull()?.revision ?: 0L
-
-    /**
-     * Long-poll wait for the room-list revision to move past [lastSeen] (the
-     * list poll's fixed tick, deleted 2026-09-06 — the companion holds the
-     * call until the list changes or the window elapses). Returns the current
-     * revision; equals [lastSeen] when the window elapsed unchanged.
-     */
-    suspend fun waitForRoomListChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
-        callRemoteServiceMethod(
-            LightServiceMethod.WaitForChange,
-            LightServiceMethod.WaitForChange.Request("rooms", null, lastSeen, timeoutMs),
-        ).getOrNull()?.revision ?: lastSeen
-
-    /** [waitForRoomListChange] for a room's newest-page revision (thread poll). */
-    suspend fun waitForPageChange(roomId: String, lastSeen: Long, timeoutMs: Long = 25_000): Long =
-        callRemoteServiceMethod(
-            LightServiceMethod.WaitForChange,
-            LightServiceMethod.WaitForChange.Request("page", roomId, lastSeen, timeoutMs),
-        ).getOrNull()?.revision ?: lastSeen
-
-    /**
-     * Long-poll wait for the room-flags revision (Phase C, 2026-09-06): the
-     * companion bumps it wherever a flag fact commits (own optimistic toggles,
-     * store-fresh rebuilds after a Beeper-side change). The thread/contact-
-     * panel flag loops refetch [getRoomFlags] on movement instead of polling.
-     */
-    suspend fun waitForFlagChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
-        callRemoteServiceMethod(
-            LightServiceMethod.WaitForChange,
-            LightServiceMethod.WaitForChange.Request("flags", null, lastSeen, timeoutMs),
-        ).getOrNull()?.revision ?: lastSeen
-
-    /**
-     * Long-poll wait for the status revision (Phase C, 2026-09-06): the
-     * companion bumps it wherever a connection-state or verification-state
-     * fact commits. The Account/Verification/Settings screens refetch their
-     * status on movement instead of polling.
-     */
-    suspend fun waitForStatusChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
-        callRemoteServiceMethod(
-            LightServiceMethod.WaitForChange,
-            LightServiceMethod.WaitForChange.Request("status", null, lastSeen, timeoutMs),
-        ).getOrNull()?.revision ?: lastSeen
+        runCatching {
+            val page = MatrixRepository.getMessages(roomId, beforeEventId, limit)
+            LightServiceMethod.GetMessages.Response(
+                messages = page.messages,
+                hasMore = page.hasMore,
+                encrypted = page.encrypted,
+                audioPlayingEventId = MatrixRepository.audioPlayingEventId(),
+                audioPositionMs = MatrixRepository.audioPositionMs(),
+            )
+        }.getOrNull()
 
     /**
      * Sends [body] to [roomId]. The response carries the outbox transaction id
@@ -152,158 +94,112 @@ object ChatClient {
         roomId: String,
         body: String,
     ): LightServiceMethod.SendMessage.Response? =
-        callRemoteServiceMethod(
-            LightServiceMethod.SendMessage,
-            LightServiceMethod.SendMessage.Request(roomId, body),
-        ).getOrNull()
+        runCatching { MatrixRepository.sendMessage(roomId, body, null) }.getOrNull()
 
     /**
-     * Re-sends a locally-failed message: the companion clears the outbox error
+     * Re-sends a locally-failed message: the repository clears the outbox error
      * on [transactionId] (the txn of the "local-…" row) and Trixnity re-sends
      * the same transaction — idempotent, no duplicate if it already landed.
      */
     suspend fun retrySend(roomId: String, transactionId: String) {
-        callRemoteServiceMethod(
-            LightServiceMethod.RetrySend,
-            LightServiceMethod.RetrySend.Request(roomId, transactionId),
-        )
+        runCatching { MatrixRepository.retrySend(roomId, transactionId) }
     }
 
     /**
      * Sends a reaction (an m.reaction annotation; [key] = the emoji) on a
-     * message (Phase A, 2026-09-03). False when the companion rejected it.
+     * message (Phase A, 2026-09-03). False when the repository rejected it.
      */
     suspend fun sendReaction(roomId: String, eventId: String, key: String): Boolean =
-        callRemoteServiceMethod(
-            LightServiceMethod.SendReaction,
-            LightServiceMethod.SendReaction.Request(roomId, eventId, key),
-        ) is LightResult.Success
+        runCatching { MatrixRepository.sendReaction(roomId, eventId, key) }.isSuccess
 
     /** Unsends (redacts) the signed-in user's reaction with [key] on [eventId]. */
     suspend fun unsendReaction(roomId: String, eventId: String, key: String): Boolean =
-        callRemoteServiceMethod(
-            LightServiceMethod.UnsendReaction,
-            LightServiceMethod.UnsendReaction.Request(roomId, eventId, key),
-        ) is LightResult.Success
+        runCatching { MatrixRepository.unsendReaction(roomId, eventId, key) }.getOrDefault(false)
 
     /**
      * Edits an own text message (Phase C, 2026-09-03). Returns null on
      * success, the failure message otherwise (the composer displays it — a
      * rejected edit must not read as an eternal "sending", LP3 2026-09-04).
      */
-    suspend fun editMessage(roomId: String, eventId: String, newBody: String): String? =
-        when (val result = callRemoteServiceMethod(
-            LightServiceMethod.EditMessage,
-            LightServiceMethod.EditMessage.Request(roomId, eventId, newBody),
-        )) {
-            is LightResult.Error -> result.extra ?: "edit failed"
-            else -> null
-        }
+    suspend fun editMessage(roomId: String, eventId: String, newBody: String): String? {
+        val failure = runCatching { MatrixRepository.editMessage(roomId, eventId, newBody) }
+            .exceptionOrNull() ?: return null
+        return failure.message ?: "edit failed"
+    }
 
     /** Unsends (redacts) an own message — removed for everyone the bridge can
-     *  reach (Phase C, 2026-09-03). False when the companion rejected it. */
+     *  reach (Phase C, 2026-09-03). False when the repository rejected it. */
     suspend fun unsendMessage(roomId: String, eventId: String): Boolean =
-        callRemoteServiceMethod(
-            LightServiceMethod.UnsendMessage,
-            LightServiceMethod.UnsendMessage.Request(roomId, eventId),
-        ) is LightResult.Success
+        runCatching { MatrixRepository.unsendMessage(roomId, eventId) }.isSuccess
 
     suspend fun markRead(roomId: String, eventId: String) {
-        callRemoteServiceMethod(
-            LightServiceMethod.MarkRead,
-            LightServiceMethod.MarkRead.Request(roomId, eventId),
-        )
+        runCatching { MatrixRepository.markRead(roomId, eventId) }
     }
 
     suspend fun setTyping(roomId: String, active: Boolean) {
-        callRemoteServiceMethod(
-            LightServiceMethod.SetTyping,
-            LightServiceMethod.SetTyping.Request(roomId, active),
-        )
+        runCatching { MatrixRepository.setTyping(roomId, active) }
     }
 
     /** Mutes/unmutes [roomId]'s notifications (contact panel, 2026-08-23). */
     suspend fun setRoomMuted(roomId: String, muted: Boolean) {
-        callRemoteServiceMethod(
-            LightServiceMethod.SetRoomMuted,
-            LightServiceMethod.SetRoomMuted.Request(roomId, muted),
-        )
+        runCatching { MatrixRepository.setRoomMuted(roomId, muted) }
     }
 
     /** Pins/unpins [roomId] (m.favourite tag, synced; contact panel, 2026-08-28). */
     suspend fun setRoomPinned(roomId: String, pinned: Boolean) {
-        callRemoteServiceMethod(
-            LightServiceMethod.SetRoomPinned,
-            LightServiceMethod.SetRoomPinned.Request(roomId, pinned),
-        )
+        runCatching { MatrixRepository.setRoomPinned(roomId, pinned) }
     }
-
-    /** The room's current pinned/muted/archived flags (contact panel live poll). */
-    suspend fun getRoomFlags(roomId: String): LightServiceMethod.GetRoomFlags.Response? =
-        callRemoteServiceMethod(
-            LightServiceMethod.GetRoomFlags,
-            LightServiceMethod.GetRoomFlags.Request(roomId),
-        ).getOrNull()
 
     /** Archives/unarchives [roomId] (Beeper inbox.done, synced; contact panel, 2026-08-28). */
     suspend fun setRoomArchived(roomId: String, archived: Boolean) {
-        callRemoteServiceMethod(
-            LightServiceMethod.SetRoomArchived,
-            LightServiceMethod.SetRoomArchived.Request(roomId, archived),
-        )
+        runCatching { MatrixRepository.setRoomArchived(roomId, archived) }
     }
 
-    /** Tells the companion which room is on screen (null = list/settings/background). */
+    /** Tells the repository which room is on screen (null = list/settings/background). */
     suspend fun setActiveRoom(roomId: String?) {
-        callRemoteServiceMethod(
-            LightServiceMethod.SetActiveRoom,
-            LightServiceMethod.SetActiveRoom.Request(roomId),
-        )
+        runCatching { MatrixRepository.setActiveRoom(roomId) }
     }
 
     suspend fun connectionState(): LightServiceMethod.GetConnectionState.Response? =
-        callRemoteServiceMethod(LightServiceMethod.GetConnectionState, Unit).getOrNull()
+        runCatching { MatrixRepository.connectionState() }.getOrNull()
 
-    /** Pauses/resumes the companion's sync loop (Settings → Sync, audit 2026-08-14). */
+    /** Pauses/resumes the sync loop (Settings → Sync, audit 2026-08-14). */
     suspend fun setSyncEnabled(enabled: Boolean): Boolean =
-        callRemoteServiceMethod(
-            LightServiceMethod.SetSyncEnabled,
-            LightServiceMethod.SetSyncEnabled.Request(enabled),
-        ).getOrNull()?.ok == true
+        runCatching { MatrixRepository.setSyncEnabled(enabled) }.isSuccess
 
     suspend fun e2eeState(): LightServiceMethod.GetE2eeState.Response? =
-        callRemoteServiceMethod(LightServiceMethod.GetE2eeState, Unit).getOrNull()
+        runCatching { MatrixRepository.e2eeState() }.getOrNull()
 
     suspend fun startDeviceVerification(): LightServiceMethod.StartDeviceVerification.Response? =
-        callRemoteServiceMethod(LightServiceMethod.StartDeviceVerification, Unit).getOrNull()
+        MatrixRepository.startDeviceVerification().fold(
+            onSuccess = { LightServiceMethod.StartDeviceVerification.Response(started = true) },
+            onFailure = {
+                LightServiceMethod.StartDeviceVerification.Response(started = false, error = it.message)
+            },
+        )
 
     suspend fun verificationState(): LightServiceMethod.GetVerificationState.Response? =
-        callRemoteServiceMethod(LightServiceMethod.GetVerificationState, Unit).getOrNull()
+        runCatching { MatrixRepository.verificationState() }.getOrNull()
 
     suspend fun verifyAction(action: String): String? =
-        when (val r = callRemoteServiceMethod(
-            LightServiceMethod.VerifyAction,
-            LightServiceMethod.VerifyAction.Request(action),
-        )) {
-            is LightResult.Success -> if (r.data.ok) null else r.data.error ?: "verification failed"
-            is LightResult.Error -> r.extra ?: "verification action failed"
-        }
+        MatrixRepository.verifyAction(action).fold(
+            onSuccess = { null },
+            onFailure = { it.message ?: "verification failed" },
+        )
 
     /** Non-interactive verification with the account's recovery key. @return null on success, else the error. */
     suspend fun recoverWithKey(recoveryKey: String): String? =
-        when (val r = callRemoteServiceMethod(
-            LightServiceMethod.RecoverWithKey,
-            LightServiceMethod.RecoverWithKey.Request(recoveryKey),
-        )) {
-            is LightResult.Success -> if (r.data.ok) null else r.data.error ?: "recovery failed"
-            is LightResult.Error -> r.extra ?: "recovery failed"
-        }
+        MatrixRepository.recoverWithKey(recoveryKey).fold(
+            onSuccess = { null },
+            onFailure = { it.message ?: "recovery failed" },
+        )
 
     /**
      * Starts the attach-a-photo flow for [roomId]. @return the flattened
-     * component name of the companion's photo-picker activity, which the tool
+     * component name of the photo-picker activity, which the tool
      * launches via `SimpleLightScreen.startServerActivity` (the tool runtime
-     * forbids startActivity).
+     * forbids startActivity). Stays on the binder: the SDK's server-side
+     * activity flow owns the launch (NO-SEAM keeps this one).
      */
     suspend fun startPhotoSend(roomId: String): String? =
         callRemoteServiceMethod(
@@ -313,47 +209,36 @@ object ChatClient {
 
     /**
      * Display-ready JPEG bytes for an image message, or null when unavailable.
-     * [allowMobileData] false + a cellular connection = the companion skips
-     * the download (Settings → Mobile data downloads).
+     * [allowMobileData] false + a cellular connection = the download is
+     * skipped (Settings → Mobile data downloads).
      */
     suspend fun getMessageMedia(
         roomId: String,
         eventId: String,
         allowMobileData: Boolean,
     ): ByteArray? =
-        callRemoteServiceMethod(
-            LightServiceMethod.GetMessageMedia,
-            LightServiceMethod.GetMessageMedia.Request(roomId, eventId, allowMobileData),
-        ).getOrNull()?.bytes
+        runCatching { MatrixRepository.getMessageMedia(roomId, eventId, allowMobileData) }.getOrNull()
 
     /** Saves an image message to the device's Pictures/Chats album
      *  (photo viewer save button, 2026-09-03). */
     suspend fun saveMessageImage(roomId: String, eventId: String): Boolean =
-        callRemoteServiceMethod(
-            LightServiceMethod.SaveMessageImage,
-            LightServiceMethod.SaveMessageImage.Request(roomId, eventId),
-        ).getOrNull()?.ok == true
+        runCatching { MatrixRepository.saveMessageImage(roomId, eventId) }.getOrDefault(false)
 
     /**
-     * Toggles voice-note playback in the companion: plays [eventId], or stops
+     * Toggles voice-note playback: plays [eventId], or stops
      * it if it is already the one playing. @return (nowPlaying, error) — the
-     * tool surfaces a fetch/playback failure on the row instead of a silent
+     * row surfaces a fetch/playback failure instead of a silent
      * no-op (feedback 2026-08-19).
      */
-    suspend fun playVoiceNote(roomId: String, eventId: String): Pair<Boolean, String?> {
-        val result = callRemoteServiceMethod(
-            LightServiceMethod.PlayVoiceNote,
-            LightServiceMethod.PlayVoiceNote.Request(roomId, eventId),
-        )
-        return when (result) {
-            is LightResult.Success -> result.data.playing to result.data.error
-            is LightResult.Error -> false to (result.extra ?: "playback failed")
-        }
-    }
+    suspend fun playVoiceNote(roomId: String, eventId: String): Pair<Boolean, String?> =
+        runCatching { MatrixRepository.playVoiceNote(roomId, eventId) }
+            .getOrElse { false to (it.message ?: "playback failed") }
 
     /**
      * Media volume (level, max) for the in-app volume panel (feedback
      * 2026-08-30): the SDK server answers GetVolumeLevel from the platform.
+     * Stays on the binder — this is an SDK-level method routed through the
+     * server's customServiceMethodResolver (NO-SEAM keeps this one).
      */
     suspend fun volumeLevel(): Pair<Int, Int>? =
         callRemoteServiceMethod(LightServiceMethod.GetVolumeLevel, Unit)
@@ -361,7 +246,7 @@ object ChatClient {
 
     /**
      * Starts the record-a-voice-note flow for [roomId]. @return the flattened
-     * component name of the companion's recording activity, which the tool
+     * component name of the recording activity, which the tool
      * launches via `SimpleLightScreen.startServerActivity`.
      */
     suspend fun startVoiceNoteSend(roomId: String): String? =
@@ -369,4 +254,17 @@ object ChatClient {
             LightServiceMethod.StartVoiceNoteSend,
             LightServiceMethod.StartVoiceNoteSend.Request(roomId),
         ).getOrNull()?.activityComponent
+
+    /**
+     * Long-poll wait for the status revision (Phase C, 2026-09-06): the
+     * repository bumps it wherever a connection-state or verification-state
+     * fact commits. The Account/Verification/Settings screens refetch their
+     * status on movement instead of polling. (The list/thread/screens' room
+     * and page loops died with the NO-SEAM flows — this is the one wait left.)
+     */
+    suspend fun waitForStatusChange(lastSeen: Long, timeoutMs: Long = 25_000): Long =
+        callRemoteServiceMethod(
+            LightServiceMethod.WaitForChange,
+            LightServiceMethod.WaitForChange.Request("status", null, lastSeen, timeoutMs),
+        ).getOrNull()?.revision ?: lastSeen
 }

--- a/app/src/main/kotlin/com/lightphone/chats/Format.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/Format.kt
@@ -6,6 +6,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
 
 /**
  * Relative timestamp for room rows: 24-hour time of day for today ("14:02" —
@@ -28,17 +30,11 @@ fun formatRelativeTimestamp(timestampMs: Long): String {
     return when {
         date == today -> dateTime.toLocalTime().format(ROW_TIME_FORMAT)
         date == today.minusDays(1) -> "Yest"
-        date.isAfter(today.minusDays(7)) -> SHORT_DAY_NAMES[date.dayOfWeek.value - 1]
+        date.isAfter(today.minusDays(7)) -> date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.US)
         date.year == today.year -> date.format(MONTH_DAY_FORMAT)
         else -> date.format(MONTH_YEAR_FORMAT)
     }
 }
-
-/** Full capitalized weekday names (ISO: Monday=1 … Sunday=7), for thread day tags. */
-private val DAY_NAMES = arrayOf("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-
-/** Short capitalized weekday names (ISO: Monday=1 … Sunday=7), for room rows. */
-private val SHORT_DAY_NAMES = arrayOf("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
 /**
  * Timestamp for a message row in the thread: the time plus a day tag when the
@@ -59,7 +55,7 @@ fun formatMessageTime(timestampMs: Long): String {
     val tag = when {
         date == today -> null
         date == today.minusDays(1) -> "Yesterday"
-        date.isAfter(today.minusDays(7)) -> DAY_NAMES[date.dayOfWeek.value - 1]
+        date.isAfter(today.minusDays(7)) -> date.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.US)
         date.year == today.year -> date.format(MONTH_DAY_FORMAT)
         else -> date.format(MONTH_DAY_YEAR_FORMAT)
     }

--- a/app/src/main/kotlin/com/lightphone/chats/Format.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/Format.kt
@@ -78,7 +78,7 @@ fun dayOf(timestampMs: Long): LocalDate =
  * 1 (US/Canada, 1 + 10), 2 (Germany/France/…, 2 + 9..11), else 3. Non-phone
  * strings pass through unchanged.
  */
-fun formatBridgePhone(raw: String): String {
+private fun formatBridgePhone(raw: String): String {
     val digits = raw.trim().removePrefix("+").filter { it.isDigit() }
     if (digits.length < 10) return raw
     val ccLen = when {

--- a/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
@@ -383,17 +383,16 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
                                 // The Enter code entry appears once a code has
                                 // been requested (feedback 2026-08-19: the
                                 // request-code overlay dismisses back here).
-                                // The removed "Code sent to…" status line's
-                                // info lives in the label now (feedback
-                                // 2026-09-06).
+                                // No email in the label/title — privacy on
+                                // shared screens (feedback 2026-09-06).
                                 if (codeStatus != null || beeperCode.isNotEmpty()) {
                                     FormField(
-                                        label = "Enter code sent to $beeperEmail",
+                                        label = "Enter code sent to your email",
                                         value = beeperCode,
                                         placeholder = "6-digit code",
                                         onClick = {
                                             editField(
-                                                title = "Enter code sent to $beeperEmail",
+                                                title = "Enter Beeper code",
                                                 field = viewModel.beeperCode,
                                                 // The code editor submits (was
                                                 // SAVE — feedback 2026-08-19).

--- a/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
@@ -85,8 +85,7 @@ class AccountViewModel : LightViewModel<Unit>() {
      * Whether the e2ee verdict has settled. The first read on a cold trust
      * store can lag a poll behind the truth, so "Verify Device" only shows
      * after a verified read OR two consecutive unverified reads — until then
-     * the row reads "Checking…" (feedback 2026-08-20: "not verified" flashed
-     * on launch before loading to "verified").
+     * the row reads "Checking…".
      */
     val e2eeSettled = MutableStateFlow(false)
     /** The verification state machine's state string ("none" | "waiting" |
@@ -171,7 +170,7 @@ class AccountViewModel : LightViewModel<Unit>() {
      *  Runs off-main: the in-process binder executes the server's handler on
      *  the caller's thread, and these are multi-second network calls (the
      *  login also starts the foreground sync service — a main-thread block
-     *  past its 5 s window crashed the app, LP3 2026-08-19). */
+     *  past its 5 s window crashed the app). */
     fun requestCode(onSuccess: (email: String) -> Unit) {
         if (busy.value) return
         val email = beeperEmail.value.trim()
@@ -193,9 +192,7 @@ class AccountViewModel : LightViewModel<Unit>() {
                     onSuccess(email)
                 }
             } finally {
-                // A binder exception must not leave the button dead (feedback
-                // 2026-08-19: the same stuck-flag class as the thread's
-                // loading guard) — busy always clears.
+                // A binder exception must not leave the button dead — busy always clears.
                 busy.value = false
             }
         }
@@ -328,15 +325,15 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
                     // Settings rows start 0.5 gu below the top bar (its scroll
                     // Column carries vertical 0.5 gu padding) — match it so the
                     // "Server" row sits at the same height as Settings'
-                    // "Account" row (feedback 2026-09-06).
+                    // "Account" row.
                     LightScrollView(
                         modifier = Modifier.padding(top = 0.5f.gridUnitsAsDp()),
                     ) {
                         if (account?.loggedIn == true) {
                             // Logged in: just the account status + actions — the
                             // login form (email/code) would be dead weight here.
-                            // The device-verification row leads the panel
-                            // (feedback 2026-09-01); the account name is not
+                            // The device-verification row leads the panel;
+                            // the account name is not
                             // shown, only the sync status.
                             EncryptionRow(
                                 e2ee = e2ee,
@@ -381,10 +378,9 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
                                     onClick = { editField("Beeper email", viewModel.beeperEmail) },
                                 )
                                 // The Enter code entry appears once a code has
-                                // been requested (feedback 2026-08-19: the
-                                // request-code overlay dismisses back here).
+                                // been requested.
                                 // No email in the label/title — privacy on
-                                // shared screens (feedback 2026-09-06).
+                                // shared screens.
                                 if (codeStatus != null || beeperCode.isNotEmpty()) {
                                     FormField(
                                         label = "Enter code sent to your email",
@@ -430,8 +426,7 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
                                 )
                             }
                             error?.let { message -> StatusLine(message) }
-                            // "Code sent to…" line removed (feedback
-                            // 2026-09-06) — the Enter code field's label
+                            // "Code sent to…" line removed — the Enter code field's label
                             // carries the email now; codeStatus still gates
                             // the field's appearance.
                         }
@@ -454,8 +449,7 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
                         } else if (beeperMode) {
                             // Beeper flow: the bar's button sends the emailed
                             // code, then an overlay panel confirms it and the
-                            // user enters the code via the Enter code field
-                            // (feedback 2026-08-19).
+                            // user enters the code via the Enter code field.
                             LightBarButton.Text(
                                 text = if (busy) "…" else if (codeRequested) "REQUEST AGAIN" else "REQUEST CODE",
                                 onClick = if (busy) null else {
@@ -486,7 +480,7 @@ class AccountScreen(sealedActivity: SealedLightActivity) :
      *  replaces the field, an explicit back (no result) keeps the old value.
      *  [onResult] fires with the accepted value (e.g. the beeper login after
      *  the code). [submitLabel] — SAVE for field editors, SUBMIT for the code
-     *  entry (feedback 2026-08-19). */
+     *  entry. */
     private fun editField(
         title: String,
         field: MutableStateFlow<String>,
@@ -544,7 +538,7 @@ private fun TokenToggleRow(
             .padding(horizontal = 2f.gridUnitsAsDp(), vertical = 0.75f.gridUnitsAsDp()),
         // The toggle sits immediately left of its action label, the row
         // top-aligned so it lines up with the main label (same as Audiobooks
-        // Settings, feedback 2026-08-17).
+        // Settings).
         verticalAlignment = Alignment.Top,
     ) {
         Box(
@@ -582,7 +576,7 @@ private fun TokenToggleRow(
 /** Login path row: a single "Server" entry whose value is the active
  *  selection (Beeper or Matrix homeserver); tapping opens [ServerScreen].
  *  Value-row anatomy — "Server" is the Copy-sized top text, the selection the
- *  Heading-sized main text, flush-left (DESIGN.md §6, feedback 2026-08-19). */
+ *  Heading-sized main text, flush-left (DESIGN.md §6). */
 @Composable
 private fun ServerRow(
     beeperMode: Boolean,
@@ -674,9 +668,9 @@ private fun ServerOptionRow(
     )
 }
 
-/** The request-code confirmation overlay (feedback 2026-08-19): centered
+/** The request-code confirmation overlay: centered
  *  "A code has been sent to <email>." / "Check your email." on separate lines
- *  (2026-08-29) with an X dismiss in the bottom centre; dismissing returns to
+ * with an X dismiss in the bottom centre; dismissing returns to
  *  the account panel, where the Enter code field now appears. */
 class CodeSentPanel(
     sealedActivity: SealedLightActivity,
@@ -741,7 +735,7 @@ class CodeSentPanel(
     }
 }
 
-/** The logout confirmation overlay (feedback 2026-08-19): centered
+/** The logout confirmation overlay: centered
  *  "Do you want to log out of your account?" with the LP3 X (dismiss) and
  *  triangle (confirm) — same panel grammar as the verify confirm. Result:
  *  true = log out. */
@@ -805,12 +799,11 @@ private fun AccountStatus(
         connection?.let { state ->
             val allSynced = state.state == "syncing" &&
                 state.roomsTotal > 0 && state.roomsResolved >= state.roomsTotal
-            // Feedback 2026-08-19: the status line reads plainly — "sync
+            // The status line reads plainly — "sync
             // paused" when the toggle is off, "offline" when there's simply
-            // no connection. The thread count shares the same line
-            // (2026-08-29): "Syncing 34 of 52 threads" (no separator dot —
-            // feedback 2026-09-06). Same Fine size as the restore line below
-            // (feedback 2026-09-06).
+            // no connection. The thread count shares the same line:
+            // "Syncing 34 of 52 threads" (no separator dot). Same Fine
+            // size as the restore line below.
             val statusText = when {
                 allSynced -> "Synced"
                 state.state == "syncing" -> "Syncing"
@@ -828,7 +821,7 @@ private fun AccountStatus(
                 text = countText?.let { "$statusText $it" } ?: statusText,
                 variant = LightTextVariant.Fine,
             )
-            // Key-backup restore crawl (2026-08-29): "Recovering… x of y
+            // Key-backup restore crawl: "Recovering… x of y
             // rooms" while the daily restore runs; "All messages restored"
             // once it finished AND sync has fully caught up.
             if (state.restoreScanning && state.restoreRoomsTotal > 0) {
@@ -852,11 +845,11 @@ private fun AccountStatus(
 private fun pluralThreads(count: Int): String =
     if (count == 1) "1 thread" else "$count threads"
 
-/** Device-verification row (2026-08-29): the action reads "Verify Device"
+/** Device-verification row: the action reads "Verify Device"
  *  while unverified, and is a status-only row once verified. No toggle — the
  *  state reads "Device Verified" / "Verifying" (mid-verification, so a
  *  back-out keeps the process visible) / "Verify Device". While the verdict
- *  hasn't settled (a cold trust store can lag a poll — feedback 2026-08-20)
+ *  hasn't settled (a cold trust store can lag a poll)
  *  it reads "Checking…" and is not tappable, so launch never claims a false
  *  "Verify Device". The old "Encrypted messages" label is gone. */
 @Composable
@@ -883,12 +876,12 @@ private fun EncryptionRow(
 
 /** The LP3 keyboard editor for a single settings field. Result: the edited
  *  text (trimmed; "" clears the field). The keyboard is stripped — no emoji,
- *  return, or voice keys (the passes code-entry style, feedback 2026-08-19);
+ *  return, or voice keys (the passes code-entry style);
  *  the input centers vertically between the top bar and the keyboard. The
  *  submit label defaults to SAVE (field editors); the code entry passes
- *  SUBMIT (feedback 2026-08-19); an optional [submitIcon] renders the
- *  submit as an icon instead of the label button (contacts search,
- *  2026-08-30). */
+ *  SUBMIT; an optional [submitIcon] renders the
+ *  submit as an icon instead of the label button (contacts search).
+ */
 class FieldEditorScreen(
     sealedActivity: SealedLightActivity,
     private val title: String,

--- a/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
@@ -114,12 +114,18 @@ class AccountViewModel : LightViewModel<Unit>() {
         stopPolling()
     }
 
-    /** Keeps the status fresh while Account is visible (sync state, rooms). */
+    /** Keeps the status fresh while Account is visible (sync state, rooms).
+     *  A long-poll wait on the companion's status revision (bumped wherever a
+     *  connection/verification fact commits) replaces the fixed 5 s tick; the
+     *  wait's timeout window doubles as the dead-man re-check that settles
+     *  the e2ee verdict (two consecutive reads). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
+            var last = 0L
             while (true) {
-                delay(POLL_INTERVAL_MS)
+                val revision = ChatClient.waitForStatusChange(last)
+                if (revision != last) last = revision
                 refreshStatus()
             }
         }
@@ -260,10 +266,6 @@ class AccountViewModel : LightViewModel<Unit>() {
     }
 
     private var pollJob: Job? = null
-
-    private companion object {
-        const val POLL_INTERVAL_MS = 5_000L
-    }
 }
 
 class AccountScreen(sealedActivity: SealedLightActivity) :

--- a/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/AccountScreen.kt
@@ -799,15 +799,15 @@ private fun AccountStatus(
         connection?.let { state ->
             val allSynced = state.state == "syncing" &&
                 state.roomsTotal > 0 && state.roomsResolved >= state.roomsTotal
-            // The status line reads plainly — "sync
-            // paused" when the toggle is off, "offline" when there's simply
-            // no connection. The thread count shares the same line:
+            // The status line reads plainly — "battery
+            // saver" when background sync is off, "offline" when there's
+            // simply no connection. The thread count shares the same line:
             // "Syncing 34 of 52 threads" (no separator dot). Same Fine
             // size as the restore line below.
             val statusText = when {
                 allSynced -> "Synced"
                 state.state == "syncing" -> "Syncing"
-                !state.syncEnabled -> "sync paused"
+                !state.syncEnabled -> "battery saver"
                 state.state == "offline" -> "offline"
                 state.state == "connecting" -> "connecting"
                 else -> state.state.replaceFirstChar { it.uppercase() }

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -25,9 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -56,7 +54,6 @@ import com.thelightphone.sdk.ui.LightThemeController
 import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
-import com.thelightphone.sdk.ui.LocalHapticsEnabled
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -683,8 +680,7 @@ private fun RoomRow(
 ) {
     val currentOnOpen by rememberUpdatedState(onOpen)
     val currentOnLongPress by rememberUpdatedState(onLongPress)
-    val haptic = LocalHapticFeedback.current
-    val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
+    val buzz = rememberHapticBuzz()
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -697,15 +693,11 @@ private fun RoomRow(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onTap = {
-                        if (currentHapticsEnabled) {
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
+                        buzz()
                         currentOnOpen()
                     },
                     onLongPress = {
-                        if (currentHapticsEnabled) {
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
+                        buzz()
                         currentOnLongPress()
                     },
                 )

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.viewModelScope
 import com.lightphone.chats.ChatClient
 import com.lightphone.chats.contactIdentifier
 import com.lightphone.chats.formatRelativeTimestamp
+import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.InitialScreen
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
@@ -121,52 +122,48 @@ class ChatListViewModel : LightViewModel<Unit>() {
     /**
      * Contact-panel state for the long-press entry (2026-08-29): long-pressing
      * a room row opens the same contact panel as the thread's name, seeded from
-     * the row's flags and refreshed from the companion's flags revision while
-     * the panel is open, so a Beeper-side toggle reaches it live (same pattern
-     * as ThreadViewModel's flag sync).
+     * the row's flags (the repository's fresher roomFlags value wins) and kept
+     * live by the roomFlags flow collector while the panel is open, so a
+     * Beeper-side toggle reaches it (same pattern as ThreadViewModel's flag sync).
      */
     val panelMuted = MutableStateFlow(false)
     val panelPinned = MutableStateFlow(false)
     val panelArchived = MutableStateFlow(false)
     private var panelRoomId: String? = null
-    private var panelFlagSyncJob: Job? = null
 
-    /** Seeds the panel from the row and starts the live flag wait. */
-    fun openContactPanel(room: LightServiceMethod.GetRooms.Room) {
-        // Kill any waiter leaked by an earlier panel before starting this one:
-        // startPanelFlagSync's guard would otherwise keep watching the FIRST
-        // panel's room and clobber this panel's flags with them (2026-08-29:
-        // archive toggles flipped back to ARCHIVE after 3 s for exactly that).
-        panelFlagSyncJob?.cancel()
-        panelFlagSyncJob = null
-        panelRoomId = room.id
-        panelMuted.value = room.muted
-        panelPinned.value = room.pinned
-        panelArchived.value = room.archived
-        startPanelFlagSync(room.id)
-    }
-
-    /** Stops the wait when the panel is dismissed (X pops back to the list). */
-    fun closeContactPanel() {
-        panelFlagSyncJob?.cancel()
-        panelFlagSyncJob = null
-        panelRoomId = null
-    }
-
-    private fun startPanelFlagSync(roomId: String) {
-        if (panelFlagSyncJob?.isActive == true) return
-        panelFlagSyncJob = viewModelScope.launch {
-            var lastFlags = 0L
-            while (true) {
-                val revision = ChatClient.waitForFlagChange(lastFlags)
-                if (revision == lastFlags) continue
-                lastFlags = revision
-                val flags = ChatClient.getRoomFlags(roomId) ?: continue
-                panelMuted.value = flags.muted
-                panelPinned.value = flags.pinned
-                panelArchived.value = flags.archived
+    init {
+        // Panel flags ride the repository's roomFlags flow (NO-SEAM, replaces
+        // the per-panel revision-wait job): keyed on [panelRoomId], so an open
+        // panel tracks exactly its room and a closed one (null) idles.
+        viewModelScope.launch {
+            MatrixRepository.roomFlags.collect { flags ->
+                val id = panelRoomId ?: return@collect
+                flags[id]?.let { f ->
+                    panelMuted.value = f.muted
+                    panelPinned.value = f.pinned
+                    panelArchived.value = f.archived
+                }
             }
         }
+    }
+
+    /** Seeds the panel from the row (the flow's fresher value wins). */
+    fun openContactPanel(room: LightServiceMethod.GetRooms.Room) {
+        panelRoomId = room.id
+        MatrixRepository.roomFlags.value[room.id]?.let { f ->
+            panelMuted.value = f.muted
+            panelPinned.value = f.pinned
+            panelArchived.value = f.archived
+        } ?: run {
+            panelMuted.value = room.muted
+            panelPinned.value = room.pinned
+            panelArchived.value = room.archived
+        }
+    }
+
+    /** Closing the panel (X pops back to the list) idles the collector. */
+    fun closeContactPanel() {
+        panelRoomId = null
     }
 
     fun togglePanelMuted() {
@@ -250,34 +247,27 @@ class ChatListViewModel : LightViewModel<Unit>() {
     }
 
     /**
-     * Re-fetches the list while it stays visible (the companion's room-list
-     * cache fills in placeholders + updates live rooms in the background, so a
-     * periodic quiet refresh keeps the list current without user action).
-     *
-     * Revision gate (2026-09-01, the Beeper comparison): the poll first asks
-     * the list's cheap revision and only fetches the full (400-room) payload
-     * when it moved — an idle list costs one tiny binder read every 5 s, not
-     * the whole [GetRooms] transfer. The connection state still refreshes each
-     * tick so the offline banner stays live.
+     * Live list + connection updates while the screen is visible. The
+     * repository's flows drive them directly (NO-SEAM, 2026-09-07 — the
+     * revision long-poll over the binder is gone): a room-list publish
+     * refetches the list (the [refresh] fetch shape is unchanged), a
+     * connection-state change refreshes the offline banner.
      */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
-            // Seed with the revision the show-time refresh reflected, so the
-            // first poll skips a list that hasn't moved since. The wait holds
-            // the binder call until the revision moves or the window elapses
-            // (2026-09-06: replaced the fixed 2 s tick — a change lands within
-            // milliseconds; an idle list costs one held call per window).
-            var lastRevision = ChatClient.roomListRevision()
-            while (true) {
-                val revision = ChatClient.waitForRoomListChange(lastRevision)
-                if (revision > 0 && revision != lastRevision) {
-                    lastRevision = revision
-                    refresh(quiet = true)
-                } else {
-                    // Window elapsed unchanged — keep the banner live with the
-                    // tiny connection read instead of the full payload.
-                    ChatClient.connectionState()?.let { connection.value = it }
+            var seeded = false
+            launch {
+                MatrixRepository.roomList.collect {
+                    // The collection-start snapshot is skipped: the show-time
+                    // refresh() (with its cold-start retries) owns the first
+                    // fetch; every publish after it refetches quietly.
+                    if (seeded) refresh(quiet = true) else seeded = true
+                }
+            }
+            launch {
+                MatrixRepository.connectionState.collect {
+                    connection.value = MatrixRepository.connectionState()
                 }
             }
         }

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -67,9 +67,6 @@ import kotlinx.coroutines.launch
 /** Grow the list slice when the last visible row is within this many of the end. */
 private const val REVEAL_THRESHOLD = 4
 
-/** Live flag poll for the long-press contact panel (same cadence as the thread). */
-private const val PANEL_FLAG_SYNC_MS = 3_000L
-
 /** Shown while the initial sync pulls the whole account (can take minutes). */
 private const val DOWNLOADING_TEXT = "Downloading your chat history…"
 
@@ -124,8 +121,9 @@ class ChatListViewModel : LightViewModel<Unit>() {
     /**
      * Contact-panel state for the long-press entry (2026-08-29): long-pressing
      * a room row opens the same contact panel as the thread's name, seeded from
-     * the row's flags and polled while the panel is open so a Beeper-side
-     * toggle reaches it live (same pattern as ThreadViewModel's flag sync).
+     * the row's flags and refreshed from the companion's flags revision while
+     * the panel is open, so a Beeper-side toggle reaches it live (same pattern
+     * as ThreadViewModel's flag sync).
      */
     val panelMuted = MutableStateFlow(false)
     val panelPinned = MutableStateFlow(false)
@@ -133,10 +131,10 @@ class ChatListViewModel : LightViewModel<Unit>() {
     private var panelRoomId: String? = null
     private var panelFlagSyncJob: Job? = null
 
-    /** Seeds the panel from the row and starts the live flag poll. */
+    /** Seeds the panel from the row and starts the live flag wait. */
     fun openContactPanel(room: LightServiceMethod.GetRooms.Room) {
-        // Kill any poll leaked by an earlier panel before starting this one:
-        // startPanelFlagSync's guard would otherwise keep polling the FIRST
+        // Kill any waiter leaked by an earlier panel before starting this one:
+        // startPanelFlagSync's guard would otherwise keep watching the FIRST
         // panel's room and clobber this panel's flags with them (2026-08-29:
         // archive toggles flipped back to ARCHIVE after 3 s for exactly that).
         panelFlagSyncJob?.cancel()
@@ -148,7 +146,7 @@ class ChatListViewModel : LightViewModel<Unit>() {
         startPanelFlagSync(room.id)
     }
 
-    /** Stops the poll when the panel is dismissed (X pops back to the list). */
+    /** Stops the wait when the panel is dismissed (X pops back to the list). */
     fun closeContactPanel() {
         panelFlagSyncJob?.cancel()
         panelFlagSyncJob = null
@@ -158,8 +156,11 @@ class ChatListViewModel : LightViewModel<Unit>() {
     private fun startPanelFlagSync(roomId: String) {
         if (panelFlagSyncJob?.isActive == true) return
         panelFlagSyncJob = viewModelScope.launch {
+            var lastFlags = 0L
             while (true) {
-                delay(PANEL_FLAG_SYNC_MS)
+                val revision = ChatClient.waitForFlagChange(lastFlags)
+                if (revision == lastFlags) continue
+                lastFlags = revision
                 val flags = ChatClient.getRoomFlags(roomId) ?: continue
                 panelMuted.value = flags.muted
                 panelPinned.value = flags.pinned

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -120,7 +120,7 @@ class ChatListViewModel : LightViewModel<Unit>() {
     val networkFilter = MutableStateFlow<String?>(null)
 
     /**
-     * Contact-panel state for the long-press entry (2026-08-29): long-pressing
+     * Contact-panel state for the long-press entry: long-pressing
      * a room row opens the same contact panel as the thread's name, seeded from
      * the row's flags (the repository's fresher roomFlags value wins) and kept
      * live by the roomFlags flow collector while the panel is open, so a
@@ -198,19 +198,14 @@ class ChatListViewModel : LightViewModel<Unit>() {
 
     /**
      * Room-list scroll position, persisted across navigation so a thread exit
-     * returns the list to where it was instead of the top (feedback 2026-08-19:
-     * "select a room half way down the list, enter, exit — return half way
-     * down"). The screen saves it continuously and the list re-creates its
-     * LazyListState seeded from it on show (feedback 2026-08-20: the old
-     * scroll-after-compose restore flashed the top of the list first).
+     * returns the list to where it was instead of the top. The screen saves it continuously and the list re-creates its
+     * LazyListState seeded from it on show.
      */
     var savedScrollIndex = 0
     var savedScrollOffset = 0
 
     /**
-     * One POST_NOTIFICATIONS runtime request per process run (audit
-     * 2026-08-23: the server's message notifications never showed — the
-     * permission was never requested, importance=NONE). The request itself
+     * One POST_NOTIFICATIONS runtime request per process run. The request itself
      * goes through the SDK flow (ChatsPermissionActivity in the server).
      */
     var notificationPermissionRequested = false
@@ -248,7 +243,7 @@ class ChatListViewModel : LightViewModel<Unit>() {
 
     /**
      * Live list + connection updates while the screen is visible. The
-     * repository's flows drive them directly (NO-SEAM, 2026-09-07 — the
+     * repository's flows drive them directly (NO-SEAM — the
      * revision long-poll over the binder is gone): a room-list publish
      * refetches the list (the [refresh] fetch shape is unchanged), a
      * connection-state change refreshes the offline banner.
@@ -400,9 +395,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
 
     @Composable
     override fun Content() {
-        // Runtime permission for the server's message notifications (audit
-        // 2026-08-23: POST_NOTIFICATIONS was never requested → importance=NONE
-        // → ChatNotifier silently no-oped every message). The SDK flow routes
+        // Runtime permission for the server's message notifications. The SDK flow routes
         // the request through the server's ChatsPermissionActivity (AOSP
         // dialog). One request per process run.
         val permissionLauncher = rememberPermissionRequestLauncher(Manifest.permission.POST_NOTIFICATIONS)
@@ -424,9 +417,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
         val permissionComponent by viewModel.notificationPermissionComponent.collectAsState()
         val networkFilter by viewModel.networkFilter.collectAsState()
         val themeColors by LightThemeController.colors.collectAsState()
-        // The saved position seeds the list state directly (feedback
-        // 2026-08-20: restoring with a post-compose scroll flashed the top of
-        // the list for a frame). The ViewModel keeps the position across
+        // The saved position seeds the list state directly. The ViewModel keeps the position across
         // navigation (the composition is disposed on navigate), so a fresh
         // composition picks it up with no flash.
         val listState = rememberLazyListState(
@@ -434,10 +425,9 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
             initialFirstVisibleItemScrollOffset = viewModel.savedScrollOffset,
         )
 
-        // Phase 7 filters: the network selector narrows the list; the full
-        // room set stays in the ViewModel. (The unread toggle moved to the
-        // Search screen, feedback 2026-08-21.) Archived rooms hide unless
-        // pinned (pinned wins, 2026-08-28); pinned rooms sort to the top —
+        // Filters: the network selector narrows the list; the full
+        // room set stays in the ViewModel. Archived rooms hide unless
+        // pinned (pinned wins); pinned rooms sort to the top —
         // stable, so server recency holds within the pinned group.
         val filteredRooms = remember(rooms, networkFilter) {
             rooms.filter { room ->
@@ -481,13 +471,12 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
             }
         }
 
-        // Feedback pass: switching the filter (network selection) returns the
+        // Switching the filter (network selection) returns the
         // list to the top — the user expects the newest conversations, not a
         // stale scroll position from the previous filter. Guarded so it fires
         // only on an actual filter CHANGE: the screen fully re-composes on
         // every thread return, and an ungated effect would yank the list to
-        // the top each time (feedback 2026-08-23: "exit a thread — bounce
-        // back to the top of the room list"). The guard remembers the filter
+        // the top each time. The guard remembers the filter
         // that last triggered the reset; a fresh composition re-initializes
         // it to the current filter, so a plain return is a no-op.
         var filterAtLastReset by remember { mutableStateOf(networkFilter) }
@@ -510,12 +499,11 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
             }
         }
 
-        // Feedback pass: a new-message bump reorders the list; when the user
+        // A new-message bump reorders the list; when the user
         // was at (or within a row of) the top, keep the newest conversation
         // pinned at index 0 — LazyColumn anchors by key, so the room that slid
         // down stays in view and the bumped room hides just above the
-        // viewport without this (feedback 2026-08-17: "the room bumps to the
-        // top, but the panel requires scrolling up to see it").
+        // viewport without this.
         LaunchedEffect(filteredRooms.firstOrNull()?.id) {
             if (listState.firstVisibleItemIndex <= 1) {
                 listState.requestScrollToItem(0)
@@ -539,12 +527,12 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
                         .fillMaxSize()
                         .background(LightThemeTokens.colors.background),
                 ) {
-                // Feedback pass: with a network filter active the list gets a
+                // With a network filter active the list gets a
                 // context top bar naming the network ("WhatsApp"); on "All"
                 // it stays a bare list home (the 2-gu bar). A filtered list is
                 // a standard top-bar screen — the top bar REPLACES the 2-gu
-                // bar, so the header height matches every other titled screen
-                // (feedback 2026-08-19). The null left/right slots render as
+                // bar, so the header height matches every other titled screen.
+                // The null left/right slots render as
                 // spacers, so the title stays centered.
                 val activeAccount = networkFilter
                 if (activeAccount != null) {
@@ -620,7 +608,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
                             onClick = { openContacts() },
                             contentDescription = "Contacts",
                         ),
-                        // Feedback pass: the network filter lives behind the
+                        // The network filter lives behind the
                         // bottom-right menu (3-dash) which opens the Networks
                         // panel; the active network shows in the context top bar.
                         LightBarButton.LightIcon(
@@ -646,7 +634,7 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
     }
 
     /**
-     * The contact overlay from the room list (2026-08-29): long-pressing a row
+     * The contact overlay from the room list: long-pressing a row
      * opens the same contact panel as the thread's top-bar name, seeded from
      * the row's flags and polling the companion while open; the X pops back to
      * the list.
@@ -673,10 +661,10 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
     }
 
     private fun openContacts() {
-        // The starting point carries in (2026-08-30): opened from All the
+        // The starting point carries in: opened from All the
         // panel shows every contact; from a filtered list only that network's.
         // The list's current census seeds the panel's first frame — no empty
-        // flash while the first GetRooms round-trips (feedback 2026-09-01).
+        // flash while the first GetRooms round-trips.
         navigateTo(
             screenFactory = { ContactsScreen(it, viewModel.networkFilter.value, viewModel.rooms.value) },
         )
@@ -700,8 +688,8 @@ private fun RoomRow(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            // Long-press opens the contact panel (2026-08-29). Trigger-only
-            // haptics (LP3 feedback 2026-09-03): the buzz fires when the
+            // Long-press opens the contact panel. Trigger-only
+            // haptics: the buzz fires when the
             // gesture actually completes — on a genuine tap into the room
             // (finger-up inside the row; a scroll drag never reaches onTap)
             // and when the long-press opens the panel — never on finger-down,
@@ -722,14 +710,12 @@ private fun RoomRow(
                     },
                 )
             }
-            // Left matches the Phone tool's recents rows (LP3-verified
-            // 2026-08-21): 0.5-gu margin, then the unread star's 1-gu slot.
+            // Left matches the Phone tool's recents rows: 0.5-gu margin, then the unread star's 1-gu slot.
             // The room name lands at 2.75 gu — flush with the bottom-left
             // bottom-bar icon's left edge (the SDK centers the 2-gu icon in
             // a 3.5-gu touch box, so the icon sits at 2 + 0.75 gu). The
             // right leaves the time clear of the scrollbar. 12dp vertical
-            // padding fits exactly 6 rows on the panel (LP3 480dpi, user
-            // 2026-08-29 — 17dp fit only 5 on the real device).
+            // padding fits exactly 6 rows on the panel.
             .padding(start = 0.5f.gridUnitsAsDp(), end = 0.5f.gridUnitsAsDp(), top = 12.dp, bottom = 12.dp),
     ) {
         Row(
@@ -741,10 +727,7 @@ private fun RoomRow(
             // The unread marker is a large asterisk in the row's leading
             // buffer: 0.5-gu margin, the star's 1-gu slot, then a 0.25-gu gap
             // to the room name at 1.75 gu — the asterisk lands visually
-            // centered between the left edge and the name (feedback
-            // 2026-08-23: the original 1.25-gu gap left the space after the
-            // asterisk dwarfing the space before it; the name moved left to
-            // balance it). The slot stays even without a star so names never
+            // centered between the left edge and the name. The slot stays even without a star so names never
             // shift.
             Box(modifier = Modifier.width(1f.gridUnitsAsDp())) {
                 if (room.unreadCount > 0) {
@@ -768,11 +751,9 @@ private fun RoomRow(
                 )
             }
             // The latest-message time sits at the row's right, on the name
-            // line like the built-in list, with the short hand format
-            // (feedback 2026-08-17: back on the right after the under-name
-            // Detail date; the unread count was removed at the same time).
-            // Solid white, same as everything else (feedback 2026-08-21).
-            // Pinned rows drop the latest-message time (user, 2026-08-28).
+            // line like the built-in list, with the short hand format.
+            // Solid white, same as everything else.
+            // Pinned rows drop the latest-message time.
             if (!room.pinned) {
                 LightText(
                     text = formatRelativeTimestamp(room.lastTimestampMs),
@@ -796,9 +777,9 @@ private fun OfflineBanner(text: String) {
 
 @Composable
 private fun StatusText(text: String) {
-    // Centered like the LP3's own loading state (LP3 feedback 2026-09-03):
+    // Centered like the LP3's own loading state:
     // the "Loading…" used to sit top-left. Bottom padding biases the center
-    // slightly upward — optical centering (feedback 2026-09-06).
+    // slightly upward — optical centering.
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -417,10 +417,15 @@ class ChatListScreen(sealedActivity: SealedLightActivity) :
         // room set stays in the ViewModel. Archived rooms hide unless
         // pinned (pinned wins); pinned rooms sort to the top —
         // stable, so server recency holds within the pinned group.
+        // Rooms with no stampable message (ts 0: bridge integration
+        // rooms, notice/state-only rooms the resolver parked) hide
+        // like Beeper's inbox — they carry no chat content, only
+        // Contacts/Search still list them.
         val filteredRooms = remember(rooms, networkFilter) {
             rooms.filter { room ->
                 (networkFilter == null || room.network == networkFilter) &&
-                    !(room.archived && !room.pinned) // archived hidden unless pinned wins
+                    !(room.archived && !room.pinned) && // archived hidden unless pinned wins
+                    !(!room.pinned && room.lastTimestampMs == 0L)
             }.sortedByDescending { it.pinned } // stable — server recency holds within groups
         }
         // Network labels for the Networks panel, from the rooms the companion

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ChatListScreen.kt
@@ -163,23 +163,14 @@ class ChatListViewModel : LightViewModel<Unit>() {
         panelRoomId = null
     }
 
-    fun togglePanelMuted() {
-        val next = !panelMuted.value
-        panelMuted.value = next
-        panelRoomId?.let { viewModelScope.launch { ChatClient.setRoomMuted(it, next) } }
-    }
+    fun togglePanelMuted() =
+        viewModelScope.toggleAndPersist(panelMuted, { panelRoomId }, ChatClient::setRoomMuted)
 
-    fun togglePanelPinned() {
-        val next = !panelPinned.value
-        panelPinned.value = next
-        panelRoomId?.let { viewModelScope.launch { ChatClient.setRoomPinned(it, next) } }
-    }
+    fun togglePanelPinned() =
+        viewModelScope.toggleAndPersist(panelPinned, { panelRoomId }, ChatClient::setRoomPinned)
 
-    fun togglePanelArchived() {
-        val next = !panelArchived.value
-        panelArchived.value = next
-        panelRoomId?.let { viewModelScope.launch { ChatClient.setRoomArchived(it, next) } }
-    }
+    fun togglePanelArchived() =
+        viewModelScope.toggleAndPersist(panelArchived, { panelRoomId }, ChatClient::setRoomArchived)
 
     /**
      * One-shot launch request for the companion's POST_NOTIFICATIONS

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ComposerScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ComposerScreen.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Unsent composer drafts, keyed by room id (feedback 2026-08-22): leaving the
+ * Unsent composer drafts, keyed by room id: leaving the
  * composer mid-draft restores the text on return — thread → list → thread —
  * until it's sent or cleared. Process-scoped; a restart starts empty.
  */
@@ -55,7 +55,7 @@ data class ComposerResult(
 
 class ComposerViewModel(
     private val roomId: String,
-    /** When set (Phase C, 2026-09-03), the composer EDITS this message:
+    /** When set, the composer EDITS this message:
      *  SEND routes to [ChatClient.editMessage] and pops back with the edit
      *  result instead of sending a new message. */
     private val editTarget: LightServiceMethod.GetMessages.Message? = null,
@@ -120,7 +120,7 @@ class ComposerViewModel(
             } finally {
                 // A failed/exception RPC must not leave the busy flag set —
                 // every later press would silently return and Send would look
-                // dead (feedback 2026-08-17: "send needs multiple presses").
+                // dead.
                 ChatClient.setTyping(roomId, false)
                 busy.value = false
             }
@@ -148,17 +148,16 @@ class ComposerScreen(
         // The LP3 keyboard's mic key is handled inside the closed light-keyboard
         // library (it needs a speech-recognition service, which LightOS doesn't
         // ship) — it does nothing here. Voice notes have their own button on
-        // the thread (Phase 14), so hide the dead key instead of showing a
-        // control that can't act. The return key stays (feedback 2026-08-20:
-        // it was removed at the send-round, then the user wanted it back) —
+        // the thread, so hide the dead key instead of showing a
+        // control that can't act. The return key stays —
         // it inserts a newline rather than sending (submitOnReturn = false):
         // messages may span lines, and SEND lives in the top bar.
         val keyboardOptionsFlow = remember {
             MutableStateFlow(defaultKeyboardOptions().copy(displayVoice = false, displayReturn = true))
         }
-        // Restore the room's unsent draft (feedback 2026-08-22); the composer
+        // Restore the room's unsent draft; the composer
         // saves every change back to [composerDrafts] so leaving mid-draft
-        // keeps the text until it's sent or cleared. An edit (Phase C)
+        // keeps the text until it's sent or cleared. An edit
         // prefills the row's body instead and never touches the draft — a
         // cancelled edit must not leak into the next normal composer.
         val textState = rememberTextFieldState(editTarget?.body ?: composerDrafts[roomId] ?: "")
@@ -183,12 +182,10 @@ class ComposerScreen(
                     submitIcon = LightIcons.SEND,
                     // Notes-style entry (feedback pass): small wrapping text
                     // anchored at the bottom, growing upward, keyboard flush at
-                    // the bottom; the return key makes newlines, not sends
-                    // (feedback 2026-08-20). Send lives in the top-right bar.
+                    // the bottom; the return key makes newlines, not sends.
+                    // Send lives in the top-right bar.
                     // The keyboard opens in caps mode — a new message starts
-                    // with a capital letter like the native composer
-                    // (feedback 2026-08-20: "compose … ensure the keyboard is
-                    // capitalised mode").
+                    // with a capital letter like the native composer.
                     singleLine = false,
                     submitOnReturn = false,
                     bottomAligned = true,
@@ -198,8 +195,7 @@ class ComposerScreen(
                 )
                 // Quiet failure line (same grammar as the thread's row error):
                 // a rejected send/edit shows here instead of reading as an
-                // eternal "sending" (LP3 2026-09-04: the 403'd edit stalled
-                // silently). Cleared on the next send attempt.
+                // eternal "sending". Cleared on the next send attempt.
                 viewModel.error.collectAsState().value?.let { message ->
                     LightText(
                         text = message,
@@ -210,19 +206,11 @@ class ComposerScreen(
                             .padding(start = 1f.gridUnitsAsDp(), bottom = 1f.gridUnitsAsDp()),
                     )
                 }
-                // Clear-draft X, bottom-right corner of the screen (feedback
-                // 2026-08-21: the old 218 dp-above-keyboard position overlapped
-                // the draft's last line; the first bottom-right attempt
-                // overlapped the keyboard's bottom row). The composer keyboard
+                // Clear-draft X, bottom-right corner of the screen. The composer keyboard
                 // (submitInTopBar) reserves the 5-gu bottom-bar row below the
                 // keys, so the X sits in that row at the far right, vertically
-                // centered like a native bottom-bar icon (LP3-verified
-                // 2026-08-22: the doubled 1-gu outer + 1-gu inner padding put
-                // the icon 2 gu off the bottom, leaving a big buffer under it;
-                // the inner padding is horizontal-only now, so the icon lands
-                // at y 1120-1200 — the native bar-icon band). Always visible
-                // while the composer is open (feedback 2026-08-21: the X was
-                // gated on text, so it appeared only after typing); with an
+                // centered like a native bottom-bar icon. Always visible
+                // while the composer is open; with an
                 // empty draft it's a harmless no-op.
                 Box(
                     modifier = Modifier

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContactScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContactScreen.kt
@@ -31,19 +31,18 @@ import com.thelightphone.sdk.ui.lightClickable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 /**
- * The contact overlay (feedback 2026-08-21): tapping the thread's top-bar
+ * The contact overlay: tapping the thread's top-bar
  * room name opens a minimal contact page — Name, the other party's
- * identifier (same size as the name, second line; 2026-09-01), and the
+ * identifier (same size as the name, second line), and the
  * network underneath as the small subtext (WhatsApp / Instagram). No top
  * bar; the bottom bar carries only an X in the middle to dismiss. The
  * identity block sits near the screen's vertical center; the PIN / MUTE /
  * ARCHIVE toggles sit centred between the network tag and the bottom bar's
- * X (LP3 feedback 2026-08-28 + 2026-09-03).
- *
+ * X.
  * Data source: the identifier is the contact's real number/username,
  * resolved by the companion from the bridge's contact API when the room
- * data doesn't carry it (WhatsApp LID heroes, Instagram usernames —
- * 2026-09-01); the room-data localpart heuristic is the fallback. The user
+ * data doesn't carry it (WhatsApp LID heroes, Instagram usernames);
+ * the room-data localpart heuristic is the fallback. The user
  * offered the LP3's phone contact panel as a design reference; revisit the
  * layout when it's shared.
  */
@@ -55,8 +54,7 @@ class ContactScreen(
     /**
      * For rooms inside a bridged community (WhatsApp community groups): the
      * community's own name. Renders as the second Heading line when the room
-     * has no identifier — the group fills the slot the id occupies for 1:1s
-     * (feedback 2026-09-01).
+     * has no identifier — the group fills the slot the id occupies for 1:1s.
      */
     private val community: String? = null,
     private val identifier: String?,
@@ -70,16 +68,16 @@ class ContactScreen(
      */
     private val phone: String? = null,
     /**
-     * Mute state (2026-08-23): the MUTE button under the network line reads
+     * Mute state: the MUTE button under the network line reads
      * MUTE / UNMUTE; muting stops notifications for the room while the unread
      * badge stays. A StateFlow — the thread keeps it in sync with other
-     * devices while the panel is open (LP3 feedback 2026-08-28).
+     * devices while the panel is open.
      */
     private val muted: StateFlow<Boolean> = MutableStateFlow(false),
     /** Flips the room's mute server-side; the panel mirrors the new state locally. */
     private val onToggleMute: () -> Unit = {},
     /**
-     * Pin state (2026-08-28): the PIN button reads PIN / UNPIN; pinned chats
+     * Pin state: the PIN button reads PIN / UNPIN; pinned chats
      * sort to the top of the room list and their rows drop the latest
      * timestamp. StateFlow like [muted].
      */
@@ -87,7 +85,7 @@ class ContactScreen(
     /** Flips the room's pin server-side (m.favourite tag); the panel mirrors locally. */
     private val onTogglePin: () -> Unit = {},
     /**
-     * Archive state (2026-08-28): the ARCHIVE button reads ARCHIVE /
+     * Archive state: the ARCHIVE button reads ARCHIVE /
      * UNARCHIVE; archived rooms hide from the main list and go silent,
      * reachable only via search VIEW ALL. StateFlow like [muted].
      */
@@ -124,11 +122,8 @@ class ContactScreen(
                     .background(LightThemeTokens.colors.background),
             ) {
                 // Identity block, then the toggles, with three weighted
-                // spacers setting the gaps independently (LP3 feedback
-                // 2026-09-03: the weight-split layout coupled them — moving
-                // the name down pushed the buttons down with it). 21 : 3 : 8
-                // (measured on the 1080x1240 @ 480 grid): both old gaps
-                // halved — name→UNPIN ~86px, ARCHIVE→X ~239px — and the name
+                // spacers setting the gaps independently. 21: 3: 8
+                // (measured on the 1080x1240 @ 480 grid), keeping the name
                 // block centering near the screen's vertical middle.
                 Spacer(modifier = Modifier.weight(21f))
                 Column(
@@ -144,12 +139,9 @@ class ContactScreen(
                         )
                         // The id (number/username) as the second line, the same
                         // size as the name; the network tag stays small
-                        // underneath (feedback 2026-09-01: the id came back off
-                        // the network line onto its own Heading line, the
-                        // network stays the Detail subtext). Groups with no id
+                        // underneath. Groups with no id
                         // show the community name in this slot — except the
-                        // community's own room, where the community IS the name
-                        // (LP3 2026-09-01).
+                        // community's own room, where the community IS the name.
                         (identifier ?: phone ?: community?.takeUnless {
                             it.equals(name, ignoreCase = true)
                         })?.takeIf { it.isNotBlank() }?.let {
@@ -167,8 +159,7 @@ class ContactScreen(
                                 text = it,
                                 variant = LightTextVariant.Detail,
                                 // Solid white — the network line reads like the
-                                // name above it, not dimmed (feedback
-                                // 2026-08-27).
+                                // name above it, not dimmed.
                                 align = TextAlign.Center,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
@@ -178,9 +169,8 @@ class ContactScreen(
                     }
                 // Gap: name block → buttons. Equal to the gap below the
                 // buttons, so the toggle block sits centred between the
-                // {network} tag and the X (LP3 feedback 2026-09-03). 21 : 5.5
-                // : 5.5 keeps the same total and the same name-block position
-                // the 2026-09-03 tuning set (21/32 of the free space).
+                // {network} tag and the X. 21: 5.5
+                // (21/32 of the free space).
                 Spacer(modifier = Modifier.weight(5.5f))
                 // Toggle block (LP3 feedback 2026-08-28): three full-width
                 // buttons stacked with a tight 0.25gu gap.
@@ -202,7 +192,7 @@ class ContactScreen(
                             icon = LightIcons.CLOSE,
                             // Pop with a Unit result so the caller's navigateTo
                             // callback fires — the room list's panel stops its
-                            // flag poll on dismissal (ThreadScreen pattern, 2026-08-29).
+                            // flag poll on dismissal (ThreadScreen pattern).
                             onClick = { goBack(Unit) },
                             contentDescription = "Close contact",
                         ),

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.viewModelScope
 import com.lightphone.chats.ChatClient
 import com.lightphone.chats.contactIdentifier
 import com.lightphone.chats.roomMatchesQuery
-import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
@@ -100,18 +99,10 @@ class ContactsViewModel(
 
     /** The live census (NO-SEAM — the revision-wait poll is
      *  gone): the repository's roomList flow fills and keeps the panel
-     *  current while it is open. The trimmed row shape matches the old
-     *  GetAllRooms reply; an empty census never wipes the first frame's
-     *  seed (or an already-loaded list) during a cold start. */
+     *  current while it is open (see [collectRoomCensus]). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
-        pollJob = viewModelScope.launch {
-            MatrixRepository.roomList.collect { census ->
-                census.map { it.copy(lastMessage = "", unreadCount = 0, lastEventId = null) }
-                    .takeIf { it.isNotEmpty() || rooms.value.isEmpty() }
-                    ?.let { rooms.value = it }
-            }
-        }
+        pollJob = collectRoomCensus(viewModelScope, rooms)
     }
 
     private fun stopPolling() {

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
@@ -45,29 +45,29 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Contacts (2026-08-29): the main list's bottom-middle CONTACTS icon opens
+ * Contacts: the main list's bottom-middle CONTACTS icon opens
  * this — every chat, alphabetically, under Direct/Group tabs styled like the
  * Radio tool's Stations panel (Favourites/Recent). Direct is the default tab:
  * it dedupes by contact id (a person with several threads appears once, as
  * their newest room); Group lists every non-direct room. Archived rooms
  * appear in whichever tab their direct/group flag lands them in. The panel
- * is seeded from the chat list's active network filter (2026-08-30): opened
+ * is seeded from the chat list's active network filter: opened
  * from All it shows every contact (title "All Contacts", network name as each
  * row's subtext — trial feature); opened from WhatsApp only that network's
  * rooms (title "WhatsApp Contacts", no subtext). SEARCH top-right filters the ACTIVE
  * tab's list (an in-panel query, not the room search): the editor title is
  * "Search All Contacts"/"Search {Network} Contacts" with the SEARCH icon, and the panel
- * title shows the searched term in quotes while a query is active
- * (feedback 2026-09-01). Tapping a row
+ * title shows the searched term in quotes while a query is active.
+ * Tapping a row
  * opens that thread; back from the thread pops the contacts list too,
- * landing on the main list (the SearchScreen pattern, feedback 2026-08-22).
+ * landing on the main list (the SearchScreen pattern).
  */
 class ContactsViewModel(
     /** The chat list's active network filter (null = all networks). */
     private val network: String? = null,
     /** The census the panel was opened from — seeds the first frame so the
      *  panel renders instantly instead of flashing the empty state while the
-     *  first GetRooms round-trips (feedback 2026-09-01). */
+     *  first GetRooms round-trips. */
     seedRooms: List<LightServiceMethod.GetRooms.Room> = emptyList(),
 ) : LightViewModel<Unit>() {
 
@@ -98,7 +98,7 @@ class ContactsViewModel(
         stopPolling()
     }
 
-    /** The live census (NO-SEAM, 2026-09-07 — the revision-wait poll is
+    /** The live census (NO-SEAM — the revision-wait poll is
      *  gone): the repository's roomList flow fills and keeps the panel
      *  current while it is open. The trimmed row shape matches the old
      *  GetAllRooms reply; an empty census never wipes the first frame's
@@ -123,7 +123,7 @@ class ContactsViewModel(
      *  (the first room of each group is the newest for that person); GROUP
      *  lists every non-direct room. A non-blank query keeps only matching
      *  names. The network filter (null = all) applies first, so contacts
-     *  opened from WhatsApp show only WhatsApp rooms (2026-08-30). [rooms],
+     *  opened from WhatsApp show only WhatsApp rooms. [rooms],
      *  [tab] and [query] are passed in from the screen's collected state —
      *  reading the flows' .value directly never recomposes when they change. */
     fun entries(
@@ -159,7 +159,7 @@ class ContactsScreen(
     sealedActivity: SealedLightActivity,
     /** The chat list's active network filter (null = all networks) — the
      *  starting point matters: opened from All the panel lists every contact,
-     *  from WhatsApp only WhatsApp rooms (2026-08-30). */
+     *  from WhatsApp only WhatsApp rooms. */
     private val network: String? = null,
     /** The census the panel was opened from — seeds the first frame (see
      *  [ContactsViewModel]). */
@@ -191,11 +191,10 @@ class ContactsScreen(
                         onClick = { goBack() },
                         contentDescription = "Back to chats",
                     ),
-                    // Title grammar (2026-08-30): the active search shows the
-                    // searched term in quotes (feedback 2026-09-01); otherwise
+                    // Title grammar: the active search shows the
+                    // searched term in quotes; otherwise
                     // the network the panel was opened from ("WhatsApp
-                    // Contacts"), or "All Contacts" from All (feedback
-                    // 2026-09-01).
+                    // Contacts"), or "All Contacts" from All.
                     center = LightTopBarCenter.Text(
                         when {
                             query.isNotBlank() -> "'$query'"
@@ -240,9 +239,7 @@ class ContactsScreen(
                             items(entries, key = { it.key }) { contact ->
                                 // The community's own room (announcement room)
                                 // is named after the community — showing the
-                                // community subtag there repeats the name
-                                // (LP3 2026-09-01: "BERLIN SCENE LAB" read
-                                // "WhatsApp · BERLIN SCENE LAB").
+                                // community subtag there repeats the name.
                                 val community = contact.room.community?.takeUnless {
                                     it.equals(contact.room.name, ignoreCase = true)
                                 }
@@ -258,14 +255,13 @@ class ContactsScreen(
                                     ).takeIf { !it.isNullOrBlank() }
                                 ContactRow(
                                     contact = contact,
-                                    // Subtext grammar (2026-09-01): from All the
+                                    // Subtext grammar: from All the
                                     // row reads "{Network} · {id}" (network alone
                                     // when the id hasn't resolved yet); inside a
                                     // network's own panel just the id — the
                                     // network would repeat. Groups with no id
                                     // show their community name in the id slot
-                                    // (WhatsApp community groups, feedback
-                                    // 2026-09-01).
+                                    // (WhatsApp community groups).
                                     subtext = subtext,
                                     onOpen = { openThread(contact) },
                                 )
@@ -287,8 +283,8 @@ class ContactsScreen(
         // The query editor reuses the account screen's field editor: LP3
         // keyboard, no emoji/return/voice, SEARCH submits. Empty clears the
         // filter; backing out without submitting keeps the previous query.
-        // Title grammar (2026-08-30): "Search All Contacts" from All, "Search
-        // {Network} Contacts" inside a network (feedback 2026-09-01); the
+        // Title grammar: "Search All Contacts" from All, "Search
+        // {Network} Contacts" inside a network; the
         // SEARCH button is now the search icon.
         navigateTo(
             screenFactory = {
@@ -361,12 +357,11 @@ private fun identifierOf(contact: ContactsViewModel.Contact): String? =
     contactIdentifier(contact.room.contactId, contact.room.name, contact.room.contactPhone)
 
 /** A contact row: the name, Heading, with the id — and the network when the
- *  panel was opened from All — as a light subtext line (2026-08-30 trial,
- *  extended 2026-09-01: the id joined the network in the subtext). The
+ *  panel was opened from All — as a light subtext line. The
  *  leading inset (1.75 gu) sits the name where the room list's names land —
  *  the contacts rows have no unread-star column, so the 2.75-gu padding the
  *  search rows need to align with the starred list would float the names
- *  clear of the edge (feedback 2026-09-01: too much buffer). */
+ *  clear of the edge. */
 @Composable
 private fun ContactRow(
     contact: ContactsViewModel.Contact,
@@ -391,9 +386,7 @@ private fun ContactRow(
             overflow = TextOverflow.Ellipsis,
         )
         if (subtext != null) {
-            // The id/network line, Superfine — smaller than the room name
-            // (feedback 2026-08-30: subtext was too big; 2026-09-01: Detail
-            // still too big).
+            // The id/network line, Superfine — smaller than the room name.
             LightText(
                 text = subtext,
                 variant = LightTextVariant.Superfine,

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
@@ -40,7 +40,6 @@ import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import com.thelightphone.sdk.ui.lightClickable
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -101,12 +100,16 @@ class ContactsViewModel(
 
     /** Re-fetches the census while the panel stays open (a cold process can
      *  answer the first call with an empty list while the companion's
-     *  resolver seeds — the poll fills the panel in, same as the main list). */
+     *  resolver seeds — the first publish bumps the room-list revision, which
+     *  wakes this wait and fills the panel in, same as the main list). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
+            var lastRevision = 0L
             while (true) {
-                delay(POLL_INTERVAL_MS)
+                val revision = ChatClient.waitForRoomListChange(lastRevision)
+                if (revision == lastRevision) continue
+                lastRevision = revision
                 refreshRooms()
             }
         }
@@ -154,10 +157,7 @@ class ContactsViewModel(
             }
     }
 
-    private companion object {
-        /** Panel refresh cadence — matches the main list's poll. */
-        const val POLL_INTERVAL_MS = 5_000L
-    }
+    private companion object
 }
 
 class ContactsScreen(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContactsScreen.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewModelScope
 import com.lightphone.chats.ChatClient
 import com.lightphone.chats.contactIdentifier
 import com.lightphone.chats.roomMatchesQuery
+import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
@@ -89,7 +90,6 @@ class ContactsViewModel(
         super.onScreenShow(screen)
         // No thread is on screen here; let the companion notify again.
         viewModelScope.launch { ChatClient.setActiveRoom(null) }
-        refreshRooms()
         startPolling()
     }
 
@@ -98,19 +98,18 @@ class ContactsViewModel(
         stopPolling()
     }
 
-    /** Re-fetches the census while the panel stays open (a cold process can
-     *  answer the first call with an empty list while the companion's
-     *  resolver seeds — the first publish bumps the room-list revision, which
-     *  wakes this wait and fills the panel in, same as the main list). */
+    /** The live census (NO-SEAM, 2026-09-07 — the revision-wait poll is
+     *  gone): the repository's roomList flow fills and keeps the panel
+     *  current while it is open. The trimmed row shape matches the old
+     *  GetAllRooms reply; an empty census never wipes the first frame's
+     *  seed (or an already-loaded list) during a cold start. */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
-            var lastRevision = 0L
-            while (true) {
-                val revision = ChatClient.waitForRoomListChange(lastRevision)
-                if (revision == lastRevision) continue
-                lastRevision = revision
-                refreshRooms()
+            MatrixRepository.roomList.collect { census ->
+                census.map { it.copy(lastMessage = "", unreadCount = 0, lastEventId = null) }
+                    .takeIf { it.isNotEmpty() || rooms.value.isEmpty() }
+                    ?.let { rooms.value = it }
             }
         }
     }
@@ -118,10 +117,6 @@ class ContactsViewModel(
     private fun stopPolling() {
         pollJob?.cancel()
         pollJob = null
-    }
-
-    private fun refreshRooms() {
-        viewModelScope.launch { rooms.value = ChatClient.getAllRooms() }
     }
 
     /** The active tab's rows, alphabetically: DIRECT dedupes by contact id

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
@@ -60,18 +60,14 @@ private val REACTION_ROWS = listOf(
  * half of the screen for the long-pressed message — the Phone tool's overlay
  * panel presentation (measured from the LP3, 1080x1240 @ 480 dpi). Top level
  * stacks the action rows; REACT / EDIT REACTION open the 3x8 emoji grid; a
- * tap sets that reaction. Every completing action dismisses the panel —
- * except SAVE, whose dismissal waits for the confirmation (the caller clears
- * the target when the fullscreen confirm lands, so the panel never vanishes
- * before it). The
+ * tap sets that reaction. Every completing action dismisses the panel. The
  * wide thin chevron at the very bottom center dismisses (any level).
  * One own reaction at a time (replace semantics) on a RECEIVED message: no
  * own reaction shows LIKE + REACT; an existing one shows EDIT
  * REACTION + REMOVE REACTION. Own messages show
  * EDIT / UNSEND instead — each only when the row still allows it
  * ([LightServiceMethod.GetMessages.Message.canEdit] / `canUnsend`, the
- * bridge's capability gate). Image rows add SAVE
- * — the fullscreen viewer's save flow — on the received paths.
+ * bridge's capability gate).
  * Raw black/white + fixed sizes are deliberate: this replicates a system
  * overlay panel (see [com.lightphone.chats.VolumePanelOverlay]), not themed
  * app UI. The panel covers the bottom bar while open — the Phone tool's does
@@ -86,8 +82,6 @@ fun ContextWindowOverlay(
     onRemoveReaction: () -> Unit,
     onEdit: () -> Unit,
     onUnsend: () -> Unit,
-    /** Non-null on image rows: the SAVE row (the viewer's save flow). */
-    onSave: (() -> Unit)? = null,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -134,18 +128,10 @@ fun ContextWindowOverlay(
                     ownReaction == null -> buildList {
                         add("LIKE" to { onLike(); onDismiss() })
                         add("REACT" to { level = ContextLevel.Reactions })
-                        // Image rows carry SAVE. The
-                        // panel does NOT dismiss here — it stays up until the
-                        // save confirmation appears (the caller clears the
-                        // target then), so the confirm never chases a vanished
-                        // panel.
-                        onSave?.let { save -> add("SAVE" to { save() }) }
                     }
                     else -> buildList {
                         add("EDIT REACTION" to { level = ContextLevel.Reactions })
                         add("REMOVE REACTION" to { onRemoveReaction(); onDismiss() })
-                        // Same deferred dismissal as the no-reaction SAVE row.
-                        onSave?.let { save -> add("SAVE" to { save() }) }
                     }
                 }
                 Column(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
@@ -45,7 +45,7 @@ private enum class ContextLevel {
 
 /**
  * The reaction keys, in the LP3 emoji panel's exact layout (3 rows x 8,
- * captured from the Phone tool's emoji panel 2026-09-03): row 1 faces, row 2
+ * captured from the Phone tool's emoji panel): row 1 faces, row 2
  * hands, row 3 symbols. The string is the Matrix reaction key — it must stay
  * byte-identical everywhere (send + unsend + the served tag match).
  */
@@ -56,7 +56,7 @@ private val REACTION_ROWS = listOf(
 )
 
 /**
- * The context window (Phase B, 2026-09-03): a black panel over the bottom
+ * The context window: a black panel over the bottom
  * half of the screen for the long-pressed message — the Phone tool's overlay
  * panel presentation (measured from the LP3, 1080x1240 @ 480 dpi). Top level
  * stacks the action rows; REACT / EDIT REACTION open the 3x8 emoji grid; a
@@ -65,15 +65,13 @@ private val REACTION_ROWS = listOf(
  * the target when the fullscreen confirm lands, so the panel never vanishes
  * before it). The
  * wide thin chevron at the very bottom center dismisses (any level).
- *
  * One own reaction at a time (replace semantics) on a RECEIVED message: no
  * own reaction shows LIKE + REACT; an existing one shows EDIT
- * REACTION + REMOVE REACTION. Own messages (Phase C, 2026-09-03) show
+ * REACTION + REMOVE REACTION. Own messages show
  * EDIT / UNSEND instead — each only when the row still allows it
  * ([LightServiceMethod.GetMessages.Message.canEdit] / `canUnsend`, the
- * bridge's capability gate). Image rows (LP3 feedback 2026-09-03) add SAVE
+ * bridge's capability gate). Image rows add SAVE
  * — the fullscreen viewer's save flow — on the received paths.
- *
  * Raw black/white + fixed sizes are deliberate: this replicates a system
  * overlay panel (see [com.lightphone.chats.VolumePanelOverlay]), not themed
  * app UI. The panel covers the bottom bar while open — the Phone tool's does
@@ -106,7 +104,7 @@ fun ContextWindowOverlay(
             // dispatches pointer events to everything under the finger — a
             // background alone consumes nothing, so taps in the panel's empty
             // regions fell through to rows beneath (a voice-note play button
-            // under LIKE, LP3 feedback 2026-09-07). Swallow every event in
+            // under LIKE). Swallow every event in
             // the panel's area; the action rows and the chevron are children
             // and see each pass first, so they keep working.
             .pointerInput(Unit) {
@@ -121,7 +119,7 @@ fun ContextWindowOverlay(
             },
     ) {
         when (level) {
-            // LP3 feedback 2026-09-03: the action rows read like bottom-bar
+            // The action rows read like bottom-bar
             // text buttons — the [LightTextVariant.Button] label, centered in
             // the row, rows sharing the panel height (centered vertically),
             // instead of the left-aligned Heading list rows.
@@ -136,11 +134,11 @@ fun ContextWindowOverlay(
                     ownReaction == null -> buildList {
                         add("LIKE" to { onLike(); onDismiss() })
                         add("REACT" to { level = ContextLevel.Reactions })
-                        // Image rows carry SAVE (LP3 feedback 2026-09-03). The
+                        // Image rows carry SAVE. The
                         // panel does NOT dismiss here — it stays up until the
                         // save confirmation appears (the caller clears the
                         // target then), so the confirm never chases a vanished
-                        // panel (LP3 feedback 2026-09-03).
+                        // panel.
                         onSave?.let { save -> add("SAVE" to { save() }) }
                     }
                     else -> buildList {
@@ -157,8 +155,7 @@ fun ContextWindowOverlay(
                         // never sits under it.
                         .padding(bottom = ChevronZone),
                     // Bottom-bar-height rows, grouped at the panel's center —
-                    // full-height weight(1f) rows sat too far apart (LP3
-                    // feedback 2026-09-03).
+                    // full-height weight(1f) rows sat too far apart.
                     verticalArrangement = Arrangement.Center,
                 ) {
                     rows.forEach { (label, action) ->
@@ -227,6 +224,5 @@ private val EmojiCell = 46.dp
  *  2026-09-03) — one size down. */
 private val EmojiFontSize = 24.sp
 /** The chevron's tap zone at the panel's bottom edge; action rows keep clear
- *  of it. The chevron itself touches the bottom edge (LP3 feedback
- *  2026-09-03) — no float above it. */
+ *  of it. The chevron itself touches the bottom edge — no float above it. */
 private val ChevronZone = 38.dp

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ContextWindow.kt
@@ -2,6 +2,8 @@ package com.lightphone.chats.screens
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -98,7 +101,24 @@ fun ContextWindowOverlay(
         modifier = modifier
             .fillMaxWidth()
             .fillMaxHeight(0.5f)
-            .background(Color.Black),
+            .background(Color.Black)
+            // The panel is an overlay over the thread list, and Compose
+            // dispatches pointer events to everything under the finger — a
+            // background alone consumes nothing, so taps in the panel's empty
+            // regions fell through to rows beneath (a voice-note play button
+            // under LIKE, LP3 feedback 2026-09-07). Swallow every event in
+            // the panel's area; the action rows and the chevron are children
+            // and see each pass first, so they keep working.
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false).consume()
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        event.changes.forEach { it.consume() }
+                        if (event.changes.none { it.pressed }) break
+                    }
+                }
+            },
     ) {
         when (level) {
             // LP3 feedback 2026-09-03: the action rows read like bottom-bar

--- a/app/src/main/kotlin/com/lightphone/chats/screens/FullscreenImageScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/FullscreenImageScreen.kt
@@ -47,10 +47,10 @@ import kotlinx.coroutines.withContext
 /**
  * Fullscreen photo viewer: tapping an image row in the thread opens it here.
  * Shows the display JPEG scaled to fit the screen; the back button (or a tap
- * on the photo) closes. Pinch zooms up to 5x, double-tap toggles 1x/2x
- * (feedback 2026-08-23). The bottom bar saves the photo to the device's
+ * on the photo) closes. Pinch zooms up to 5x, double-tap toggles 1x/2x.
+ * The bottom bar saves the photo to the device's
  * Pictures/Chats album (server-side original, not this display JPEG);
- * the LP3-classic fullscreen panel confirms (2026-09-03).
+ * the LP3-classic fullscreen panel confirms.
  */
 class FullscreenImageScreen(
     sealedActivity: SealedLightActivity,
@@ -64,9 +64,9 @@ class FullscreenImageScreen(
     override fun Content() {
         val themeColors by LightThemeController.colors.collectAsState()
         // Decode off the main thread; the viewer shows the background until
-        // the bitmap lands (feedback 2026-08-23). Seeded from the shared
+        // the bitmap lands. Seeded from the shared
         // decode cache so the thread row finds the bitmap already decoded
-        // when this viewer closes (LP3 2026-08-23 — re-decode flash).
+        // when this viewer closes.
         val bitmap by produceState<ImageBitmap?>(chatsBitmapCache.get(eventId), bytes) {
             if (value == null) {
                 value = withContext(Dispatchers.Default) {

--- a/app/src/main/kotlin/com/lightphone/chats/screens/RecoveryKeyEditorScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/RecoveryKeyEditorScreen.kt
@@ -77,9 +77,8 @@ class RecoveryKeyEditorScreen(
                 // small centered text, lines growing upward. The typography
                 // tokens carry no color, so copy the active content color —
                 // without it BasicText falls back to black-on-black on the dark
-                // theme and the key is unreadable. Copy-sized (was paragraph) —
-                // feedback 2026-08-19: slightly bigger, the 3-line key still
-                // fits above the keyboard.
+                // theme and the key is unreadable. Copy-sized — slightly bigger
+                // than paragraph, so the 3-line key still fits above the keyboard.
                 inputTextStyle = LightThemeTokens.typography.copy
                     .copy(color = themeColors.content, textAlign = TextAlign.Center)
                     .scaledForScreenHeight(),

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
@@ -47,16 +47,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Chat search (feedback 2026-08-21): replaces the room list's VIEW UNREAD
+ * Chat search: replaces the room list's VIEW UNREAD
  * toggle. Type a query (the LP3 keyboard, no emoji/mic/return rows — the
  * search action lives in the keyboard's bottom zone, DESIGN.md §16), tap the
  * SEARCH icon, and the results view lists matching rooms alphabetically. A
  * 1-character query matches; an empty search lists every chat. Results are
  * DIRECT chats by default — the bottom-middle "VIEW ALL" toggle reveals
- * groups + archived rooms (2026-08-28). The chat list's active network
+ * groups + archived rooms. The chat list's active network
  * filter (all / WhatsApp / Instagram) carries into the search. Selecting a
  * row opens that room's thread.
- *
  * Two views like the radio SearchScreen (radio/.../SearchScreen.kt): a
  * typing view and a results view. [SearchViewModel.showResults] lives in the
  * view model so the results view survives the thread round-trip (the
@@ -90,7 +89,7 @@ class SearchViewModel(
         stopPolling()
     }
 
-    /** The live census (NO-SEAM, 2026-09-07 — the revision-wait poll is
+    /** The live census (NO-SEAM — the revision-wait poll is
      *  gone): the repository's roomList flow fills and keeps the results
      *  current while the screen is open. The trimmed row shape matches the
      *  old GetAllRooms reply (no preview/unread on search rows). */
@@ -117,10 +116,10 @@ class SearchViewModel(
     /**
      * Matching rooms, alphabetically: a blank query matches everything.
      * VIEW DIRECT by default (direct, non-archived chats); VIEW ALL includes
-     * groups + archived rooms (2026-08-28). The chat list's active network
+     * groups + archived rooms. The chat list's active network
      * filter (all / WhatsApp / Instagram) applies. [rooms] is passed in from
      * the screen's collected state — reading the flow's .value directly
-     * would never recompose when the fetch lands (2026-08-30).
+     * would never recompose when the fetch lands.
      */
     fun matchingRooms(rooms: List<LightServiceMethod.GetRooms.Room>): List<LightServiceMethod.GetRooms.Room> {
         val q = query.value.trim()
@@ -188,7 +187,7 @@ class SearchScreen(
         // Returning from a thread opened via search closes the search: the
         // thread's back pops with a Unit result, so this callback pops the
         // search screen too — back from the thread lands on the MAIN list, not
-        // the search results (feedback 2026-08-22).
+        // the search results.
         navigateTo(screenFactory = { ThreadScreen(it, room) }) { goBack() }
     }
 }
@@ -229,8 +228,7 @@ private fun QueryView(
         submitIcon = LightIcons.SEARCH,
         singleLine = true,
         // The input centers vertically between the top bar and the keyboard —
-        // the same treatment as the login field editors (design standard,
-        // feedback 2026-08-22: the field sat flush under the top bar).
+        // the same treatment as the login field editors (design standard).
         centered = true,
     )
 }
@@ -238,8 +236,7 @@ private fun QueryView(
 /** The results view: matching rooms alphabetically ("no chats found" when
  *  nothing matches), a bottom-middle VIEW DIRECT / VIEW ALL mode switch, and
  *  a back arrow returning to the query. VIEW DIRECT by default. The top bar
- *  shows the searched term in quotes instead of "Search Results" (feedback
- *  2026-09-01). */
+ *  shows the searched term in quotes instead of "Search Results". */
 @Composable
 private fun ColumnScope.ResultsView(
     dmsOnly: Boolean,
@@ -279,7 +276,7 @@ private fun ColumnScope.ResultsView(
         items = listOf(
             // Bottom-middle (single-item bar): exclusive mode switch — direct,
             // non-archived chats by default; "VIEW ALL" swaps in groups +
-            // archived rooms and flips the label (2026-08-28).
+            // archived rooms and flips the label.
             LightBarButton.Text(
                 text = if (dmsOnly) "VIEW ALL" else "VIEW DIRECT",
                 onClick = onToggleDmsOnly,

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.lightphone.chats.ChatClient
 import com.lightphone.chats.roomMatchesQuery
+import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
@@ -81,9 +82,6 @@ class SearchViewModel(
         super.onScreenShow(screen)
         // No thread is on screen here; let the companion notify again.
         viewModelScope.launch { ChatClient.setActiveRoom(null) }
-        // Refresh the room set (also on return from a thread — a new chat may
-        // have arrived); the results list keeps its current rows meanwhile.
-        refreshRooms()
         startPolling()
     }
 
@@ -92,19 +90,17 @@ class SearchViewModel(
         stopPolling()
     }
 
-    /** Re-fetches the census while the screen stays open (a cold process can
-     *  answer the first call with an empty list while the companion's
-     *  resolver seeds — the first publish bumps the room-list revision, which
-     *  wakes this wait and fills the results in, same as the main list). */
+    /** The live census (NO-SEAM, 2026-09-07 — the revision-wait poll is
+     *  gone): the repository's roomList flow fills and keeps the results
+     *  current while the screen is open. The trimmed row shape matches the
+     *  old GetAllRooms reply (no preview/unread on search rows). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
-            var lastRevision = 0L
-            while (true) {
-                val revision = ChatClient.waitForRoomListChange(lastRevision)
-                if (revision == lastRevision) continue
-                lastRevision = revision
-                refreshRooms()
+            MatrixRepository.roomList.collect { census ->
+                census.map { it.copy(lastMessage = "", unreadCount = 0, lastEventId = null) }
+                    .takeIf { it.isNotEmpty() || rooms.value.isEmpty() }
+                    ?.let { rooms.value = it }
             }
         }
     }
@@ -112,10 +108,6 @@ class SearchViewModel(
     private fun stopPolling() {
         pollJob?.cancel()
         pollJob = null
-    }
-
-    private fun refreshRooms() {
-        viewModelScope.launch { rooms.value = ChatClient.getAllRooms() }
     }
 
     fun updateQuery(newQuery: String) {

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
@@ -42,7 +42,6 @@ import com.thelightphone.sdk.ui.defaultKeyboardOptions
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import com.thelightphone.sdk.ui.lightClickable
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -95,12 +94,16 @@ class SearchViewModel(
 
     /** Re-fetches the census while the screen stays open (a cold process can
      *  answer the first call with an empty list while the companion's
-     *  resolver seeds — the poll fills the results in, same as the main list). */
+     *  resolver seeds — the first publish bumps the room-list revision, which
+     *  wakes this wait and fills the results in, same as the main list). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
+            var lastRevision = 0L
             while (true) {
-                delay(POLL_INTERVAL_MS)
+                val revision = ChatClient.waitForRoomListChange(lastRevision)
+                if (revision == lastRevision) continue
+                lastRevision = revision
                 refreshRooms()
             }
         }
@@ -138,10 +141,7 @@ class SearchViewModel(
             .sortedBy { it.name.lowercase() }
     }
 
-    private companion object {
-        /** Results refresh cadence — matches the main list's poll. */
-        const val POLL_INTERVAL_MS = 5_000L
-    }
+    private companion object
 }
 
 class SearchScreen(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SearchScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.lightphone.chats.ChatClient
 import com.lightphone.chats.roomMatchesQuery
-import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
@@ -91,17 +90,11 @@ class SearchViewModel(
 
     /** The live census (NO-SEAM — the revision-wait poll is
      *  gone): the repository's roomList flow fills and keeps the results
-     *  current while the screen is open. The trimmed row shape matches the
-     *  old GetAllRooms reply (no preview/unread on search rows). */
+     *  current while the screen is open (see [collectRoomCensus]; no
+     *  preview/unread on search rows). */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
-        pollJob = viewModelScope.launch {
-            MatrixRepository.roomList.collect { census ->
-                census.map { it.copy(lastMessage = "", unreadCount = 0, lastEventId = null) }
-                    .takeIf { it.isNotEmpty() || rooms.value.isEmpty() }
-                    ?.let { rooms.value = it }
-            }
-        }
+        pollJob = collectRoomCensus(viewModelScope, rooms)
     }
 
     private fun stopPolling() {

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
@@ -86,6 +86,22 @@ class SettingsViewModel : LightViewModel<Unit>() {
                     delay(STARTING_SYNC_TIMEOUT_MS)
                     startingSync.value = false
                 }
+                // Wake half: the companion bumps the status revision the instant
+                // the connection state commits — clear the starting state as
+                // soon as "syncing" lands instead of riding out the window.
+                launch {
+                    var last = 0L
+                    while (startingSync.value) {
+                        val revision = ChatClient.waitForStatusChange(last)
+                        if (revision == last) break
+                        last = revision
+                        connection.value = ChatClient.connectionState()
+                        if (connection.value?.state == "syncing") {
+                            startingSync.value = false
+                            break
+                        }
+                    }
+                }
             }
             ChatClient.setSyncEnabled(value)
             refresh()

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
@@ -42,14 +42,13 @@ import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import com.thelightphone.sdk.ui.lightClickable
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
  * Tool settings: the account panel (login setup + verification) lives behind
- * the Account row, the sync toggle pauses the companion's loop, and toggles
- * control the "seen" marker + data-saver media downloads. The
+ * the Account row, Battery Saver turns off background notifications, and
+ * toggles control the "seen" marker + data-saver media downloads. The
  * status-heavy content — account state, sync progress, encryption — moved to
  * [AccountScreen].
  */
@@ -57,9 +56,6 @@ class SettingsViewModel : LightViewModel<Unit>() {
 
     val account = MutableStateFlow<LightServiceMethod.GetAccountState.Response?>(null)
     val connection = MutableStateFlow<LightServiceMethod.GetConnectionState.Response?>(null)
-
-    /** True between the user turning sync on and the companion reporting "syncing". */
-    val startingSync = MutableStateFlow(false)
 
     override fun onScreenShow(screen: SimpleLightScreen<Unit>) {
         super.onScreenShow(screen)
@@ -72,37 +68,13 @@ class SettingsViewModel : LightViewModel<Unit>() {
         viewModelScope.launch {
             account.value = ChatClient.accountState()
             connection.value = ChatClient.connectionState()
-            if (connection.value?.state == "syncing") startingSync.value = false
         }
     }
 
-    /** Toggles the companion's sync loop (audit 2026-08-14 — battery escape hatch). */
+    /** Toggles Battery Saver on the companion (audit 2026-08-14 — battery
+     *  escape hatch; semantics 2026-09-07: stops background sync only). */
     fun setSyncEnabled(value: Boolean) {
         viewModelScope.launch {
-            if (value && connection.value?.syncEnabled != true) {
-                startingSync.value = true
-                // Safety net: clear even if "syncing" never arrives (offline…).
-                launch {
-                    delay(STARTING_SYNC_TIMEOUT_MS)
-                    startingSync.value = false
-                }
-                // Wake half: the companion bumps the status revision the instant
-                // the connection state commits — clear the starting state as
-                // soon as "syncing" lands instead of riding out the window.
-                launch {
-                    var last = 0L
-                    while (startingSync.value) {
-                        val revision = ChatClient.waitForStatusChange(last)
-                        if (revision == last) break
-                        last = revision
-                        connection.value = ChatClient.connectionState()
-                        if (connection.value?.state == "syncing") {
-                            startingSync.value = false
-                            break
-                        }
-                    }
-                }
-            }
             ChatClient.setSyncEnabled(value)
             refresh()
         }
@@ -121,10 +93,6 @@ class SettingsViewModel : LightViewModel<Unit>() {
             ChatSettings.setDownloadOverMobile(lightContext, value)
         }
     }
-
-    private companion object {
-        const val STARTING_SYNC_TIMEOUT_MS = 10_000L
-    }
 }
 
 class SettingsScreen(sealedActivity: SealedLightActivity) :
@@ -139,7 +107,6 @@ class SettingsScreen(sealedActivity: SealedLightActivity) :
     override fun Content() {
         val account by viewModel.account.collectAsState()
         val connection by viewModel.connection.collectAsState()
-        val startingSync by viewModel.startingSync.collectAsState()
         val showReadStatus by ChatSettings.showReadStatus.collectAsState()
         val downloadOverMobile by ChatSettings.downloadOverMobile.collectAsState()
         val themeColors by LightThemeController.colors.collectAsState()
@@ -175,25 +142,23 @@ class SettingsScreen(sealedActivity: SealedLightActivity) :
                                 } ?: "…",
                                 onClick = { navigateTo(screenFactory = { AccountScreen(it) }) },
                             )
+                            // Battery Saver: on = no sync while the screen is
+                            // dark; messages arrive whenever the screen is on.
                             val syncEnabled = connection?.syncEnabled ?: true
-                            ToggleRow(
-                                checked = syncEnabled,
-                                title = "Background Sync",
-                                subtitle = when {
-                                    !syncEnabled -> "Paused"
-                                    startingSync -> "Initializing..."
-                                    else -> "Syncing"
-                                },
-                                onToggle = {
-                                    viewModel.setSyncEnabled(!syncEnabled)
-                                },
-                            )
                             ToggleRow(
                                 checked = showReadStatus,
                                 title = "Seen Status",
                                 subtitle = "visible under your messages",
                                 onToggle = {
                                     viewModel.setShowReadStatus(lightContext, !showReadStatus)
+                                },
+                            )
+                            ToggleRow(
+                                checked = !syncEnabled,
+                                title = "Battery Saver",
+                                subtitle = "Pause background notifications",
+                                onToggle = {
+                                    viewModel.setSyncEnabled(!syncEnabled)
                                 },
                             )
                             ToggleRow(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/SettingsScreen.kt
@@ -246,7 +246,7 @@ private fun SettingsRow(
                     // Value-row main text — Heading. Pulled up into the label's
                     // descender space so the two sit almost touching (the emulator
                     // letterboxes ~0.66×, so the ink gap renders ~1.5× on the
-                    // LP3 — feedback 2026-08-19).
+                    // LP3).
                     variant = LightTextVariant.Heading,
                     modifier = Modifier.offset(y = (-3).dp),
                 )
@@ -270,8 +270,7 @@ private fun ToggleRow(
             .padding(horizontal = 2f.gridUnitsAsDp(), vertical = 0.75f.gridUnitsAsDp()),
         // The toggle sits immediately left of its action label, the row
         // top-aligned so it lines up with the main label — not centered
-        // between the label and the caption (same as Audiobooks Settings,
-        // feedback 2026-08-17).
+        // between the label and the caption (same as Audiobooks Settings).
         verticalAlignment = Alignment.Top,
     ) {
         Box(

--- a/app/src/main/kotlin/com/lightphone/chats/screens/Shared.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/Shared.kt
@@ -1,0 +1,50 @@
+package com.lightphone.chats.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import com.lightphone.chats.server.MatrixRepository
+import com.thelightphone.sdk.ui.LocalHapticsEnabled
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * The app's gesture buzz for row taps and long-press context panels: a
+ * LongPress-type click (the app's standard click feel), gated by the same
+ * LocalHapticsEnabled the SDK's lightClickable reads. (The SDK's context-based
+ * haptic helper is plugin-banned in tool code, so this goes through Compose's
+ * haptic API.) The state stays fresh across recompositions, so a gesture
+ * handler can just call the returned lambda.
+ */
+@Composable
+fun rememberHapticBuzz(): () -> Unit {
+    val haptic = LocalHapticFeedback.current
+    val enabled = rememberUpdatedState(LocalHapticsEnabled.current)
+    return remember(haptic) {
+        {
+            if (enabled.value) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+}
+
+/**
+ * The live room census both list screens poll (NO-SEAM): collects the
+ * repository's roomList into [rooms] trimmed to the old GetAllRooms row shape
+ * (no preview/unread — those never render on list rows); an empty census never
+ * wipes the first frame's seed (or an already-loaded list) during a cold
+ * start. Returns the job for the caller's on-screen-hide cancel.
+ */
+fun collectRoomCensus(
+    scope: CoroutineScope,
+    rooms: MutableStateFlow<List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room>>,
+): Job = scope.launch {
+    MatrixRepository.roomList.collect { census ->
+        census.map { it.copy(lastMessage = "", unreadCount = 0, lastEventId = null) }
+            .takeIf { it.isNotEmpty() || rooms.value.isEmpty() }
+            ?.let { rooms.value = it }
+    }
+}

--- a/app/src/main/kotlin/com/lightphone/chats/screens/Shared.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/Shared.kt
@@ -48,3 +48,18 @@ fun collectRoomCensus(
             ?.let { rooms.value = it }
     }
 }
+
+/**
+ * The contact-panel flag toggle shared by both screens: flips [flow] locally
+ * and persists the new value server-side. [roomId] is re-read per toggle
+ * (the chat list's panel room changes); a null room skips the persist.
+ */
+fun CoroutineScope.toggleAndPersist(
+    flow: MutableStateFlow<Boolean>,
+    roomId: () -> String?,
+    persist: suspend (String, Boolean) -> Unit,
+) {
+    val next = !flow.value
+    flow.value = next
+    roomId()?.let { id -> launch { persist(id, next) } }
+}

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -1,7 +1,6 @@
 package com.lightphone.chats.screens
 
 import android.graphics.BitmapFactory
-import android.util.Log
 import android.text.format.DateUtils
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -545,7 +544,6 @@ class ThreadViewModel(
                 // reflects, then ride the rest on top — the heart (dis)appears
                 // instantly after a toggle instead of waiting on this poll.
                 var fetched = page?.messages.orEmpty()
-                Log.d("ChatsDebug", "loadNewest: page=${page != null} size=${fetched.size} overlays=${reactionOverlays.value.size}")
                 dropReflectedOverlays(fetched)
                 fetched = applyReactionOverlays(fetched)
                 loaded = fetched
@@ -793,7 +791,6 @@ class ThreadViewModel(
      * never react (nothing to like back — restraint).
      */
     fun toggleLike(message: LightServiceMethod.GetMessages.Message) {
-        Log.d("ChatsDebug", "toggleLike: id=${message.id} isMine=${message.isMine} type=${message.contentType} own=${effectiveOwnKeys(message)} haptics gate ok")
         if (message.isMine || message.id.startsWith(LOCAL_ROW_PREFIX)) return
         if (LIKE_KEY in effectiveOwnKeys(message)) removeReaction(message)
         else setReaction(message, LIKE_KEY)
@@ -867,7 +864,6 @@ class ThreadViewModel(
         val updates = own.associateWith { false } + (key to true)
         reactionOverlays.value = reactionOverlays.value +
             (message.id to ((reactionOverlays.value[message.id] ?: emptyMap()) + updates))
-        Log.d("ChatsDebug", "setReaction: id=${message.id} overlay=$updates")
         messages.value = applyReactionOverlays(messages.value)
         loadNewest(quiet = true)
         viewModelScope.launch {
@@ -879,7 +875,6 @@ class ThreadViewModel(
                 ChatClient.unsendReaction(room.id, message.id, old)
             }
             val ok = ChatClient.sendReaction(room.id, message.id, key)
-            Log.d("ChatsDebug", "setReaction RPC: ok=$ok")
             if (!ok) {
                 // Only the new key reverts — the old keys' removal entries
                 // self-heal when a served page reflects them.
@@ -983,7 +978,6 @@ class ThreadViewModel(
     ): List<LightServiceMethod.GetMessages.Message> {
         val overlays = reactionOverlays.value
         if (overlays.isEmpty()) return page
-        Log.d("ChatsDebug", "applyReactionOverlays: ${overlays.keys}")
         return page.map { m ->
             val keys = overlays[m.id] ?: return@map m
             var reactions = m.reactions

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -2059,26 +2059,11 @@ private fun MessageRow(
             }
             // A forwarded message carries a small "forwarded" tag — the
             // bridge's WhatsApp forward marker, lifted out of the body by the
-            // companion and served as this flag. Outgoing TEXT rows lead with
-            // the ↷ glyph (Subtitle) above the body with the word under it;
-            // incoming text and MEDIA rows put the glyph beside the content
-            // with the word under it. Tight, lowercase, consistent with the other tags.
-            if (message.forwarded && message.contentType == "text" && message.isMine) {
-                Row(
-                    modifier = Modifier.padding(top = 1.dp, bottom = 1.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    LightText(
-                        text = "\u21B7",
-                        variant = LightTextVariant.Subtitle,
-                    )
-                    LightText(
-                        text = "forwarded",
-                        variant = LightTextVariant.Superfine,
-                        modifier = Modifier.padding(start = 0.25f.gridUnitsAsDp()),
-                    )
-                }
-            }
+            // companion and served as this flag. Every forwarded row shares
+            // one grammar, incoming or own: the ↷ glyph trails the content at
+            // the far right, centred vertically on it, and the lowercase
+            // "forwarded" word sits under the whole block — same spot as the
+            // other tags. Tight, lowercase, consistent with the other tags.
             // Media rows open the context window on long-press — received rows always (LIKE/REACT [+ SAVE on
             // images]), own rows only while the bridge still allows an unsend
             // (canEdit never applies to media; otherwise no panel at all).
@@ -2086,11 +2071,11 @@ private fun MessageRow(
                 { onOpenContext(message) }
             } else null
             if (message.contentType == "image") {
-                ForwardedMediaRow(message) {
+                ForwardedMediaRow(message, caption = message.caption) {
                     ImageMessageContent(message, media, onOpenImage, contextGesture)
                 }
             } else if (message.contentType == "audio") {
-                ForwardedMediaRow(message) {
+                ForwardedMediaRow(message, caption = message.caption) {
                     AudioMessageContent(
                         message = message,
                         playing = message.id == voice.playingEventId,
@@ -2105,27 +2090,27 @@ private fun MessageRow(
                     )
                 }
             } else {
-                if (message.isMine) {
-                    // Outgoing: block sized to the first line so the top line's
-                    // last word always touches the right edge (see
-                    // [OutgoingBodyText]).
-                    OutgoingBodyText(message.body, bodyMaxWidthPx)
-                } else if (message.forwarded) {
-                    // Forwarded incoming text: the ↷ glyph anchors the left,
-                    // beside the body like the call notices' phone icon. It
-                    // renders at Paragraph — same line box as the body, so
-                    // the row hugs the text — scaled ~2.1x (≈ the Subtitle
-                    // ink size) about the box center, which keeps the arrow
-                    // centered on the body line: Subtitle's far taller line
-                    // box carried the ink low and opened gaps above/below
-                    // The small "forwarded" word sits
-                    // at the message's left edge under both.
+                if (message.forwarded) {
+                    // Forwarded text — incoming and own share the grammar: the
+                    // ↷ glyph trails the body at the far right, centred
+                    // vertically on it ([ForwardedArrowGlyph]: Paragraph
+                    // scaled ~2.1x about a low pivot keeps the ink centered on
+                    // the body's line box), the lowercase "forwarded" word
+                    // under the whole block.
                     Column(modifier = Modifier.padding(top = 1.dp)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            ForwardedArrowGlyph()
-                            LightText(
-                                text = message.body,
-                                variant = LightTextVariant.Paragraph,
+                            if (message.isMine) {
+                                // Outgoing: block sized to the first line so
+                                // the top line's last word touches the right
+                                // edge (see [OutgoingBodyText]).
+                                OutgoingBodyText(message.body, bodyMaxWidthPx)
+                            } else {
+                                LightText(
+                                    text = message.body,
+                                    variant = LightTextVariant.Paragraph,
+                                )
+                            }
+                            ForwardedArrowGlyph(
                                 modifier = Modifier.padding(start = 0.5f.gridUnitsAsDp()),
                             )
                         }
@@ -2135,6 +2120,11 @@ private fun MessageRow(
                             modifier = Modifier.padding(top = 1.dp),
                         )
                     }
+                } else if (message.isMine) {
+                    // Outgoing: block sized to the first line so the top line's
+                    // last word always touches the right edge (see
+                    // [OutgoingBodyText]).
+                    OutgoingBodyText(message.body, bodyMaxWidthPx)
                 } else if (message.body.startsWith("Incoming call")) {
                     // Bridged call notices ("Incoming call. Use the WhatsApp
                     // app to answer." — Beeper's bridges can't relay calls, so
@@ -2245,7 +2235,7 @@ private fun MessageRow(
  *  Paragraph line box; the pivot keeps the ink centered and the equal
  *  padding re-absorbs the scaled ink. */
 @Composable
-private fun ForwardedArrowGlyph() {
+private fun ForwardedArrowGlyph(modifier: Modifier = Modifier) {
     LightText(
         text = "\u21B7",
         variant = LightTextVariant.Paragraph,
@@ -2255,26 +2245,38 @@ private fun ForwardedArrowGlyph() {
                 scaleY = 2.1f
                 transformOrigin = TransformOrigin(0.5f, 0.72f)
             }
-            .padding(2.5.dp),
+            .padding(2.5.dp)
+            .then(modifier),
     )
 }
 
-/** Forwarded MEDIA rows: the ↷ glyph beside the
- *  content, the small "forwarded" word under it — the same grammar as
- *  forwarded incoming text. */
+/** Forwarded MEDIA rows: the ↷ glyph trails the media at the far right
+ *  (spaced off it — it used to hug the photo), any caption moves UNDER the
+ *  media instead of beside it, and the small "forwarded" word sits under the
+ *  whole block — the same grammar as forwarded text. */
 @Composable
 private fun ForwardedMediaRow(
     message: LightServiceMethod.GetMessages.Message,
+    caption: String?,
     content: @Composable () -> Unit,
 ) {
     if (!message.forwarded) {
         content()
+        caption?.let {
+            LightText(
+                text = it,
+                variant = LightTextVariant.Paragraph,
+                modifier = Modifier.padding(top = 1.dp),
+            )
+        }
         return
     }
     Column(modifier = Modifier.padding(top = 1.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            ForwardedArrowGlyph()
             content()
+            ForwardedArrowGlyph(
+                modifier = Modifier.padding(start = 0.5f.gridUnitsAsDp()),
+            )
         }
         LightText(
             text = "forwarded",
@@ -2331,15 +2333,6 @@ private fun ImageMessageContent(
             variant = LightTextVariant.Paragraph,
             modifier = bodyModifier.padding(top = 1.dp),
         )
-        // The caption still shows under the placeholder — the text row is all
-        // the context there is (feedback 2026-09-01).
-        message.caption?.let { caption ->
-            LightText(
-                text = caption,
-                variant = LightTextVariant.Paragraph,
-                modifier = Modifier.padding(top = 1.dp),
-            )
-        }
         return
     }
     Image(
@@ -2367,16 +2360,6 @@ private fun ImageMessageContent(
                 )
             },
     )
-    // Feedback round 2026-08-19: received photos with a caption (the m.image
-    // body) show it under the thumbnail, like native messaging apps.
-    val caption = message.caption
-    if (caption != null) {
-        LightText(
-            text = caption,
-            variant = LightTextVariant.Paragraph,
-            modifier = Modifier.padding(top = 1.dp),
-        )
-    }
 }
 
 /** A voice-note row: a play/pause icon + label, tapped to toggle playback in

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -1239,6 +1239,14 @@ class ThreadScreen(
         val showReadStatus by ChatSettings.showReadStatus.collectAsState()
         val downloadOverMobile by ChatSettings.downloadOverMobile.collectAsState()
         val themeColors by LightThemeController.colors.collectAsState()
+        // Row-state bundles collected once here instead of a 10-parameter
+        // wall on [MessageRow]: the image fetch state, and the raw voice-note
+        // playback state (the per-row id comparisons happen in [MessageRow]).
+        val media = MediaState(mediaBytes, downloadOverMobile, viewModel::ensureMedia)
+        val voice = VoiceState(
+            playingEventId, playingPositionMs, playingPositionAtMs, counterPending,
+            pausedEventId, pausedPositionMs, voiceError, viewModel::playVoiceNote,
+        )
         // Restore the saved position at FIRST composition (the initial-params
         // overload): returning from the fullscreen photo viewer otherwise
         // created the list at the bottom and the post-composition scroll
@@ -1410,18 +1418,9 @@ class ThreadScreen(
                                                 // "delivered" shows regardless (2026-09-06).
                                                 ?.takeIf { it.second != "seen" || showReadStatus }
                                                 ?.second,
-                                            mediaBytes = mediaBytes,
-                                            allowMobile = downloadOverMobile,
-                                            playing = row.message.id == playingEventId,
-                                            playingPositionMs = playingPositionMs,
-                                            playingPositionAtMs = playingPositionAtMs,
-                                            counterPending = counterPending,
-                                            paused = row.message.id == pausedEventId,
-                                            pausedPositionMs = pausedPositionMs,
-                                            voiceError = voiceError,
+                                            media = media,
+                                            voice = voice,
                                             reactionError = reactionError,
-                                            onEnsureMedia = viewModel::ensureMedia,
-                                            onPlayVoiceNote = viewModel::playVoiceNote,
                                             onRetrySend = viewModel::retrySend,
                                             onResendAsNew = viewModel::resendAsNew,
                                             onToggleLike = viewModel::toggleLike,
@@ -1848,24 +1847,40 @@ private fun OutgoingBodyText(body: String, maxWidthPx: Int) {
     )
 }
 
+/** Image-row state shared by every row: the fetched display bytes by message
+ *  id, the mobile-data download toggle, and the fetch callback (see
+ *  [ImageMessageContent]). One immutable object collected once in
+ *  [ThreadScreen.Content] instead of a parameter trio per row. */
+private data class MediaState(
+    val mediaBytes: Map<String, ByteArray>,
+    val allowMobile: Boolean,
+    val onEnsureMedia: (String, Boolean) -> Unit,
+)
+
+/** Voice-note row state shared by every row: the raw playback state from the
+ *  view model (see [AudioMessageContent]). Collected once in
+ *  [ThreadScreen.Content]; the per-row comparisons (message.id vs the
+ *  playing/paused event id, the per-row error) happen in [MessageRow]. */
+private data class VoiceState(
+    val playingEventId: String?,
+    val playingPositionMs: Long?,
+    val playingPositionAtMs: Long,
+    val counterPending: Boolean,
+    val pausedEventId: String?,
+    val pausedPositionMs: Long?,
+    val error: Pair<String, String>?,
+    val onPlayVoiceNote: (String) -> Unit,
+)
+
 @Composable
 private fun MessageRow(
     message: LightServiceMethod.GetMessages.Message,
     showSender: Boolean,
     showTime: Boolean,
     statusTag: String?,
-    mediaBytes: Map<String, ByteArray>,
-    allowMobile: Boolean,
-    playing: Boolean,
-    playingPositionMs: Long?,
-    playingPositionAtMs: Long,
-    counterPending: Boolean,
-    paused: Boolean,
-    pausedPositionMs: Long?,
-    voiceError: Pair<String, String>?,
+    media: MediaState,
+    voice: VoiceState,
     reactionError: Pair<String, String>?,
-    onEnsureMedia: (String, Boolean) -> Unit,
-    onPlayVoiceNote: (String) -> Unit,
     onRetrySend: (LightServiceMethod.GetMessages.Message) -> Unit,
     onResendAsNew: (LightServiceMethod.GetMessages.Message) -> Unit,
     onToggleLike: (LightServiceMethod.GetMessages.Message) -> Unit,
@@ -2072,20 +2087,20 @@ private fun MessageRow(
             } else null
             if (message.contentType == "image") {
                 ForwardedMediaRow(message) {
-                    ImageMessageContent(message, mediaBytes, allowMobile, onEnsureMedia, onOpenImage, contextGesture)
+                    ImageMessageContent(message, media, onOpenImage, contextGesture)
                 }
             } else if (message.contentType == "audio") {
                 ForwardedMediaRow(message) {
                     AudioMessageContent(
                         message = message,
-                        playing = playing,
-                        playingPositionMs = playingPositionMs,
-                        playingPositionAtMs = playingPositionAtMs,
-                        counterPending = counterPending,
-                        paused = paused,
-                        pausedPositionMs = pausedPositionMs,
-                        error = voiceError?.takeIf { it.first == message.id }?.second,
-                        onTogglePlay = { onPlayVoiceNote(message.id) },
+                        playing = message.id == voice.playingEventId,
+                        playingPositionMs = voice.playingPositionMs,
+                        playingPositionAtMs = voice.playingPositionAtMs,
+                        counterPending = voice.counterPending,
+                        paused = message.id == voice.pausedEventId,
+                        pausedPositionMs = voice.pausedPositionMs,
+                        error = voice.error?.takeIf { it.first == message.id }?.second,
+                        onTogglePlay = { voice.onPlayVoiceNote(message.id) },
                         onOpenContext = contextGesture,
                     )
                 }
@@ -2274,16 +2289,14 @@ private fun ForwardedMediaRow(
 @Composable
 private fun ImageMessageContent(
     message: LightServiceMethod.GetMessages.Message,
-    mediaBytes: Map<String, ByteArray>,
-    allowMobile: Boolean,
-    onEnsureMedia: (String, Boolean) -> Unit,
+    media: MediaState,
     onOpenImage: (ByteArray) -> Unit,
     onOpenContext: (() -> Unit)?,
 ) {
     // The toggle is part of the key: flipping "Mobile data downloads" (or
     // moving off cellular) re-attempts rows that were skipped as Wi-Fi-only.
-    LaunchedEffect(message.id, allowMobile) { onEnsureMedia(message.id, allowMobile) }
-    val bytes = mediaBytes[message.id]
+    LaunchedEffect(message.id, media.allowMobile) { media.onEnsureMedia(message.id, media.allowMobile) }
+    val bytes = media.mediaBytes[message.id]
     // Decode off the main thread: the in-composition decode blocked the UI
     // thread's first paint for every visible photo.
     // The text fallback below renders until the bitmap lands. Seeded from the
@@ -2311,7 +2324,7 @@ private fun ImageMessageContent(
         // re-run it without leaving the thread. Decode failures (bytes but no bitmap) stay
         // dead text; re-fetching would not help.
         val bodyModifier =
-            if (bytes == null) Modifier.lightClickable(onClick = { onEnsureMedia(message.id, allowMobile) })
+            if (bytes == null) Modifier.lightClickable(onClick = { media.onEnsureMedia(message.id, media.allowMobile) })
             else Modifier
         LightText(
             text = message.body,

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -36,9 +36,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
@@ -73,7 +71,6 @@ import com.thelightphone.sdk.ui.LightThemeController
 import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
-import com.thelightphone.sdk.ui.LocalHapticsEnabled
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import com.thelightphone.sdk.ui.lightClickable
 import com.thelightphone.sdk.ui.scaledForScreenHeight
@@ -769,9 +766,7 @@ class ThreadViewModel(
             val (playing, error) = ChatClient.playVoiceNote(room.id, eventId)
             playingEventId.value = if (playing) eventId else null
             if (!playing && error != null) {
-                voiceError.value = eventId to error
-                delay(VOICE_ERROR_DISMISS_MS)
-                if (voiceError.value?.first == eventId) voiceError.value = null
+                showRowError(voiceError, eventId, error)
             }
         }
     }
@@ -835,11 +830,23 @@ class ThreadViewModel(
             }
             if (!ok) {
                 revertReactionOverlay(message.id, key)
-                reactionError.value = message.id to "reaction failed"
-                delay(VOICE_ERROR_DISMISS_MS)
-                if (reactionError.value?.first == message.id) reactionError.value = null
+                showRowError(reactionError, message.id, "reaction failed")
             }
         }
+    }
+
+    /**
+     * Surfaces the quiet row error tag on [slot] and clears it after the
+     * dismiss delay — unless a newer error replaced it first.
+     */
+    private suspend fun showRowError(
+        slot: MutableStateFlow<Pair<String, String>?>,
+        eventId: String,
+        text: String,
+    ) {
+        slot.value = eventId to text
+        delay(VOICE_ERROR_DISMISS_MS)
+        if (slot.value?.first == eventId) slot.value = null
     }
 
     /** Rolls back one key's optimistic overlay entry after a failed RPC. */
@@ -884,9 +891,7 @@ class ThreadViewModel(
                 // Only the new key reverts — the old keys' removal entries
                 // self-heal when a served page reflects them.
                 revertReactionOverlay(message.id, key)
-                reactionError.value = message.id to "reaction failed"
-                delay(VOICE_ERROR_DISMISS_MS)
-                if (reactionError.value?.first == message.id) reactionError.value = null
+                showRowError(reactionError, message.id, "reaction failed")
             }
         }
     }
@@ -911,9 +916,7 @@ class ThreadViewModel(
             }
             if (!ok) {
                 own.forEach { revertReactionOverlay(message.id, it) }
-                reactionError.value = message.id to "reaction failed"
-                delay(VOICE_ERROR_DISMISS_MS)
-                if (reactionError.value?.first == message.id) reactionError.value = null
+                showRowError(reactionError, message.id, "reaction failed")
             }
         }
     }
@@ -966,9 +969,7 @@ class ThreadViewModel(
             val ok = ChatClient.unsendMessage(room.id, message.id)
             if (!ok) {
                 unsentOverlays.value = unsentOverlays.value - message.id
-                reactionError.value = message.id to "unsend failed"
-                delay(VOICE_ERROR_DISMISS_MS)
-                if (reactionError.value?.first == message.id) reactionError.value = null
+                showRowError(reactionError, message.id, "unsend failed")
             }
         }
     }
@@ -1487,8 +1488,7 @@ class ThreadScreen(
                         // Tap-away dismiss buzzes like every other panel
                         // dismissal, gated by the
                         // same LocalHapticsEnabled the rows read.
-                        val scrimHaptic = LocalHapticFeedback.current
-                        val scrimHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
+                        val scrimBuzz = rememberHapticBuzz()
                         Box(
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
@@ -1497,9 +1497,7 @@ class ThreadScreen(
                                 .padding(top = 3f.gridUnitsAsDp())
                                 .pointerInput(Unit) {
                                     detectTapGestures(onTap = {
-                                        if (scrimHapticsEnabled) {
-                                            scrimHaptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        }
+                                        scrimBuzz()
                                         contextMessage = null
                                     })
                                 },
@@ -1994,9 +1992,8 @@ private fun MessageRow(
                         // the same LocalHapticsEnabled the SDK's lightClickable
                         // reads; the SDK's context-based haptic helper is
                         // plugin-banned in tool code, so this goes through
-                        // Compose's haptic API instead.
-                        val haptic = LocalHapticFeedback.current
-                        val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
+                        // Compose's haptic API instead (see [rememberHapticBuzz]).
+                        val buzz = rememberHapticBuzz()
                         Modifier
                             .pointerInput(message.id) {
                                 val doubleTapMs = viewConfiguration.doubleTapTimeoutMillis
@@ -2005,13 +2002,7 @@ private fun MessageRow(
                                     // The like guards isMine itself (own rows never
                                     // react) — one gesture block serves both sides.
                                     onTap = {
-                                        if (currentHapticsEnabled) {
-                                            // LongPress-type buzz (the app's
-                                            // standard click feel) — the old
-                                            // TextHandleMove tick was
-                                            // imperceptible on the LP3.
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        }
+                                        buzz()
                                         val now = System.currentTimeMillis()
                                         if (now - lastTapMs < doubleTapMs) {
                                             lastTapMs = 0L
@@ -2021,9 +2012,7 @@ private fun MessageRow(
                                         }
                                     },
                                     onLongPress = {
-                                        if (currentHapticsEnabled) {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        }
+                                        buzz()
                                         onOpenContext(gestureMessage)
                                     },
                                 )
@@ -2323,8 +2312,7 @@ private fun ImageMessageContent(
     // so without this the captured lambdas kept the first-composed snapshot.
     val currentOnOpenImage by rememberUpdatedState(onOpenImage)
     val currentOnOpenContext by rememberUpdatedState(onOpenContext)
-    val haptic = LocalHapticFeedback.current
-    val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
+    val buzz = rememberHapticBuzz()
     if (bytes == null || image == null) {
         // Still loading, or the media can't be fetched/decoded (e.g.
         // still-encrypted): fall back to the row text ("[Photo]" or the file
@@ -2369,9 +2357,7 @@ private fun ImageMessageContent(
                     onTap = { currentOnOpenImage(bytes) },
                     // A long-press consumes the gesture — no viewer open.
                     onLongPress = {
-                        if (currentHapticsEnabled) {
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
+                        buzz()
                         currentOnOpenContext?.invoke()
                     },
                 )
@@ -2441,8 +2427,7 @@ private fun AudioMessageContent(
     }
     val currentOnTogglePlay by rememberUpdatedState(onTogglePlay)
     val currentOnOpenContext by rememberUpdatedState(onOpenContext)
-    val haptic = LocalHapticFeedback.current
-    val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
+    val buzz = rememberHapticBuzz()
     Row(
         modifier = Modifier
             // Tap toggles playback; long-press opens the context window — detectTapGestures consumes the long-press
@@ -2453,9 +2438,7 @@ private fun AudioMessageContent(
                 detectTapGestures(
                     onTap = { currentOnTogglePlay() },
                     onLongPress = {
-                        if (currentHapticsEnabled) {
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
+                        buzz()
                         currentOnOpenContext?.invoke()
                     },
                 )

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -55,6 +55,7 @@ import com.lightphone.chats.VolumePanelState
 import com.lightphone.chats.contactIdentifier
 import com.lightphone.chats.dayOf
 import com.lightphone.chats.formatMessageTime
+import com.lightphone.chats.server.MatrixRepository
 import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
@@ -82,6 +83,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
@@ -145,6 +148,16 @@ internal object threadStateCache {
     }
 
     fun takeScroll(roomId: String): Pair<Int, Int>? = scroll[roomId]
+}
+
+/**
+ * Process-wide optimistic edit/unsend overlays (2026-09-07): survives the
+ * thread's ViewModel so an exit + re-enter inside the page-cache refresh
+ * window keeps showing the edited body (see [ThreadViewModel]'s overlay doc).
+ */
+internal object editEchoCache {
+    val edits = MutableStateFlow<Map<String, String>>(emptyMap())
+    val unsent = MutableStateFlow<Set<String>>(emptySet())
 }
 
 /**
@@ -235,29 +248,28 @@ class ThreadViewModel(
 
     /**
      * Keeps the contact panel honest with OTHER devices (LP3 feedback
-     * 2026-08-28): waits on the companion's flags revision (bumped wherever a
-     * flag fact commits — own toggles, Beeper-side sync) and refetches the
-     * synced flags on movement, updating [muted]/[pinned]/[archived] live
-     * (items 1/5). Runs while the thread — and the contact panel over it — is
-     * on screen (started on [onScreenShow], NOT stopped on [onScreenHide]);
-     * stops when the app backgrounds and dies with the ViewModel on
-     * back-navigation.
+     * 2026-08-28): collects the repository's roomFlags flow for this room
+     * (NO-SEAM, 2026-09-07 — replaces the flags-revision wait + refetch),
+     * updating [muted]/[pinned]/[archived] live (items 1/5). Runs while the
+     * thread — and the contact panel over it — is on screen (started on
+     * [onScreenShow], NOT stopped on [onScreenHide]); stops when the app
+     * backgrounds and dies with the ViewModel on back-navigation.
      */
     private var flagSyncJob: Job? = null
 
     fun startFlagSync() {
         if (flagSyncJob?.isActive == true) return
         flagSyncJob = viewModelScope.launch {
-            var lastFlags = 0L
-            while (true) {
-                val revision = ChatClient.waitForFlagChange(lastFlags)
-                if (revision == lastFlags) continue
-                lastFlags = revision
-                val flags = ChatClient.getRoomFlags(room.id) ?: continue
-                muted.value = flags.muted
-                pinned.value = flags.pinned
-                archived.value = flags.archived
-            }
+            MatrixRepository.roomFlags
+                .map { it[room.id] }
+                .distinctUntilChanged()
+                .collect { flags ->
+                    if (flags != null) {
+                        muted.value = flags.muted
+                        pinned.value = flags.pinned
+                        archived.value = flags.archived
+                    }
+                }
         }
     }
 
@@ -347,10 +359,13 @@ class ThreadViewModel(
      * reacts instantly instead of waiting on the 3 s poll. Entries drop once
      * a served page reflects the action; unsend failures revert and surface
      * [reactionError] (edit failures keep the composer open instead — the
-     * text survives for a retry).
+     * text survives for a retry). Process-wide (2026-09-07): the page cache
+     * can serve a pre-echo page after the ViewModel died (exit + re-enter),
+     * which reverted the row to its unedited body until the rebuild landed —
+     * the overlays now survive the round-trip like [threadStateCache].
      */
-    private val editOverlays = MutableStateFlow<Map<String, String>>(emptyMap())
-    private val unsentOverlays = MutableStateFlow<Set<String>>(emptySet())
+    private val editOverlays get() = editEchoCache.edits
+    private val unsentOverlays get() = editEchoCache.unsent
 
     /**
      * In-app volume panel state (null = hidden), the shared LightOS replica
@@ -486,39 +501,33 @@ class ThreadViewModel(
     }
 
     /**
-     * Quietly re-fetches the newest page while the thread stays visible
-     * (feedback pass): picks up the send echo and Beeper send-status events
-     * within a few seconds, with no spinner and no scroll jump. The server
-     * serves the cached newest page for the active room, so each poll is cheap.
+     * Newest-page updates while the thread stays visible, driven by the
+     * repository (NO-SEAM, 2026-09-07 — the page-revision long-poll is gone):
+     * every server-side page bump (new/edited/unsent events, receipt patches,
+     * pending echoes) emits [MatrixRepository.pageChanges] and the collector
+     * re-reads the served page in-process. No binder serialization, no poll
+     * delay — the merge is the same quiet [loadNewest] path the poll used.
      *
-     * Revision gate (2026-09-01, the Beeper comparison): the poll first asks
-     * the page's cheap revision and skips the [GetMessages] round trip while
-     * it hasn't moved — an open thread on a quiet room costs one tiny binder
-     * read every 3 s instead of a full page transfer. A playing voice note
-     * keeps the poll alive regardless: its position advances without any page
-     * change, and only a poll reads it back.
+     * A playing voice note keeps a tick: its position advances without any
+     * page change, and only a fetch reads it back.
      */
     private fun startPolling() {
         if (pollJob?.isActive == true) return
         pollJob = viewModelScope.launch {
-            // Seed with the revision the initial load reflected, so the first
-            // poll skips a page that hasn't moved since. The wait holds the
-            // binder call until the page revision moves or the window elapses
-            // (2026-09-06: replaced the fixed 1.5 s tick). A playing voice
-            // note keeps the short tick: its position advances without any
-            // page change, and only a poll reads it back.
-            var lastRevision = ChatClient.messagePageRevision(room.id)
-            while (true) {
-                if (playingEventId.value != null) {
-                    delay(THREAD_POLL_MS)
-                    lastRevision = ChatClient.messagePageRevision(room.id)
-                    loadNewest(quiet = true)
-                    continue
+            launch {
+                MatrixRepository.pageChanges.collect { roomId ->
+                    if (roomId == room.id) loadNewest(quiet = true)
                 }
-                val revision = ChatClient.waitForPageChange(room.id, lastRevision)
-                if (revision != lastRevision) {
-                    lastRevision = revision
-                    loadNewest(quiet = true)
+            }
+            launch {
+                while (true) {
+                    playingEventId.first { it != null } // wait for playback to start
+                    while (playingEventId.value != null) {
+                        delay(THREAD_POLL_MS)
+                        loadNewest(quiet = true)
+                    }
+                    // The fetch that cleared playingEventId already synced the
+                    // ended state; loop back to waiting.
                 }
             }
         }
@@ -575,8 +584,12 @@ class ThreadViewModel(
             if (!quiet && !restoreScroll) {
                 jumpToBottom.value = true
                 // Opening the thread marks it read up to the newest event; the
-                // room list's unread count drops on its next refresh.
-                val markEventId = loaded.lastOrNull()?.id ?: room.lastEventId ?: return@launch
+                // room list's unread count drops on its next refresh. Optimistic
+                // "local-…" rows are skipped — a receipt at a fake id never
+                // confirms and leaves the badge logic flapping (LP3 2026-09-07).
+                val markEventId = loaded.lastOrNull {
+                    !it.id.startsWith(LOCAL_ROW_PREFIX)
+                }?.id ?: room.lastEventId ?: return@launch
                 ChatClient.markRead(room.id, markEventId)
                 lastMarkedId = markEventId
             }
@@ -585,9 +598,11 @@ class ThreadViewModel(
             // arriving later (or the page catching up to the store's real
             // newest) would otherwise leave the room list's unread asterisk
             // up. Deduped via [lastMarkedId] — no RPC on ticks where nothing
-            // changed (feedback 2026-08-23).
+            // changed (feedback 2026-08-23). Local rows skipped (see above).
             if (quiet) {
-                val newestId = loaded.lastOrNull()?.id
+                val newestId = loaded.lastOrNull {
+                    !it.id.startsWith(LOCAL_ROW_PREFIX)
+                }?.id
                 if (newestId != null && newestId != lastMarkedId) {
                     lastMarkedId = newestId
                     ChatClient.markRead(room.id, newestId)

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -97,7 +97,7 @@ private const val MEDIA_PREFETCH_COUNT = 4
 /**
  * Process-wide display-JPEG cache, shared by every ThreadViewModel: a photo
  * fetched once renders instantly in later opens (same or other room) with no
- * re-fetch RPC (feedback 2026-08-23). Keyed by event id, which is globally
+ * re-fetch RPC. Keyed by event id, which is globally
  * unique.
  */
 private val chatsMediaCache = MutableStateFlow<Map<String, ByteArray>>(emptyMap())
@@ -107,7 +107,7 @@ private val chatsMediaCache = MutableStateFlow<Map<String, ByteArray>>(emptyMap(
  * [chatsMediaCache] and survive navigation; the decode does not — returning
  * from the fullscreen viewer re-enters the row's composition, and the
  * re-decode started from a null frame, flashing the "[Photo]" fallback before
- * the image popped back in (LP3 2026-08-23). Bounded: full-res photos decode
+ * the image popped back in. Bounded: full-res photos decode
  * to tens of MB, so only the most recent few are kept (eviction is
  * insertion-order, fine for a handful of photos; ponytail: LRU if the count
  * ever matters).
@@ -130,8 +130,8 @@ internal object chatsBitmapCache {
  * Loaded message pages + last scroll position per room id. The thread's
  * [ThreadViewModel] is recreated on every open, so paged-in history and the
  * scroll position were lost on exit — re-opening re-fetched the newest page
- * and re-paged from the server ("exit and come back, it has to load again",
- * LP3 2026-08-23). Kept process-wide (like [chatsMediaCache]) so a re-open
+ * and re-paged from the server ("exit and come back, it has to load again").
+ * Kept process-wide (like [chatsMediaCache]) so a re-open
  * renders the already-loaded history instantly and restores the position.
  * Room ids are server-scoped, so a different account can't collide.
  */
@@ -151,7 +151,7 @@ internal object threadStateCache {
 }
 
 /**
- * Process-wide optimistic edit/unsend overlays (2026-09-07): survives the
+ * Process-wide optimistic edit/unsend overlays: survives the
  * thread's ViewModel so an exit + re-enter inside the page-cache refresh
  * window keeps showing the edited body (see [ThreadViewModel]'s overlay doc).
  */
@@ -161,7 +161,7 @@ internal object editEchoCache {
 }
 
 /**
- * Resend-attempt counter per message id (2026-08-23): "not delivered. tap to
+ * Resend-attempt counter per message id: "not delivered. tap to
  * resend" caps at [MAX_RESEND_ATTEMPTS] — each tap sends the body as a NEW
  * message, so an endless loop would spam duplicates. The count propagates to
  * the resend's new row (the chain shares one number), so tapping the original
@@ -190,7 +190,7 @@ class ThreadViewModel(
     /**
      * Oldest-first page of messages; older pages are prepended by [loadOlder].
      * Process-wide per room ([threadStateCache]) — re-opening the thread keeps
-     * the already-loaded history instead of re-fetching it (2026-08-23).
+     * the already-loaded history instead of re-fetching it.
      */
     val messages = threadStateCache.messagesFlow(room.id)
     val loading = MutableStateFlow(true)
@@ -204,7 +204,7 @@ class ThreadViewModel(
     val roomEncrypted = MutableStateFlow(false)
 
     /**
-     * Mute state for the contact panel (2026-08-23): starts from the room
+     * Mute state for the contact panel: starts from the room
      * list's value and updates locally on toggle — the list re-fetch keeps the
      * server copy in sync, this keeps the panel honest within the session.
      */
@@ -218,7 +218,7 @@ class ThreadViewModel(
     }
 
     /**
-     * Pin state for the contact panel (2026-08-28): starts from the room
+     * Pin state for the contact panel: starts from the room
      * list's value and updates locally on toggle — same honest-within-session
      * pattern as [muted].
      */
@@ -232,7 +232,7 @@ class ThreadViewModel(
     }
 
     /**
-     * Archive state for the contact panel (2026-08-28): starts from the room
+     * Archive state for the contact panel: starts from the room
      * list's value and updates locally on toggle — same honest-within-session
      * pattern as [muted]. Archived rooms hide from the main list and go
      * silent, reachable only via search VIEW ALL.
@@ -247,9 +247,8 @@ class ThreadViewModel(
     }
 
     /**
-     * Keeps the contact panel honest with OTHER devices (LP3 feedback
-     * 2026-08-28): collects the repository's roomFlags flow for this room
-     * (NO-SEAM, 2026-09-07 — replaces the flags-revision wait + refetch),
+     * Keeps the contact panel honest with OTHER devices: collects the repository's roomFlags flow for this room
+     * (NO-SEAM — replaces the flags-revision wait + refetch),
      * updating [muted]/[pinned]/[archived] live (items 1/5). Runs while the
      * thread — and the contact panel over it — is on screen (started on
      * [onScreenShow], NOT stopped on [onScreenHide]); stops when the app
@@ -279,7 +278,7 @@ class ThreadViewModel(
     }
 
     /**
-     * Display JPEG bytes per image-message event id (Phase 13). This is a view
+     * Display JPEG bytes per image-message event id. This is a view
      * of the process-wide [chatsMediaCache] (event ids are globally unique), so
      * a photo already fetched in any thread renders instantly on re-open — no
      * re-fetch RPC — and each thread's poll just adds the new arrivals.
@@ -299,7 +298,7 @@ class ThreadViewModel(
     val pendingVoiceComponent = MutableStateFlow<String?>(null)
 
     /**
-     * Event id of the voice note playing in the companion (Phase 14). Fed by
+     * Event id of the voice note playing in the companion. Fed by
      * the poll's `audioPlayingEventId` and the local PlayVoiceNote response,
      * so the audio row shows its playing state without extra RPCs.
      */
@@ -317,14 +316,13 @@ class ThreadViewModel(
      * True until the poll anchors the counter after a play/resume tap: the
      * label holds the seeded position (pause point / 0:00) instead of running
      * on wall clock, which ran AHEAD of the companion while it spun the player
-     * up, then snapped back on the next poll — the "timer goes back" jump
-     * (feedback 2026-08-28). Cleared when the poll reports a live position.
+     * up, then snapped back on the next poll — the "timer goes back" jump.
+     * Cleared when the poll reports a live position.
      */
     val counterPending = MutableStateFlow(true)
 
     /**
-     * Event id + position of a voice note PAUSED in the companion (feedback
-     * 2026-08-27). The paused row keeps showing the pause point instead of the
+     * Event id + position of a voice note PAUSED in the companion. The paused row keeps showing the pause point instead of the
      * full length, and resume starts from it — no 00:00 flash, no bounce back
      * up when the next poll lands. The server holds the real pause state;
      * this is the tool's display mirror.
@@ -334,13 +332,12 @@ class ThreadViewModel(
 
     /**
      * (eventId, message) of a voice-note playback that failed to fetch/play —
-     * the row shows the error briefly instead of a silent no-op (feedback
-     * 2026-08-19). Cleared after a few seconds.
+     * the row shows the error briefly instead of a silent no-op. Cleared after a few seconds.
      */
     val voiceError = MutableStateFlow<Pair<String, String>?>(null)
 
     /**
-     * Phase B (2026-09-03) reactions. Per-event overlay over the served
+     * Phase B reactions. Per-event overlay over the served
      * reaction tags — reaction key → true = own reaction added, false =
      * suppressed — so the tag appears/disappears instantly instead of waiting
      * on the 3 s poll. Entries drop once a served page reflects the action; a
@@ -353,13 +350,13 @@ class ThreadViewModel(
     val reactionError = MutableStateFlow<Pair<String, String>?>(null)
 
     /**
-     * Phase C (2026-09-03) message overlays, same pattern as the reaction
+     * Phase C message overlays, same pattern as the reaction
      * overlays: per-event optimistic edits (eventId → new body) and unsends
      * (eventId set → tombstone), applied after the page maps in so the row
      * reacts instantly instead of waiting on the 3 s poll. Entries drop once
      * a served page reflects the action; unsend failures revert and surface
      * [reactionError] (edit failures keep the composer open instead — the
-     * text survives for a retry). Process-wide (2026-09-07): the page cache
+     * text survives for a retry). Process-wide: the page cache
      * can serve a pre-echo page after the ViewModel died (exit + re-enter),
      * which reverted the row to its unedited body until the rebuild landed —
      * the overlays now survive the round-trip like [threadStateCache].
@@ -369,7 +366,7 @@ class ThreadViewModel(
 
     /**
      * In-app volume panel state (null = hidden), the shared LightOS replica
-     * (feedback 2026-08-30): while a voice note is playing/paused the volume
+     * replica: while a voice note is playing/paused the volume
      * rocker shows this panel instead of LightOS's (which is ringer-only for
      * third-party tools). The bar level is cached and stepped locally; the
      * server adjusts the real media stream (see ServerBootstrapProvider).
@@ -437,9 +434,9 @@ class ThreadViewModel(
     /**
      * Thread scroll position, saved continuously by the screen and restored on
      * show — returning from the fullscreen photo viewer must land where the
-     * photo was, not the newest messages (feedback 2026-08-20). Persisted
+     * photo was, not the newest messages. Persisted
      * process-wide ([threadStateCache]) so a full re-open of the thread also
-     * lands where the user left off (2026-08-23).
+     * lands where the user left off.
      */
     private var savedScrollIndex = threadStateCache.takeScroll(room.id)?.first ?: 0
     private var savedScrollOffset = threadStateCache.takeScroll(room.id)?.second ?: 0
@@ -464,7 +461,7 @@ class ThreadViewModel(
         viewModelScope.launch { ChatClient.setActiveRoom(room.id) }
         // Returning from the fullscreen photo viewer restores the scroll
         // position instead of bouncing to the newest; a fresh open jumps to
-        // the newest as before (feedback 2026-08-20).
+        // the newest as before.
         val restore = if (savedScrollIndex > 0 || savedScrollOffset > 0) {
             savedScrollIndex to savedScrollOffset
         } else null
@@ -487,7 +484,7 @@ class ThreadViewModel(
         super.onScreenHide(screen)
         // Message polling stops when covered (e.g. the contact panel), but the
         // flag sync deliberately keeps running — the panel needs Beeper-side
-        // pin/mute/archive changes live (LP3 feedback 2026-08-28).
+        // pin/mute/archive changes live.
         stopPolling()
     }
 
@@ -502,12 +499,11 @@ class ThreadViewModel(
 
     /**
      * Newest-page updates while the thread stays visible, driven by the
-     * repository (NO-SEAM, 2026-09-07 — the page-revision long-poll is gone):
+     * repository (NO-SEAM — the page-revision long-poll is gone):
      * every server-side page bump (new/edited/unsent events, receipt patches,
      * pending echoes) emits [MatrixRepository.pageChanges] and the collector
      * re-reads the served page in-process. No binder serialization, no poll
      * delay — the merge is the same quiet [loadNewest] path the poll used.
-     *
      * A playing voice note keeps a tick: its position advances without any
      * page change, and only a fetch reads it back.
      */
@@ -541,15 +537,14 @@ class ThreadViewModel(
     fun loadNewest(quiet: Boolean = false, restoreScroll: Boolean = false) {
         // Serialize: rapid sends + the 3 s poll can otherwise interleave
         // read-modify-write merges on [messages] — a cluster showed rows
-        // duplicating and jumping until every send had echoed (feedback
-        // 2026-08-20). A newer call supersedes an in-flight one.
+        // duplicating and jumping until every send had echoed. A newer call supersedes an in-flight one.
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
             if (!quiet) loading.value = true
             var loaded: List<LightServiceMethod.GetMessages.Message>
             try {
                 val page = ChatClient.getMessages(room.id, null, PAGE_SIZE)
-                // Reaction overlay (Phase A): drop entries the served page now
+                // Reaction overlay: drop entries the served page now
                 // reflects, then ride the rest on top — the heart (dis)appears
                 // instantly after a toggle instead of waiting on this poll.
                 var fetched = page?.messages.orEmpty()
@@ -577,8 +572,7 @@ class ThreadViewModel(
                 }
             } finally {
                 // A binder exception mid-fetch must not leave the thread stuck on
-                // "Loading messages…" (feedback 2026-08-19: a send + quick exit +
-                // re-enter could wedge it) — the flag always clears.
+                // "Loading messages…" — the flag always clears.
                 if (!quiet) loading.value = false
             }
             if (!quiet && !restoreScroll) {
@@ -586,7 +580,7 @@ class ThreadViewModel(
                 // Opening the thread marks it read up to the newest event; the
                 // room list's unread count drops on its next refresh. Optimistic
                 // "local-…" rows are skipped — a receipt at a fake id never
-                // confirms and leaves the badge logic flapping (LP3 2026-09-07).
+                // confirms and leaves the badge logic flapping.
                 val markEventId = loaded.lastOrNull {
                     !it.id.startsWith(LOCAL_ROW_PREFIX)
                 }?.id ?: room.lastEventId ?: return@launch
@@ -598,7 +592,7 @@ class ThreadViewModel(
             // arriving later (or the page catching up to the store's real
             // newest) would otherwise leave the room list's unread asterisk
             // up. Deduped via [lastMarkedId] — no RPC on ticks where nothing
-            // changed (feedback 2026-08-23). Local rows skipped (see above).
+            // changed. Local rows skipped (see above).
             if (quiet) {
                 val newestId = loaded.lastOrNull {
                     !it.id.startsWith(LOCAL_ROW_PREFIX)
@@ -633,13 +627,12 @@ class ThreadViewModel(
      * haven't echoed yet. A real event replaces its optimistic row by id; a
      * "local-…" row (no event id known at send time) is dropped when a real
      * message with the same body and a close timestamp appears.
-     *
      * The result is deduped by id, then confirmed rows are time-sorted while
      * still-pending rows stay newest in send order, so a cluster of sends
      * stays in order while the echoes land one poll at a time — without it,
      * an echo arriving out of order (or a fast-page → full-page transition
      * leaving a stale optimistic copy at the oldest end) visibly shuffled and
-     * duplicated the rows until every send had echoed (feedback 2026-08-20).
+     * duplicated the rows until every send had echoed.
      */
     private fun mergeWithPending(loaded: List<LightServiceMethod.GetMessages.Message>):
         List<LightServiceMethod.GetMessages.Message> {
@@ -669,7 +662,7 @@ class ThreadViewModel(
         // Pending rows (still in [pendingMessages]) keep their send order and
         // stay newest: their timestamps are device-clock, while the confirmed
         // echoes carry server-clock stamps — mixing them sorted the first
-        // message of a burst below its own echoes (feedback 2026-08-23).
+        // message of a burst below its own echoes.
         // "local-…" rows are always pending; a fast-acked optimistic row with
         // a real event id is too, until the served page replaces it. The
         // confirmed sort is stable, so equal timestamps keep their order.
@@ -719,19 +712,17 @@ class ThreadViewModel(
     }
 
     /**
-     * Toggles playback of a voice note in the companion (Phase 14). The local
+     * Toggles playback of a voice note in the companion. The local
      * state flips immediately so the row reacts; the response and the poll's
      * `audioPlayingEventId` keep it accurate as playback finishes. A fetch or
-     * playback failure surfaces on the row instead of a silent no-op
-     * (feedback 2026-08-19).
+     * playback failure surfaces on the row instead of a silent no-op.
      */
     fun playVoiceNote(eventId: String) {
         val toggling = playingEventId.value == eventId
         val resuming = !toggling && pausedEventId.value == eventId
         when {
             // Tap the playing row → PAUSE: hold the interpolated position so
-            // the row shows the pause point while paused, not the full length
-            // (feedback 2026-08-27).
+            // the row shows the pause point while paused, not the full length.
             toggling -> {
                 pausedEventId.value = eventId
                 // While the counter is unanchored (player still spinning up),
@@ -750,8 +741,7 @@ class ThreadViewModel(
             // bounces when the next poll reports the real position. The
             // counter stays FROZEN at the seed until the poll anchors it —
             // counting on wall clock before the companion's player is up runs
-            // ahead, and the poll then jumps the label BACK (feedback
-            // 2026-08-28: "the timer goes back 2 seconds").
+            // ahead, and the poll then jumps the label BACK.
             resuming -> {
                 val resumeFrom = pausedPositionMs.value
                 pausedEventId.value = null
@@ -764,7 +754,7 @@ class ThreadViewModel(
             // A NEW note starts at 0:00 — the position state still holds the
             // previous note's last polled value, which otherwise showed a
             // stale "random" position for a beat until the first poll landed
-            // and snapped it to 0 (feedback 2026-08-23). Frozen at 0:00 until
+            // and snapped it to 0. Frozen at 0:00 until
             // the poll anchors, like resume.
             else -> {
                 pausedEventId.value = null
@@ -800,9 +790,9 @@ class ThreadViewModel(
     }
 
     /**
-     * Double-tap like (Phase A, 2026-09-03): Beeper semantics — double-tap
+     * Double-tap like: Beeper semantics — double-tap
      * REPLACES the user's current reaction with the ❤️ (not add alongside,
-     * LP3 feedback 2026-09-03); a second double-tap removes it. Own rows
+     * it); a second double-tap removes it. Own rows
      * never react (nothing to like back — restraint).
      */
     fun toggleLike(message: LightServiceMethod.GetMessages.Message) {
@@ -813,7 +803,7 @@ class ThreadViewModel(
 
     /**
      * Toggles the signed-in user's [key] reaction on a RECEIVED message
-     * (Phase B, 2026-09-03 — the context window's emoji grid): send when
+     * (Phase B — the context window's emoji grid): send when
      * absent, unsend when present. The optimistic overlay flips the tag
      * immediately (the 3 s poll is too slow); a failed RPC reverts it and
      * shows the quiet row error (the voice-note error pattern). Own rows
@@ -823,7 +813,7 @@ class ThreadViewModel(
         if (message.isMine || message.id.startsWith(LOCAL_ROW_PREFIX)) return
         // The toggle must see its own optimistic overlay: a quick re-tap before
         // the poll catches up reads the overlay's target state, not the stale
-        // served page (LP3 feedback 2026-09-03: re-tapping kept SENDING hearts).
+        // served page.
         val overlayKeys = reactionOverlays.value[message.id]
         val ownPresent = if (overlayKeys != null && key in overlayKeys) {
             overlayKeys.getValue(key)
@@ -863,7 +853,7 @@ class ThreadViewModel(
 
     /**
      * Sets the signed-in user's sole reaction on a RECEIVED message to [key]
-     * (Phase B, 2026-09-03 — the context window's LIKE MESSAGE / REACT /
+     * (Phase B — the context window's LIKE MESSAGE / REACT /
      * EDIT REACTION rows, one own reaction at a time, replace semantics):
      * unsends any existing own reaction(s) and sends [key]. Optimistic
      * overlay for both directions; only a failed SEND rolls the new key back
@@ -948,7 +938,7 @@ class ThreadViewModel(
     }
 
     /**
-     * Applies a completed edit optimistically (Phase C, 2026-09-03): the row
+     * Applies a completed edit optimistically: the row
      * shows the new body at once, the "edited" tag arrives with the echo. The
      * overlay drops when a served page carries the edited body
      * ([dropReflectedOverlays]). An edit RPC that fails never reaches here —
@@ -960,7 +950,7 @@ class ThreadViewModel(
     }
 
     /**
-     * Unsends an own message (Phase C, 2026-09-03 — the context window's
+     * Unsends an own message (Phase C — the context window's
      * UNSEND row, behind the confirm panel): the row becomes the
      * tombstone instantly via the overlay; a failed RPC reverts it and
      * surfaces the quiet row error (the reaction pattern). The overlay drops
@@ -1070,12 +1060,11 @@ class ThreadViewModel(
 
     /**
      * Re-sends a bridge-reported delivery failure as a NEW message (tap on a
-     * "not delivered. tap to resend" row, 2026-08-23): the event already left
+     * "not delivered. tap to resend" row): the event already left
      * the device, so there's no txn to retry — the same body goes out through
      * the normal send path (like the composer) and the poll swaps in the echo.
      * Capped at [MAX_RESEND_ATTEMPTS] per chain — each resend is a new
-     * message, so an endless loop would spam duplicates (feedback 2026-08-23:
-     * "only try twice, then just show 'failed to deliver'").
+     * message, so an endless loop would spam duplicates.
      */
     fun resendAsNew(message: LightServiceMethod.GetMessages.Message) {
         if (message.body.isBlank()) return
@@ -1133,21 +1122,17 @@ class ThreadViewModel(
                     // No sort here — pagination cursors and merge boundaries are
                     // position-based, and in rooms with non-monotonic timestamps
                     // (re-import batches) a ts-sort moved the oldest row off the
-                    // chain edge, dead-ending older-page fetches (feedback
-                    // 2026-08-23: "scroll up doesn't refresh, nothing older").
+                    // chain edge, dead-ending older-page fetches.
                     // Overlays ride on the merged list too — a reaction tapped
                     // on a row that only exists in paged history must flip the
-                    // tag here, not only on the newest page (LP3 2026-09-04:
-                    // reacting to an older message looked like a no-op).
+                    // tag here, not only on the newest page.
                     val merged = (older + messages.value).distinctBy { it.id }
                     dropReflectedOverlays(merged)
                     messages.value = applyMessageOverlays(applyReactionOverlays(merged))
                 }
                 hasMore.value = page?.hasMore ?: hasMore.value
             } finally {
-                // A binder failure must not wedge pagination (feedback
-                // 2026-08-19: an exception here left loadingMore stuck, so
-                // older messages never loaded again).
+                // A binder failure must not wedge pagination.
                 loadingMore.value = false
             }
         }
@@ -1203,7 +1188,7 @@ private fun ownReactionKeys(message: LightServiceMethod.GetMessages.Message): Li
         .map { it.removePrefix(OWN_REACTION_TAG_PREFIX) }
 
 /**
- * Max tap-to-resend attempts per message chain (2026-08-23): each resend is a
+ * Max tap-to-resend attempts per message chain: each resend is a
  * NEW message, so past this the row shows a static "failed to deliver" instead
  * of offering another duplicate.
  */
@@ -1211,7 +1196,7 @@ private const val MAX_RESEND_ATTEMPTS = 2
 
 /**
  * Failed messages older than this show a static "failed to deliver" — a stale
- * bridge FAIL isn't worth another duplicate send (feedback 2026-08-23: 4 h).
+ * bridge FAIL isn't worth another duplicate send.
  */
 private const val RESEND_MAX_AGE_MS = 4L * 60 * 60 * 1000
 
@@ -1243,12 +1228,12 @@ class ThreadScreen(
         val pausedPositionMs by viewModel.pausedPositionMs.collectAsState()
         val voiceError by viewModel.voiceError.collectAsState()
         val reactionError by viewModel.reactionError.collectAsState()
-        // Context window (Phase B, 2026-09-03): the long-pressed message
-        // (null = the panel is hidden). Phase C adds the own-message path:
-        // UNSEND parks its target here for the confirm panel.
+        // Context window: the long-pressed message
+        // (null = the panel is hidden). Own rows (EDIT / UNSEND) park their
+        // target here for the confirm panel.
         var contextMessage by remember { mutableStateOf<LightServiceMethod.GetMessages.Message?>(null) }
         var unsendConfirm by remember { mutableStateOf<LightServiceMethod.GetMessages.Message?>(null) }
-        // SAVE from the context window (LP3 feedback 2026-09-03, image rows):
+        // SAVE from the context window (image rows):
         // the same save + confirm flow as the fullscreen viewer's bottom bar.
         val contextScope = rememberCoroutineScope()
         var saveConfirm by remember { mutableStateOf<Boolean?>(null) }
@@ -1265,8 +1250,7 @@ class ThreadScreen(
         // Restore the saved position at FIRST composition (the initial-params
         // overload): returning from the fullscreen photo viewer otherwise
         // created the list at the bottom and the post-composition scroll
-        // landed a frame late, flashing the newest messages first (feedback
-        // 2026-08-23). takeScrollToRestore is consume-once, so the restore
+        // landed a frame late, flashing the newest messages first. takeScrollToRestore is consume-once, so the restore
         // effect below no-ops on this path; a fresh open (0,0) keeps the
         // jump-to-bottom behavior.
         val initialRestore = viewModel.takeScrollToRestore()
@@ -1306,26 +1290,21 @@ class ThreadScreen(
 
         // An empty page in an encrypted room means the stored events couldn't
         // be decrypted — unverified device, or a fresh login whose key requests
-        // haven't landed (LP3 2026-08-29: threads that were full before a
-        // logout/login read "No messages yet." — the server flags the page via
-        // MessagesPage.encrypted when an encrypted room's events all stayed
-        // undecryptable). Say so instead of lying about being empty.
+        // haven't landed. Say so instead of lying about being empty.
         val needsDecryptionNotice = roomEncrypted && messages.isEmpty()
 
-        // Status tag under our newest send (2026-09-06): "seen" under the
+        // Status tag under our newest send: "seen" under the
         // newest outgoing message the other party actually read (m.read
         // receipt or Beeper READ status), "delivered" under our newest send
         // carrying a real DELIVERED status (bridge SUCCESS +
         // delivered_to_users — MatrixRepository maps it; no synthetic
-        // "delivered" off a stopped SENDING spinner, the lie that got the tag
-        // dropped 2026-08-30). The tag tracks the LATEST message: delivered
+        // "delivered" off a stopped SENDING spinner). The tag tracks the LATEST message: delivered
         // there, flipped to "seen" once the read position reaches it. When
         // the read position is still behind the newest send, delivered wins —
-        // the seen-behind position marker (2026-09-03) only survives as the
+        // the seen-behind position marker only survives as the
         // fallback when there's no delivery evidence (plain Matrix rooms).
         // The list is oldest-first, so the last match is the newest.
-        // Placement rules (2026-09-03 feedback, tag only earns its place when
-        // it adds information): the contact's reply being the thread's newest
+        // Placement rules: the contact's reply being the thread's newest
         // drops both tags — a reply itself says "read everything" — except
         // "seen" stays when the read position is behind our newest send
         // (marks how far they got). No evidence → no tag. Groups get no tag
@@ -1346,7 +1325,7 @@ class ThreadScreen(
         // Infinite scroll + scroll-bar metrics, polled rather than
         // snapshotFlow-driven: in this Compose version reads of
         // LazyListState.layoutInfo don't invalidate snapshotFlow/derivedStateOf
-        // on every scroll (verified 2026-08-15), so a snapshotFlow trigger
+        // on every scroll, so a snapshotFlow trigger
         // never fired — the list sat at its top with older messages one page
         // away and "older messages don't load". The poll reads the real layout
         // info each tick; the loadOlder condition is index-exact (the topmost
@@ -1379,14 +1358,14 @@ class ThreadScreen(
                         icon = LightIcons.BACK,
                         // Pop with a Unit result so the caller's navigateTo
                         // callback fires — a thread opened via search then
-                        // closes the search on back, landing on the main list
-                        // (feedback 2026-08-22). Callers without a callback
+                        // closes the search on back, landing on the main list.
+                        // Callers without a callback
                         // are no-ops.
                         onClick = { goBack(Unit) },
                         contentDescription = "Back to chats",
                     ),
                     // Tapping the room name opens the contact overlay
-                    // (feedback 2026-08-21) — in a 1:1 it's the other party's
+                    // in a 1:1 it's the other party's
                     // identifier (their Matrix ID localpart = the bridge UID:
                     // a phone number on WhatsApp, a username on Instagram).
                     center = LightTopBarCenter.Text(
@@ -1412,7 +1391,7 @@ class ThreadScreen(
                             )
                             // Messages grouped by time gap / sender / day (the
                             // day tag lives on the group-start timestamp —
-                            // feedback 2026-08-21: the centered day dividers
+                            // the centered day dividers
                             // were removed); display order is newest-first
                             // because reverseLayout puts index 0 at the bottom.
                             val rows = remember(messages) { buildThreadRows(messages) }
@@ -1499,16 +1478,14 @@ class ThreadScreen(
                         }
                     }
                     // A tap on the free area between the top bar and the panel
-                    // dismisses it (LP3 feedback 2026-09-03) — an invisible
+                    // dismisses it — an invisible
                     // scrim over that band only (last child of this Box, drawn
                     // over the rows): top-padded clear of the top bar (back +
                     // room name stay tappable) and ending at the panel's top
-                    // edge, so taps on the panel itself never dismiss (LP3
-                    // feedback 2026-09-03 — the panel background doesn't
-                    // consume taps, a fullscreen scrim caught them).
+                    // edge, so taps on the panel itself never dismiss.
                     if (contextTarget != null) {
                         // Tap-away dismiss buzzes like every other panel
-                        // dismissal (LP3 feedback 2026-09-03), gated by the
+                        // dismissal, gated by the
                         // same LocalHapticsEnabled the rows read.
                         val scrimHaptic = LocalHapticFeedback.current
                         val scrimHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
@@ -1533,7 +1510,7 @@ class ThreadScreen(
                     modifier = Modifier.navigationBarsPadding(),
                     items = listOf(
                         // Record a voice note — bottom left, like the built-in
-                        // Messages app's layout (Phase 14). Opens the
+                        // Messages app's layout. Opens the
                         // companion's recording activity.
                         LightBarButton.LightIcon(
                             icon = LightIcons.MICROPHONE,
@@ -1542,7 +1519,7 @@ class ThreadScreen(
                         ),
                         // Attach a photo — bottom middle, like the built-in
                         // Messages app's add slot. Opens the system photo
-                        // picker via the companion (Phase 13).
+                        // picker via the companion.
                         LightBarButton.LightIcon(
                             icon = LightIcons.ADD,
                             onClick = { viewModel.attachPhoto() },
@@ -1556,10 +1533,10 @@ class ThreadScreen(
                     ),
                 )
             }
-            // Context window (Phase B, 2026-09-03): the long-pressed message's
+            // Context window: the long-pressed message's
             // panel over the bottom half — received rows get LIKE MESSAGE /
             // REACT (+ EDIT/REMOVE REACTION once a reaction exists); own rows
-            // get EDIT / UNSEND (Phase C, gated per row by
+            // get EDIT / UNSEND (gated per row by
             // the bridge caps). Actions act on the freshest polled snapshot
             // so own-reaction detection never runs on a stale page. Rendered
             // before the volume panel so the volume panel stays on top of
@@ -1573,7 +1550,7 @@ class ThreadScreen(
                 onEdit = { contextTarget?.let { openComposer(it) } },
                 onUnsend = { contextTarget?.let { unsendConfirm = it } },
                 // SAVE (image rows only — the context window's image addition,
-                // LP3 feedback 2026-09-03): the same server-side save the
+                // addition): the same server-side save the
                 // fullscreen viewer's SAVE PHOTO runs, confirming with the
                 // same panel (below).
                 onSave = contextTarget
@@ -1581,9 +1558,7 @@ class ThreadScreen(
                     ?.let { target ->
                         {
                             contextScope.launch {
-                                // The panel stays up while the save round-trips
-                                // (LP3 feedback 2026-09-03: it used to vanish
-                                // first, then the confirmation appeared); the
+                                // The panel stays up while the save round-trips; the
                                 // confirm replaces it, and clearing the target
                                 // then drops the panel behind the modal.
                                 saveConfirm = ChatClient.saveMessageImage(room.id, target.id)
@@ -1595,7 +1570,7 @@ class ThreadScreen(
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
             }
-            // The save confirmation (LP3 feedback 2026-09-03): the same
+            // The save confirmation: the same
             // fullscreen-panel grammar as the viewer's, auto-dismissing after
             // 2 s so a tap isn't needed.
             saveConfirm?.let { ok ->
@@ -1608,7 +1583,7 @@ class ThreadScreen(
                     onClose = { saveConfirm = null },
                 )
             }
-            // Unsend confirmation (Phase C, 2026-09-03): one accidental
+            // Unsend confirmation: one accidental
             // long-press must not nuke a message — the same fullscreen-panel
             // grammar as the photo viewer's save confirm.
             unsendConfirm?.let { target ->
@@ -1635,8 +1610,7 @@ class ThreadScreen(
         // from the fullscreen photo viewer restores the position at first
         // composition (the list state's initial params above) — the
         // takeScrollToRestore here is the consume-once guard, so that path
-        // never re-scrolls or jumps to the bottom (feedback 2026-08-20/
-        // 2026-08-23); the jumpToBottom key keeps the effect re-firing when
+        // never re-scrolls or jumps to the bottom; the jumpToBottom key keeps the effect re-firing when
         // the flag flips after the load.
         LaunchedEffect(jumpToBottom, messages.size) {
             if (messages.isEmpty()) return@LaunchedEffect
@@ -1684,7 +1658,7 @@ class ThreadScreen(
                         ),
                     )
                 } else {
-                    // Phase C edit: the row shows the new body instantly via
+                    // Edit: the row shows the new body instantly via
                     // the overlay; the poll's served page drops it once the
                     // edit echo lands.
                     viewModel.applyEditEcho(result.id, result.body)
@@ -1695,7 +1669,7 @@ class ThreadScreen(
     }
 
     /**
-     * The contact overlay (feedback 2026-08-21): the identifier line is the
+     * The contact overlay: the identifier line is the
      * bridge UID when it IS the number/username — see [contactIdentifier].
      */
     private fun openContact() {
@@ -1729,7 +1703,7 @@ private const val DECRYPTION_NOTICE_KEYS_PENDING =
     "Encrypted — history can't be read yet, keys from your other devices are pending (Settings → Account → Verify Device)"
 
 /**
- * The unsend confirmation (Phase C, 2026-09-03). LP3 feedback 2026-09-03: the
+ * The unsend confirmation. LP3: the
  * question reads big, the message previews under it (3 lines, ellipsized), the
  * destructive action sits alone in the bottom bar, and back (<, top left)
  * cancels — the composer's navigation grammar, not a modal.
@@ -1798,13 +1772,12 @@ private fun DecryptionNotice(text: String) {
     )
 }
 
-/** One row of the thread: a message (Phase 9). [showTime]: whether this
+/** One row of the thread: a message. [showTime]: whether this
  *  message starts a group (a new day, a different sender, or a gap of
  *  [GROUP_WINDOW_MS] from the previous message) — the only messages that
- *  carry a timestamp (feedback pass). The timestamp itself carries the day tag
+ *  carry a timestamp. The timestamp itself carries the day tag
  *  ("Yesterday", weekday, "Aug 12") when the message isn't from today
- *  (feedback 2026-08-21: day tags on the message timestamps replaced the
- *  centered day dividers). */
+ */
 private data class ThreadRow(
     val message: LightServiceMethod.GetMessages.Message,
     val showTime: Boolean,
@@ -1849,10 +1822,8 @@ private const val GROUP_WINDOW_MS = 15 * 60 * 1000L
  * line (measured without a width cap, then clipped to the message column's
  * max width), so the block hugs the text instead of the full column — a long
  * unbreakable word (a URL, an email address) no longer collapses the block to
- * the width of the short line before it (feedback 2026-08-22: "But CC in
- * hello@berlinscenelab.com" rendered as a narrow column because line 1 broke
- * at the long word). The block never exceeds the column cap, so no line spans
- * edge to edge (feedback 2026-08-17).
+ * the width of the short line before it. The block never exceeds the column cap, so no line spans
+ * edge to edge.
  */
 @Composable
 private fun OutgoingBodyText(body: String, maxWidthPx: Int) {
@@ -1875,7 +1846,7 @@ private fun OutgoingBodyText(body: String, maxWidthPx: Int) {
         }
         // Round UP: the box must be at least as wide as a line's last word —
         // a sub-pixel shortfall flips the wrap and drops the word to line 2,
-        // leaving the gap on the top line (verified on-device 2026-08-17).
+        // leaving the gap on the top line.
         val w = minOf(ceil(widestPx), maxWidthPx.toFloat())
         with(density) { w.toFloat().toDp() }
     }
@@ -1912,7 +1883,7 @@ private fun MessageRow(
     onOpenContext: (LightServiceMethod.GetMessages.Message) -> Unit,
     onOpenImage: (ByteArray) -> Unit,
 ) {
-    // Phase 13: a buffer keeps message text off the far screen edge. Outgoing
+    // A buffer keeps message text off the far screen edge. Outgoing
     // messages sit on the right and incoming on the left — the built-in Phone
     // app's layout — each capped at ~7/8 of the row width so long text never
     // spans edge to edge.
@@ -1933,9 +1904,8 @@ private fun MessageRow(
     ) {
         // Bridge system messages (m.notice: "Turned off disappearing
         // messages", timer-set notices, …) are a quiet centered small line —
-        // not a normal message from the contact (2026-08-22). Solid white,
-        // like the timestamps/labels: hierarchy from size, not dimming
-        // (feedback 2026-08-22: "no grey in the chats tool").
+        // not a normal message from the contact. Solid white,
+        // like the timestamps/labels: hierarchy from size, not dimming.
         if (message.contentType == "notice") {
             LightText(
                 text = message.body,
@@ -1945,15 +1915,15 @@ private fun MessageRow(
             )
             return@BoxWithConstraints
         }
-        // Tombstones (Phase C, 2026-09-03): the message was unsent (redacted).
+        // Tombstones: the message was unsent (redacted).
         // Rendered like a normal text row — same size and sender alignment,
         // "[Message unsent]" body, no reactions/status/gestures (the event is
         // gone for everyone). The old centered Superfine placeholder read as
-        // transient and out of place (LP3 feedback 2026-09-03). The gesture
+        // transient and out of place. The gesture
         // gate below requires contentType == "text", so tombstones stay inert.
         // The outgoing body's column cap (0.875 × the row content width):
         // outgoing text is measured against it so the block never spans the
-        // full row (feedback 2026-08-17); the block width itself comes from
+        // full row; the block width itself comes from
         // [OutgoingBodyText] (the widest line, capped here).
         val bodyMaxWidthPx = with(LocalDensity.current) {
             (maxWidth * MESSAGE_WIDTH_FRACTION).toPx().roundToInt()
@@ -1962,12 +1932,12 @@ private fun MessageRow(
         val failed = message.sendStatus?.startsWith("FAIL_") == true
         // Locally-failed rows (the outbox recorded a send error, txn still
         // pending) are tappable — tap re-sends the same transaction
-        // (2026-08-22). Bridge-reported FAIL_* text rows (real event id, no
+        // Bridge-reported FAIL_* text rows (real event id, no
         // txn to retry) re-send the same body as a NEW message instead
-        // (2026-08-23); non-text bridge failures stay a plain marker.
+        // Non-text bridge failures stay a plain marker.
         val retryable = failed && message.sendStatus == "FAIL_LOCAL_SEND" && inFlight
         val retryableNew = failed && !inFlight && message.contentType == "text" && message.body.isNotBlank()
-        // Resend budget per message chain (2026-08-23): after
+        // Resend budget per message chain: after
         // [MAX_RESEND_ATTEMPTS] — or once the message is older than
         // [RESEND_MAX_AGE_MS] — the row turns static "failed to deliver":
         // no more duplicate sends.
@@ -1980,7 +1950,7 @@ private fun MessageRow(
             modifier = Modifier
                 .fillMaxWidth(MESSAGE_WIDTH_FRACTION)
                 .align(if (message.isMine) Alignment.CenterEnd else Alignment.CenterStart)
-                // A locally-failed send re-sends when tapped (2026-08-22); the
+                // A locally-failed send re-sends when tapped; the
                 // tap target is the row's bubble area, like the image/audio
                 // rows' own clickables.
                 .then(
@@ -1990,15 +1960,15 @@ private fun MessageRow(
                         else -> Modifier
                     },
                 )
-                // Phase A (2026-09-03): double-tap a received TEXT row to like/
-                // unlike it; Phase B (2026-09-03): long-press opens the context
-                // window over the bottom half; Phase C (2026-09-03): OWN text
+                // Double-tap a received TEXT row to like/
+                // unlike it; long-press opens the context
+                // window over the bottom half; OWN text
                 // rows open it too (EDIT / UNSEND), when the
                 // bridge caps still allow either. `combinedClickable`/
                 // `lightClickable` can't do double-tap. Media rows carry their
                 // own gestures inside their content composables (image tap =
-                // viewer, voice-note tap = play, long-press = context window
-                // since LP3 feedback 2026-09-03) — the text gate stays text-
+                // viewer, voice-note tap = play, long-press = context window)
+                // — the text gate stays text-
                 // only; failed / in-flight rows keep their retry tap.
                 .then(
                     if (!failed && !inFlight && message.contentType == "text" &&
@@ -2008,13 +1978,11 @@ private fun MessageRow(
                         // key (the stable event id) doesn't change — without
                         // rememberUpdatedState the callbacks captured the
                         // first-composed row snapshot, so a toggle computed
-                        // against stale reactions re-SENT the like every time
-                        // (LP3 feedback 2026-09-03: double-tap unsend "just
-                        // sends more hearts").
+                        // against stale reactions re-SENT the like every time.
                         val gestureMessage by rememberUpdatedState(message)
-                        // LP3 feedback 2026-09-03 (the Phone tool's native
+                        // (the Phone tool's native
                         // half-panel grammar): NO vibration on finger-down —
-                        // the haptic fires on actual gestures. 2026-09-07: a
+                        // the haptic fires on actual gestures. A
                         // like double-tap buzzes on BOTH taps, so every clean
                         // tap buzzes (the same feel as the chat list's
                         // lightClickable) and the second tap inside the system
@@ -2041,8 +2009,7 @@ private fun MessageRow(
                                             // LongPress-type buzz (the app's
                                             // standard click feel) — the old
                                             // TextHandleMove tick was
-                                            // imperceptible on the LP3
-                                            // (LP3 feedback 2026-09-03).
+                                            // imperceptible on the LP3.
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         }
                                         val now = System.currentTimeMillis()
@@ -2073,12 +2040,12 @@ private fun MessageRow(
                     variant = LightTextVariant.Detail,
                 )
             }
-            // Feedback pass: only the first message of a group carries the time —
+            // Only the first message of a group carries the time —
             // consecutive same-sender messages within 15 minutes are combined
             // visually, while the sender/alignment stays on every message.
             // An IN-FLIGHT row shows "SENDING" even inside a group — the group
             // would otherwise hide the slot entirely, and the just-sent
-            // message must still be visibly pending (feedback 2026-08-17).
+            // message must still be visibly pending.
             // When the server confirms it, the served page swaps in the real
             // row: grouped → it merges under the shared timestamp; otherwise
             // it carries its own. A failed send shows its time, not SENDING.
@@ -2100,12 +2067,7 @@ private fun MessageRow(
             // companion and served as this flag. Outgoing TEXT rows lead with
             // the ↷ glyph (Subtitle) above the body with the word under it;
             // incoming text and MEDIA rows put the glyph beside the content
-            // with the word under it (feedback 2026-09-07: a forwarded photo
-            // used to sit under the tag row, reading disconnected from the
-            // glyph). Tight, lowercase, consistent with the other tags
-            // (feedback 2026-09-02: the marker used to sit in the body at
-            // full size with a blank line after it, reading like a separate
-            // message).
+            // with the word under it. Tight, lowercase, consistent with the other tags.
             if (message.forwarded && message.contentType == "text" && message.isMine) {
                 Row(
                     modifier = Modifier.padding(top = 1.dp, bottom = 1.dp),
@@ -2122,8 +2084,7 @@ private fun MessageRow(
                     )
                 }
             }
-            // Media rows open the context window on long-press (LP3 feedback
-            // 2026-09-03) — received rows always (LIKE/REACT [+ SAVE on
+            // Media rows open the context window on long-press — received rows always (LIKE/REACT [+ SAVE on
             // images]), own rows only while the bridge still allows an unsend
             // (canEdit never applies to media; otherwise no panel at all).
             val contextGesture = if (!message.isMine || message.canUnsend) {
@@ -2162,7 +2123,7 @@ private fun MessageRow(
                     // ink size) about the box center, which keeps the arrow
                     // centered on the body line: Subtitle's far taller line
                     // box carried the ink low and opened gaps above/below
-                    // (feedback 2026-09-02). The small "forwarded" word sits
+                    // The small "forwarded" word sits
                     // at the message's left edge under both.
                     Column(modifier = Modifier.padding(top = 1.dp)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -2183,8 +2144,7 @@ private fun MessageRow(
                     // Bridged call notices ("Incoming call. Use the WhatsApp
                     // app to answer." — Beeper's bridges can't relay calls, so
                     // the contact's ghost posts a plain m.text; the phone icon
-                    // marks the row as a call, like the built-in Phone tool
-                    // (feedback 2026-09-01).
+                    // marks the row as a call, like the built-in Phone tool.
                     Row(
                         modifier = Modifier.padding(top = 1.dp),
                         verticalAlignment = Alignment.CenterVertically,
@@ -2208,8 +2168,7 @@ private fun MessageRow(
                     )
                 }
                 // A video row carries its caption under the "[Video]" marker —
-                // the marker keeps the media context, the caption the content
-                // (feedback 2026-09-01).
+                // the marker keeps the media context, the caption the content.
                 message.caption?.let { caption ->
                     LightText(
                         text = caption,
@@ -2219,7 +2178,7 @@ private fun MessageRow(
                 }
             }
             // An edited message shows a quiet "edited" tag under the body
-            // (feedback 2026-08-27) — and since 2026-09-07 it shares one line
+            // and it shares one line
             // with the delivery/status tag ("edited · delivered"), same
             // grammar as the reactions separator; either alone renders as
             // before.
@@ -2236,10 +2195,9 @@ private fun MessageRow(
                         modifier = Modifier.padding(top = 1.dp),
                     )
                 }
-            // Phase 14: reactions, as a quiet tag under the message (same
+            // Reactions, as a quiet tag under the message (same
             // grammar as the "not delivered" marker). Each entry reads
             // "Name reacted with ❤️" (or "You reacted with …" for own) —
-            // feedback 2026-08-14.
             if (message.reactions.isNotEmpty()) {
                 LightText(
                     text = message.reactions.joinToString(" · "),
@@ -2249,9 +2207,9 @@ private fun MessageRow(
                     modifier = Modifier.padding(top = 1.dp),
                 )
             }
-            // Phase A: a reaction toggle that failed server-side reverted the
+            // A reaction toggle that failed server-side reverted the
             // optimistic tag — the quiet row error says so (same grammar as the
-            // voice-note error, feedback 2026-08-19).
+            // voice-note error).
             reactionError?.takeIf { it.first == message.id }?.let { error ->
                 LightText(
                     text = error.second,
@@ -2260,7 +2218,7 @@ private fun MessageRow(
                 )
             }
             // Beeper reports failed deliveries with a com.beeper.message_send_status
-            // event (Phase 10) — a quiet label beats a silent stall. The
+            // event — a quiet label beats a silent stall. The
             // thread poll surfaces it within seconds, no new send needed. It
             // shows on any message, old or new.
             if (message.isMine && failed) {
@@ -2268,8 +2226,8 @@ private fun MessageRow(
                     // A locally-failed row re-sends the same transaction when
                     // tapped; a bridge-reported text failure re-sends the body
                     // as a new message; non-text bridge failures have no resend
-                    // path (2026-08-23). A chain past [MAX_RESEND_ATTEMPTS]
-                    // turns static "failed to deliver" (feedback 2026-08-23).
+                    // path. A chain past [MAX_RESEND_ATTEMPTS]
+                    // turns static "failed to deliver".
                     text = when {
                         retryable -> "failed to send. tap to resend"
                         retryableNew && !resendExhausted -> "not delivered. tap to resend"
@@ -2278,8 +2236,7 @@ private fun MessageRow(
                     },
                     variant = LightTextVariant.Superfine,
                     // Solid white like the timestamps — the delivery labels
-                    // read like the rest of the message, not dimmed (feedback
-                    // 2026-08-21).
+                    // read like the rest of the message, not dimmed.
                     modifier = Modifier.padding(top = 1.dp),
                 )
             }
@@ -2291,7 +2248,7 @@ private fun MessageRow(
  *  ~2.1x (≈ the Subtitle ink size) about a pivot 0.72 down the line box —
  *  the ↷ falls back to Noto Sans Symbols, whose run sits low in the
  *  Paragraph line box; the pivot keeps the ink centered and the equal
- *  padding re-absorbs the scaled ink (feedback 2026-09-02). */
+ *  padding re-absorbs the scaled ink. */
 @Composable
 private fun ForwardedArrowGlyph() {
     LightText(
@@ -2307,8 +2264,7 @@ private fun ForwardedArrowGlyph() {
     )
 }
 
-/** Forwarded MEDIA rows (feedback 2026-09-07: the photo used to sit under
- *  the tag row, reading disconnected from the glyph): the ↷ glyph beside the
+/** Forwarded MEDIA rows: the ↷ glyph beside the
  *  content, the small "forwarded" word under it — the same grammar as
  *  forwarded incoming text. */
 @Composable
@@ -2349,11 +2305,11 @@ private fun ImageMessageContent(
     LaunchedEffect(message.id, allowMobile) { onEnsureMedia(message.id, allowMobile) }
     val bytes = mediaBytes[message.id]
     // Decode off the main thread: the in-composition decode blocked the UI
-    // thread's first paint for every visible photo (feedback 2026-08-23).
+    // thread's first paint for every visible photo.
     // The text fallback below renders until the bitmap lands. Seeded from the
     // process-wide [chatsBitmapCache]: returning from the fullscreen viewer
     // re-enters this composition, and re-decoding started from a null frame
-    // (a "[Photo]" flash before the image popped back in, LP3 2026-08-23).
+    // (a "[Photo]" flash before the image popped back in).
     val bitmap by produceState<ImageBitmap?>(chatsBitmapCache.get(message.id), bytes) {
         if (bytes != null && value == null) {
             value = withContext(Dispatchers.Default) {
@@ -2373,8 +2329,7 @@ private fun ImageMessageContent(
         // Still loading, or the media can't be fetched/decoded (e.g.
         // still-encrypted): fall back to the row text ("[Photo]" or the file
         // name). A failed/skipped fetch (no bytes) is worth one more tap —
-        // re-run it without leaving the thread (feedback 2026-09-01: RCS
-        // attachments time out). Decode failures (bytes but no bitmap) stay
+        // re-run it without leaving the thread. Decode failures (bytes but no bitmap) stay
         // dead text; re-fetching would not help.
         val bodyModifier =
             if (bytes == null) Modifier.lightClickable(onClick = { onEnsureMedia(message.id, allowMobile) })
@@ -2403,14 +2358,12 @@ private fun ImageMessageContent(
             // Sized to the photo's own aspect rather than stretched to the row
             // width: a tall photo caps at MAX_IMAGE_HEIGHT_DP and hugs the
             // sender's edge via the row's End/Start alignment — no centered
-            // side-bars beside portrait shots (feedback 2026-09-01).
+            // side-bars beside portrait shots.
             .heightIn(max = MAX_IMAGE_HEIGHT_DP)
             .padding(top = 1.dp)
-            // Tap opens the viewer; long-press opens the context window (LP3
-            // feedback 2026-09-03) — the old lightClickable tap-only target
+            // Tap opens the viewer; long-press opens the context window — the old lightClickable tap-only target
             // can't carry the long-press. The haptic fires on the trigger, not
-            // on finger-down (the Phone tool's half-panel grammar, LP3
-            // feedback 2026-09-03).
+            // on finger-down (the Phone tool's half-panel grammar).
             .pointerInput(Unit) {
                 detectTapGestures(
                     onTap = { currentOnOpenImage(bytes) },
@@ -2437,10 +2390,10 @@ private fun ImageMessageContent(
 }
 
 /** A voice-note row: a play/pause icon + label, tapped to toggle playback in
- *  the companion (Phase 14). The playing row shows its state via the poll's
+ *  the companion. The playing row shows its state via the poll's
  *  `audioPlayingEventId`, so the highlight survives message-list refreshes.
  *  A fetch/playback failure ([error]) shows briefly under the label instead of
- *  a silent no-op (feedback 2026-08-19). */
+ *  a silent no-op. */
 @Composable
 private fun AudioMessageContent(
     message: LightServiceMethod.GetMessages.Message,
@@ -2458,9 +2411,7 @@ private fun AudioMessageContent(
 ) {
     // While playing, refresh the interpolated position counter every second:
     // the position polls arrive every few seconds, and the label interpolates
-    // between them. (2026-08-22: the old `tick++` was never READ in
-    // composition, so the write never triggered recomposition — the label
-    // only advanced on each poll, i.e. in multi-second jumps.)
+    // between them.
     var nowMs by remember { mutableStateOf(android.os.SystemClock.elapsedRealtime()) }
     LaunchedEffect(playing) {
         while (playing) {
@@ -2476,7 +2427,7 @@ private fun AudioMessageContent(
             // position — the pause point on resume, 0:00 on a new note — until
             // the poll confirms the companion's real position. Counting on
             // wall clock here ran ahead of the companion and the next poll
-            // jumped the label BACK (feedback 2026-08-28).
+            // jumped the label BACK.
             val pos = if (counterPending) base else base + (nowMs - playingPositionAtMs)
             // Just the running position while playing (the row already showed
             // its length when idle).
@@ -2494,11 +2445,10 @@ private fun AudioMessageContent(
     val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
     Row(
         modifier = Modifier
-            // Tap toggles playback; long-press opens the context window (LP3
-            // feedback 2026-09-03) — detectTapGestures consumes the long-press
+            // Tap toggles playback; long-press opens the context window — detectTapGestures consumes the long-press
             // so it never falls through to a play. The haptic fires on the
             // trigger, not on finger-down (the Phone tool's half-panel
-            // grammar, LP3 feedback 2026-09-03).
+            // grammar).
             .pointerInput(Unit) {
                 detectTapGestures(
                     onTap = { currentOnTogglePlay() },
@@ -2543,7 +2493,7 @@ private fun formatDuration(ms: Long): String =
 
 /** Cap for the message block — long text never spans the full row width.
  *  The far-side buffer (the empty band on the message's outer side) is half
- *  of what it was: 25 % → 12.5 % (feedback 2026-08-17). Incoming text fills
+ *  of what it was: 25 % → 12.5 %. Incoming text fills
  *  this width; outgoing text is measured against it and blocks can be
  *  narrower — sized to the first line so the top line touches the right. */
 private const val MESSAGE_WIDTH_FRACTION = 0.875f

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -1314,7 +1314,14 @@ class ThreadScreen(
             val delivered = newestMine
                 ?.takeIf { it.sendStatus == "DELIVERED" && !replyIsNewest }
                 ?.let { it.id to "delivered" }
-            val tag = if (newestRead?.id == newestMine?.id) seen ?: delivered else delivered ?: seen
+            // "sent": the homeserver acked the send (outbox event id) but the
+            // sync echo hasn't replaced the pending row yet — Beeper's
+            // SENT_PENDING_SERVER_ECHO. Real DELIVERED/READ evidence outranks
+            // it; it beats the older-message "seen" fallback.
+            val sent = newestMine
+                ?.takeIf { it.sendStatus == "SENT_PENDING_ECHO" && !replyIsNewest }
+                ?.let { it.id to "sent" }
+            val tag = if (newestRead?.id == newestMine?.id) seen ?: delivered else delivered ?: sent ?: seen
             tag
         }
 

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -1163,15 +1163,15 @@ private const val LIKE_KEY = "❤️"
 
 /**
  * How the server tags the user's own reactions — the overlay strings must
- * match the served format exactly ("You reacted with $key").
+ * match the served format exactly ("You reacted $key").
  */
-private const val OWN_REACTION_TAG_PREFIX = "You reacted with "
+private const val OWN_REACTION_TAG_PREFIX = "You reacted "
 
 /**
  * The signed-in user's own reaction keys on [message], read from the served
  * tags (which already carry the optimistic overlay). Ceiling: the server's
- * collapseReactionTags can fold the own tag into an "X and others reacted
- * with …" merge, where this misses it — the same ceiling as the Phase A
+ * collapseReactionTags can fold the own tag into an "X and others
+ * reacted …" merge, where this misses it — the same ceiling as the Phase A
  * toggle.
  */
 private fun ownReactionKeys(message: LightServiceMethod.GetMessages.Message): List<String> =
@@ -1225,10 +1225,6 @@ class ThreadScreen(
         // target here for the confirm panel.
         var contextMessage by remember { mutableStateOf<LightServiceMethod.GetMessages.Message?>(null) }
         var unsendConfirm by remember { mutableStateOf<LightServiceMethod.GetMessages.Message?>(null) }
-        // SAVE from the context window (image rows):
-        // the same save + confirm flow as the fullscreen viewer's bottom bar.
-        val contextScope = rememberCoroutineScope()
-        var saveConfirm by remember { mutableStateOf<Boolean?>(null) }
         // The panel's target resolved against the freshest polled snapshot (so
         // own-reaction detection never runs on a stale page) — declared here,
         // before the list, because the in-list dismiss scrim gates on it.
@@ -1537,39 +1533,9 @@ class ThreadScreen(
                 onRemoveReaction = { contextTarget?.let { viewModel.removeReaction(it) } },
                 onEdit = { contextTarget?.let { openComposer(it) } },
                 onUnsend = { contextTarget?.let { unsendConfirm = it } },
-                // SAVE (image rows only — the context window's image addition,
-                // addition): the same server-side save the
-                // fullscreen viewer's SAVE PHOTO runs, confirming with the
-                // same panel (below).
-                onSave = contextTarget
-                    ?.takeIf { it.contentType == "image" }
-                    ?.let { target ->
-                        {
-                            contextScope.launch {
-                                // The panel stays up while the save round-trips; the
-                                // confirm replaces it, and clearing the target
-                                // then drops the panel behind the modal.
-                                saveConfirm = ChatClient.saveMessageImage(room.id, target.id)
-                                contextMessage = null
-                            }
-                        }
-                    },
                 onDismiss = { contextMessage = null },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
-            }
-            // The save confirmation: the same
-            // fullscreen-panel grammar as the viewer's, auto-dismissing after
-            // 2 s so a tap isn't needed.
-            saveConfirm?.let { ok ->
-                LaunchedEffect(ok) {
-                    delay(2_000)
-                    saveConfirm = null
-                }
-                LightFullscreenModal(
-                    message = if (ok) "Photo saved" else "Couldn't save photo",
-                    onClose = { saveConfirm = null },
-                )
             }
             // Unsend confirmation: one accidental
             // long-press must not nuke a message — the same fullscreen-panel
@@ -2182,7 +2148,7 @@ private fun MessageRow(
                 }
             // Reactions, as a quiet tag under the message (same
             // grammar as the "not delivered" marker). Each entry reads
-            // "Name reacted with ❤️" (or "You reacted with …" for own) —
+            // "Name reacted ❤️" (or "You reacted …" for own) —
             if (message.reactions.isNotEmpty()) {
                 LightText(
                     text = message.reactions.joinToString(" · "),

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -2004,22 +2004,30 @@ private fun MessageRow(
                         // sends more hearts").
                         val gestureMessage by rememberUpdatedState(message)
                         // LP3 feedback 2026-09-03 (the Phone tool's native
-                        // half-panel grammar): NO vibration on finger-down — the
-                        // haptic fires only when the gesture actually triggers,
-                        // the long press that opens the context window and the
-                        // second tap of a like. Gated by the same
-                        // LocalHapticsEnabled the SDK's lightClickable reads;
-                        // the SDK's context-based haptic helper is plugin-banned
-                        // in tool code, so this goes through Compose's haptic
-                        // API instead.
+                        // half-panel grammar): NO vibration on finger-down —
+                        // the haptic fires on actual gestures. 2026-09-07: a
+                        // like double-tap buzzes on BOTH taps, so every clean
+                        // tap buzzes (the same feel as the chat list's
+                        // lightClickable) and the second tap inside the system
+                        // double-tap window toggles the like. Compose's
+                        // onDoubleTap swallows the first tap's haptic — hence
+                        // the manual count. detectTapGestures reports taps only
+                        // on a clean up (no movement past the touch slop), so
+                        // scrolling never buzzes, same as the list. Gated by
+                        // the same LocalHapticsEnabled the SDK's lightClickable
+                        // reads; the SDK's context-based haptic helper is
+                        // plugin-banned in tool code, so this goes through
+                        // Compose's haptic API instead.
                         val haptic = LocalHapticFeedback.current
                         val currentHapticsEnabled by rememberUpdatedState(LocalHapticsEnabled.current)
                         Modifier
                             .pointerInput(message.id) {
+                                val doubleTapMs = viewConfiguration.doubleTapTimeoutMillis
+                                var lastTapMs = 0L
                                 detectTapGestures(
                                     // The like guards isMine itself (own rows never
                                     // react) — one gesture block serves both sides.
-                                    onDoubleTap = {
+                                    onTap = {
                                         if (currentHapticsEnabled) {
                                             // LongPress-type buzz (the app's
                                             // standard click feel) — the old
@@ -2028,7 +2036,13 @@ private fun MessageRow(
                                             // (LP3 feedback 2026-09-03).
                                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         }
-                                        onToggleLike(gestureMessage)
+                                        val now = System.currentTimeMillis()
+                                        if (now - lastTapMs < doubleTapMs) {
+                                            lastTapMs = 0L
+                                            onToggleLike(gestureMessage)
+                                        } else {
+                                            lastTapMs = now
+                                        }
                                     },
                                     onLongPress = {
                                         if (currentHapticsEnabled) {
@@ -2074,15 +2088,16 @@ private fun MessageRow(
             }
             // A forwarded message carries a small "forwarded" tag — the
             // bridge's WhatsApp forward marker, lifted out of the body by the
-            // companion and served as this flag. Incoming TEXT rows lead with
-            // the ↷ glyph (Subtitle) left of the body and put the word under
-            // the text, in the same spot as the "edited" tag (below); media
-            // and outgoing rows keep the glyph + word together above the
-            // content. Tight, lowercase, consistent with the other tags
+            // companion and served as this flag. Outgoing TEXT rows lead with
+            // the ↷ glyph (Subtitle) above the body with the word under it;
+            // incoming text and MEDIA rows put the glyph beside the content
+            // with the word under it (feedback 2026-09-07: a forwarded photo
+            // used to sit under the tag row, reading disconnected from the
+            // glyph). Tight, lowercase, consistent with the other tags
             // (feedback 2026-09-02: the marker used to sit in the body at
             // full size with a blank line after it, reading like a separate
             // message).
-            if (message.forwarded && (message.contentType != "text" || message.isMine)) {
+            if (message.forwarded && message.contentType == "text" && message.isMine) {
                 Row(
                     modifier = Modifier.padding(top = 1.dp, bottom = 1.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -2106,20 +2121,24 @@ private fun MessageRow(
                 { onOpenContext(message) }
             } else null
             if (message.contentType == "image") {
-                ImageMessageContent(message, mediaBytes, allowMobile, onEnsureMedia, onOpenImage, contextGesture)
+                ForwardedMediaRow(message) {
+                    ImageMessageContent(message, mediaBytes, allowMobile, onEnsureMedia, onOpenImage, contextGesture)
+                }
             } else if (message.contentType == "audio") {
-                AudioMessageContent(
-                    message = message,
-                    playing = playing,
-                    playingPositionMs = playingPositionMs,
-                    playingPositionAtMs = playingPositionAtMs,
-                    counterPending = counterPending,
-                    paused = paused,
-                    pausedPositionMs = pausedPositionMs,
-                    error = voiceError?.takeIf { it.first == message.id }?.second,
-                    onTogglePlay = { onPlayVoiceNote(message.id) },
-                    onOpenContext = contextGesture,
-                )
+                ForwardedMediaRow(message) {
+                    AudioMessageContent(
+                        message = message,
+                        playing = playing,
+                        playingPositionMs = playingPositionMs,
+                        playingPositionAtMs = playingPositionAtMs,
+                        counterPending = counterPending,
+                        paused = paused,
+                        pausedPositionMs = pausedPositionMs,
+                        error = voiceError?.takeIf { it.first == message.id }?.second,
+                        onTogglePlay = { onPlayVoiceNote(message.id) },
+                        onOpenContext = contextGesture,
+                    )
+                }
             } else {
                 if (message.isMine) {
                     // Outgoing: block sized to the first line so the top line's
@@ -2138,27 +2157,7 @@ private fun MessageRow(
                     // at the message's left edge under both.
                     Column(modifier = Modifier.padding(top = 1.dp)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            LightText(
-                                text = "\u21B7",
-                                variant = LightTextVariant.Paragraph,
-                                // The ↷ falls back to Noto Sans Symbols, whose
-                                // run sits low in the Paragraph line box — a
-                                // plain center-scale pushed the ink below the
-                                // box into the "forwarded" tag. Pivoting the
-                                // scale ~0.72 down the box keeps the arrow's
-                                // ink centered on the text line; the equal
-                                // padding (a) re-absorbs the scaled ink, which
-                                // is wider than the glyph advance, and (b)
-                                // squares the glyph's footprint (feedback
-                                // 2026-09-02).
-                                modifier = Modifier
-                                    .graphicsLayer {
-                                        scaleX = 2.1f
-                                        scaleY = 2.1f
-                                        transformOrigin = TransformOrigin(0.5f, 0.72f)
-                                    }
-                                    .padding(2.5.dp),
-                            )
+                            ForwardedArrowGlyph()
                             LightText(
                                 text = message.body,
                                 variant = LightTextVariant.Paragraph,
@@ -2211,14 +2210,23 @@ private fun MessageRow(
                 }
             }
             // An edited message shows a quiet "edited" tag under the body
-            // (feedback 2026-08-27) — same grammar as the delivery labels.
-            if (message.edited) {
-                LightText(
-                    text = "edited",
-                    variant = LightTextVariant.Superfine,
-                    modifier = Modifier.padding(top = 1.dp),
-                )
-            }
+            // (feedback 2026-08-27) — and since 2026-09-07 it shares one line
+            // with the delivery/status tag ("edited · delivered"), same
+            // grammar as the reactions separator; either alone renders as
+            // before.
+            listOfNotNull(
+                "edited".takeIf { message.edited },
+                statusTag,
+            ).joinToString(" · ")
+                .takeIf { it.isNotEmpty() }
+                ?.let { footer ->
+                    LightText(
+                        text = footer,
+                        variant = LightTextVariant.Superfine,
+                        // Solid white like the timestamps (feedback 2026-08-21).
+                        modifier = Modifier.padding(top = 1.dp),
+                    )
+                }
             // Phase 14: reactions, as a quiet tag under the message (same
             // grammar as the "not delivered" marker). Each entry reads
             // "Name reacted with ❤️" (or "You reacted with …" for own) —
@@ -2265,24 +2273,54 @@ private fun MessageRow(
                     // 2026-08-21).
                     modifier = Modifier.padding(top = 1.dp),
                 )
-            } else if (message.isMine && statusTag != null) {
-                // Phase 13, reshaped 2026-09-03; "delivered" rejoined 2026-09-06:
-                // the tag sits under the newest outgoing message the status
-                // evidence covers — "seen" needs the other party's m.read
-                // receipt (or a Beeper READ status), "delivered" needs a real
-                // bridge DELIVERED status (SUCCESS + delivered_to_users); it
-                // is never synthesized from a stopped SENDING spinner (the
-                // lie that dropped it 2026-08-30). [statusTag]'s picker
-                // owns placement + the Show-read-status gate (setting only
-                // gates "seen"); no evidence anywhere → no tag.
-                LightText(
-                    text = statusTag,
-                    variant = LightTextVariant.Superfine,
-                    // Solid white like the timestamps (feedback 2026-08-21).
-                    modifier = Modifier.padding(top = 1.dp),
-                )
             }
         }
+    }
+}
+
+/** The ↷ forward glyph beside media/text content: Paragraph variant scaled
+ *  ~2.1x (≈ the Subtitle ink size) about a pivot 0.72 down the line box —
+ *  the ↷ falls back to Noto Sans Symbols, whose run sits low in the
+ *  Paragraph line box; the pivot keeps the ink centered and the equal
+ *  padding re-absorbs the scaled ink (feedback 2026-09-02). */
+@Composable
+private fun ForwardedArrowGlyph() {
+    LightText(
+        text = "\u21B7",
+        variant = LightTextVariant.Paragraph,
+        modifier = Modifier
+            .graphicsLayer {
+                scaleX = 2.1f
+                scaleY = 2.1f
+                transformOrigin = TransformOrigin(0.5f, 0.72f)
+            }
+            .padding(2.5.dp),
+    )
+}
+
+/** Forwarded MEDIA rows (feedback 2026-09-07: the photo used to sit under
+ *  the tag row, reading disconnected from the glyph): the ↷ glyph beside the
+ *  content, the small "forwarded" word under it — the same grammar as
+ *  forwarded incoming text. */
+@Composable
+private fun ForwardedMediaRow(
+    message: LightServiceMethod.GetMessages.Message,
+    content: @Composable () -> Unit,
+) {
+    if (!message.forwarded) {
+        content()
+        return
+    }
+    Column(modifier = Modifier.padding(top = 1.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ForwardedArrowGlyph()
+            content()
+        }
+        LightText(
+            text = "forwarded",
+            variant = LightTextVariant.Superfine,
+            modifier = Modifier.padding(top = 1.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -236,20 +236,24 @@ class ThreadViewModel(
 
     /**
      * Keeps the contact panel honest with OTHER devices (LP3 feedback
-     * 2026-08-28): polls the companion's synced flags every few seconds and
-     * updates [muted]/[pinned]/[archived], so a pin/mute/archive done on a
-     * Beeper device reaches the panel live (items 1/5). Runs while the thread
-     * — and the contact panel over it — is on screen (started on
-     * [onScreenShow], NOT stopped on [onScreenHide]); stops when the app
-     * backgrounds and dies with the ViewModel on back-navigation.
+     * 2026-08-28): waits on the companion's flags revision (bumped wherever a
+     * flag fact commits — own toggles, Beeper-side sync) and refetches the
+     * synced flags on movement, updating [muted]/[pinned]/[archived] live
+     * (items 1/5). Runs while the thread — and the contact panel over it — is
+     * on screen (started on [onScreenShow], NOT stopped on [onScreenHide]);
+     * stops when the app backgrounds and dies with the ViewModel on
+     * back-navigation.
      */
     private var flagSyncJob: Job? = null
 
     fun startFlagSync() {
         if (flagSyncJob?.isActive == true) return
         flagSyncJob = viewModelScope.launch {
+            var lastFlags = 0L
             while (true) {
-                delay(FLAG_SYNC_MS)
+                val revision = ChatClient.waitForFlagChange(lastFlags)
+                if (revision == lastFlags) continue
+                lastFlags = revision
                 val flags = ChatClient.getRoomFlags(room.id) ?: continue
                 muted.value = flags.muted
                 pinned.value = flags.pinned
@@ -1149,11 +1153,9 @@ class ThreadViewModel(
         const val PAGE_SIZE = 20
         /** Older-page size: 6 ≈ one screenful per scroll-up load (2026-08-23). */
         const val OLDER_PAGE_SIZE = 6
-        /** Poll cadence while the thread is on screen (feedback pass). Phase 2
-         *  (SYNC-PERF-SPEC 2026-09-04): 3 s → 1.5 s — revision-gated cheap read. */
+        /** Poll cadence while a voice note plays: its position advances
+         *  without any page change, and only a poll reads it back. */
         const val THREAD_POLL_MS = 1_500L
-        /** Contact-panel flag poll (pin/mute/archive from other devices). */
-        const val FLAG_SYNC_MS = 3_000L
         /** How close (ms) a real echo's timestamp must be to a "local-…" row. */
         const val OPTIMISTIC_MATCH_WINDOW_MS = 5 * 60 * 1000L
         /** Media fetch retries when the first read comes back null. */

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScreen.kt
@@ -208,11 +208,8 @@ class ThreadViewModel(
     val muted = MutableStateFlow(room.muted)
 
     /** Toggles [muted] locally and persists it server-side (notifications only). */
-    fun toggleMuted() {
-        val next = !muted.value
-        muted.value = next
-        viewModelScope.launch { ChatClient.setRoomMuted(room.id, next) }
-    }
+    fun toggleMuted() =
+        viewModelScope.toggleAndPersist(muted, { room.id }, ChatClient::setRoomMuted)
 
     /**
      * Pin state for the contact panel: starts from the room
@@ -222,11 +219,8 @@ class ThreadViewModel(
     val pinned = MutableStateFlow(room.pinned)
 
     /** Toggles [pinned] locally and persists it server-side (m.favourite tag). */
-    fun togglePinned() {
-        val next = !pinned.value
-        pinned.value = next
-        viewModelScope.launch { ChatClient.setRoomPinned(room.id, next) }
-    }
+    fun togglePinned() =
+        viewModelScope.toggleAndPersist(pinned, { room.id }, ChatClient::setRoomPinned)
 
     /**
      * Archive state for the contact panel: starts from the room
@@ -237,11 +231,8 @@ class ThreadViewModel(
     val archived = MutableStateFlow(room.archived)
 
     /** Toggles [archived] locally and persists it server-side (Beeper inbox.done). */
-    fun toggleArchived() {
-        val next = !archived.value
-        archived.value = next
-        viewModelScope.launch { ChatClient.setRoomArchived(room.id, next) }
-    }
+    fun toggleArchived() =
+        viewModelScope.toggleAndPersist(archived, { room.id }, ChatClient::setRoomArchived)
 
     /**
      * Keeps the contact panel honest with OTHER devices: collects the repository's roomFlags flow for this room

--- a/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScrollBar.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/ThreadScrollBar.kt
@@ -45,7 +45,7 @@ private const val MAX_THUMB_FRACTION = 0.85f
 /** Accumulates the heights of every distinct laid-out item so the row-height
  *  average converges to the true mean. The visible-only snapshot is a biased
  *  sample — a too-short estimate made the thumb pin at the top of long
- *  threads and never reflect older pages loading in (feedback 2026-08-17). */
+ *  threads and never reflect older pages loading in. */
 internal class HeightSampler {
     private val seen = HashSet<Int>()
     private var sum = 0.0
@@ -77,9 +77,7 @@ internal class ThreadListMetrics(
     /** Display offset for the reverse-layout track: 0 = the oldest end, max =
      *  the newest end. [scrollPx] is the position from the newest end, so the
      *  thumb sits at the bottom of the track at the newest message and at the
-     *  top at the oldest (feedback 2026-08-17: the old offset-based position
-     *  read viewport-relative values in this Compose version and froze the
-     *  thumb at the track bottom). */
+     *  top at the oldest. */
     val displayScrollPx: Float get() = maxScrollPx - scrollPx
 }
 
@@ -100,8 +98,7 @@ internal fun LazyListState.threadListMetrics(sampler: HeightSampler): ThreadList
     val maxScrollPx = (totalContentPx - viewportHeightPx).coerceAtLeast(0f)
     // Position from the newest end, in items: the lowest visible index (the
     // row at the viewport's bottom edge in reverseLayout). Item `offset` is
-    // viewport-relative in this Compose version (verified 2026-08-17: the
-    // bottom-edge item reads ~0 regardless of scroll depth), so the scroll
+    // viewport-relative in this Compose version, so the scroll
     // position comes from the index, converted to px via the sampled average.
     // Index 0 (newest) visible → 0 → thumb at the track bottom; the oldest
     // end reads ≈ maxScrollPx → thumb at the top.

--- a/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
@@ -514,15 +514,15 @@ private fun TerminalPanel(
             }
         }
     }
-}/** The accept/start panel (2026-08-29): centered question, ACCEPT as a button
- *  bottom-anchored above the bottom bar; the X cancel stays in the bar. */
+}/** The accept/start panel (2026-08-29): question centered like the other
+ *  full-area panels (2026-09-06 — the half-split grammar made it jump up from
+ *  the waiting text's position), ACCEPT anchored above the bottom bar; the X
+ *  cancel stays in the bar. */
 @Composable
 private fun AcceptPanel(onAccept: () -> Unit) {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize()) {
         Box(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
+            modifier = Modifier.matchParentSize(),
             contentAlignment = Alignment.Center,
         ) {
             LightText(
@@ -532,13 +532,10 @@ private fun AcceptPanel(onAccept: () -> Unit) {
                 modifier = Modifier.padding(horizontal = 3f.gridUnitsAsDp()),
             )
         }
-        // ACCEPT centered between the question and the bottom CANCEL bar
-        // (feedback 2026-09-06), matching the terminal panel.
         Box(
             modifier = Modifier
-                .weight(1f)
+                .align(Alignment.BottomCenter)
                 .fillMaxWidth(),
-            contentAlignment = Alignment.Center,
         ) {
             PanelActionButton("ACCEPT", onClick = onAccept)
         }

--- a/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
@@ -41,7 +41,6 @@ import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
 import com.thelightphone.sdk.ui.lightClickable
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -77,22 +76,25 @@ class VerificationViewModel : LightViewModel<Unit>() {
 
     override fun onScreenShow(screen: SimpleLightScreen<Unit>) {
         super.onScreenShow(screen)
-        // Poll while the screen is up; the companion's state machine updates as
-        // the other device answers (and the recovery key updates e2ee state).
+        // One-shot fetch on entry, then a long-poll wait on the companion's
+        // status revision (bumped wherever the server-side verification state
+        // machine commits) — the screen never polls. The e2ee read includes a
+        // server round-trip, so it rides the wait's dead-man window and the
+        // Done transition; the recovery/accept actions refresh it directly
+        // anyway (feedback 2026-08-23).
         viewModelScope.launch {
-            // verificationState stays at 1 s; e2eeState is throttled to every
-            // ~10 s — it includes a server round-trip (network), and the
-            // recovery-key/accept actions refresh it directly anyway
-            // (feedback 2026-08-23).
-            var tick = 0
+            state.value = ChatClient.verificationState()
+            e2ee.value = ChatClient.e2eeState()
+            var last = 0L
             while (true) {
+                val revision = ChatClient.waitForStatusChange(last)
+                val moved = revision != last
+                last = revision
                 state.value = ChatClient.verificationState()
-                if (tick % E2EE_POLL_TICKS == 0) {
+                if (starting.value && state.value?.state != "none") starting.value = false
+                if (!moved || state.value?.state == "done") {
                     e2ee.value = ChatClient.e2eeState()
                 }
-                if (starting.value && state.value?.state != "none") starting.value = false
-                tick++
-                delay(POLL_MS)
             }
         }
     }
@@ -165,12 +167,6 @@ class VerificationViewModel : LightViewModel<Unit>() {
             if (failure != null) error.value = failure
             state.value = ChatClient.verificationState()
         }
-    }
-
-    private companion object {
-        const val POLL_MS = 1_000L
-        /** e2eeState is fetched once per this many 1 s polls (~10 s). */
-        const val E2EE_POLL_TICKS = 10
     }
 }
 

--- a/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
+++ b/app/src/main/kotlin/com/lightphone/chats/screens/VerificationScreen.kt
@@ -52,8 +52,7 @@ private const val WAITING_TEXT = "Waiting for your other device to accept..."
  * account's other device (e.g. the Beeper app), which unlocks encrypted
  * message keys. The state machine runs in the companion (Trixnity); this
  * screen polls it over the binder and forwards the user's choices.
- *
- * The flow renders as full-screen panels (feedback 2026-08-19): a local
+ * The flow renders as full-screen panels: a local
  * confirmation panel before the request is sent, then the server's states —
  * waiting / accept / compare / terminal (cancelled / error) — each with the
  * X-cancel affordance in the bottom bar.
@@ -70,8 +69,8 @@ class VerificationViewModel : LightViewModel<Unit>() {
     val confirmOpen = MutableStateFlow(false)
 
     /** True between Continue and the server reporting a non-idle verification
-     *  state — the waiting panel shows immediately, no main-panel flash
-     *  (feedback 2026-08-19). */
+     *  state — the waiting panel shows immediately, no main-panel flash.
+     */
     val starting = MutableStateFlow(false)
 
     override fun onScreenShow(screen: SimpleLightScreen<Unit>) {
@@ -81,7 +80,7 @@ class VerificationViewModel : LightViewModel<Unit>() {
         // machine commits) — the screen never polls. The e2ee read includes a
         // server round-trip, so it rides the wait's dead-man window and the
         // Done transition; the recovery/accept actions refresh it directly
-        // anyway (feedback 2026-08-23).
+        // anyway.
         viewModelScope.launch {
             state.value = ChatClient.verificationState()
             e2ee.value = ChatClient.e2eeState()
@@ -239,8 +238,7 @@ class VerificationScreen(sealedActivity: SealedLightActivity) :
                 }
 
                 // Cancelled/failed: no top bar at all — no back navigation, no
-                // title; Try Again / Use Recovery Key are the only ways out
-                // (feedback 2026-09-06).
+                // title; Try Again / Use Recovery Key are the only ways out.
                 if (state?.state != "cancelled" && state?.state != "error") {
                     LightTopBar(
                         leftButton = if (confirmOpen) {
@@ -268,7 +266,7 @@ class VerificationScreen(sealedActivity: SealedLightActivity) :
 
                         // Between Continue and the server's first non-idle
                         // state, show the waiting panel directly — no flash of
-                        // the main panel (feedback 2026-08-19).
+                        // the main panel.
                         starting && state?.state == "none" -> CenteredPanel(WAITING_TEXT)
 
                         else -> when (state?.state) {
@@ -328,10 +326,7 @@ class VerificationScreen(sealedActivity: SealedLightActivity) :
         }
     }
 
-    /** The bottom-bar action set for the current panel (feedback 2026-08-19:
-     *  X dismiss/cancel; the panel's action; the compare page has no X, the
-     *  waiting and cancelled panels' X sits centered — 2026-08-29: accept/start
-     *  and compare put their actions in the content area, X centered). */
+    /** The bottom-bar action set for the current panel. */
     private fun bottomBarItems(
         confirmOpen: Boolean,
         state: String?,
@@ -359,8 +354,8 @@ class VerificationScreen(sealedActivity: SealedLightActivity) :
             state == "accept" || state == "start" -> listOf(
                 // Both panels route through "accept" — the server prefers the
                 // pending SAS-accept over starting the SAS itself (the states
-                // churn fast, LP3 2026-08-19). ACCEPT moved into the content
-                // area above the bar (2026-08-29); the X cancels, centered.
+                // churn fast). ACCEPT moved into the content
+                // area above the bar; the X cancels, centered.
                 null,
                 cancelButton(),
                 null,
@@ -515,8 +510,7 @@ private fun TerminalPanel(
         }
     }
 }/** The accept/start panel (2026-08-29): question centered like the other
- *  full-area panels (2026-09-06 — the half-split grammar made it jump up from
- *  the waiting text's position), ACCEPT anchored above the bottom bar; the X
+ *  full-area panels, ACCEPT anchored above the bottom bar; the X
  *  cancel stays in the bar. */
 @Composable
 private fun AcceptPanel(onAccept: () -> Unit) {
@@ -558,9 +552,8 @@ private fun PanelActionButton(label: String, onClick: () -> Unit) {
 }
 
 /** The emoji-comparison panel: the SAS emojis with the confirmation line
- *  centred (feedback 2026-08-19); THEY MATCH / THEY DON'T MATCH stacked as
- *  buttons above the bottom bar (2026-08-29 — previously THEY MATCH sat in
- *  the bar). */
+ *  centred; THEY MATCH / THEY DON'T MATCH stacked as
+ *  buttons above the bottom bar. */
 @Composable
 private fun ComparePanel(
     emojis: List<String>,

--- a/docs/NO-SEAM-PLAN.md
+++ b/docs/NO-SEAM-PLAN.md
@@ -1,0 +1,122 @@
+# NO-SEAM PLAN — Chats: drop the binder seam, UI reflects the DB truth via flows
+
+Status: **implemented 2026-09-07 — see WORKLOG top entry.** No SDK changes required.
+
+## Handover prompt
+
+> Task: implement this file — drop the chats binder seam so the UI reflects the Matrix
+> DB truth via flows (single process already; the seam is the `LightServiceMethod`
+> dispatch + revision-poll loops).
+>
+> Read, in order: this file (the full verified plan), then `WORKLOG.md` top entries for
+> chats context. Do **not** modify `light-sdk/` — the plan requires no SDK changes (the
+> plugin scan only bans framework imports in tool source, verified in
+> `light-sdk/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt`).
+>
+> Key facts already established (2026-09-07):
+> - chats is single-APK/single-process since 2026-08-19 (`lighttool.toml`
+>   `serverPackage = "com.lightphone.chats"`, no `android:process` anywhere).
+> - `MatrixRepository` (chats/server) already holds reactive truth: `_roomList`
+>   StateFlow (private), `connectionState`/`verification`/`restoreProgress` (public),
+>   `messagePageCache` + `bumpMessagePageRevision` as the page-change choke point.
+> - Sluggishness = `callRemoteServiceMethod` serialization + revision-poll loops
+>   (`waitForRoomListChange`/`waitForPageChange`/`waitForFlagChange`) in
+>   ChatListScreen, ThreadScreen, SearchScreen.
+>
+> Build with `tools/build --dir chats :app:assembleDebug`; never two builds
+> concurrently. End-of-session gates: `lightos-design` skill on touched screens,
+> `tools/check-agents-size`, WORKLOG.md entry.
+
+## Finding (verified 2026-09-07)
+
+The light-sdk plugin scan (`LightSdkPlugin.kt`) only bans framework imports/patterns in
+tool-module source (`android.content.Context`, `Intent`, `LocalContext`, reflection, …).
+It does **not** ban importing `:server` classes, and `:server` doesn't apply the plugin
+at all (no scan there). Chats is already single-APK/single-process
+(`implementation(project(":server"))` in `chats/app/build.gradle.kts`,
+`serverPackage = "com.lightphone.chats"`). The Molly-Light-style model is allowed today —
+no upstream change needed.
+
+The sluggishness comes from the remaining **API seam**: `ChatClient` (app module) calls
+everything through `callRemoteServiceMethod` (serialized `LightServiceMethod` binder
+dispatch), and screens hold state via revision-poll loops (`waitForRoomListChange`,
+`waitForPageChange`, `waitForFlagChange`) instead of collecting flows.
+
+Meanwhile `MatrixRepository` already holds the truth reactively:
+
+- `_roomList: MutableStateFlow<List<GetRooms.Room>>` (private; published by
+  `publishRoomList`) — MatrixRepository.kt ~line 7399
+- `connectionState`, `verification`, `restoreProgress` — already public `StateFlow`s
+- `messagePageCache` + `bumpMessagePageRevision(roomId)` — single choke point where page
+  content changes are signalled (MatrixRepository.kt ~line 7439)
+- flags revision bump (locate beside the flag store / `WaitForFlagChange` handler)
+
+## Approach
+
+Expose the existing flows from `:server`, re-point `ChatClient` at direct calls, convert
+the three polling screens to `collectAsState`. Screens keep their structure; the polling
+loops die.
+
+## Steps
+
+### 1. `:server` — expose reactive truth (`MatrixRepository.kt`)
+
+- Make the room list flow public: `val roomList: StateFlow<List<GetRooms.Room>>`
+  (rename `_roomList` exposure; keep `publishRoomList` as the only writer).
+- Add `publishedPages: StateFlow<Map<String, MessagesPage>>`, updated **inside
+  `bumpMessagePageRevision(roomId)`** (it's already the single "page content changed"
+  event — piggyback `messagePageCache[roomId]?.page` into the flow; zero changes to the
+  ~8 cache write sites).
+- Add `roomFlags: StateFlow<Map<String, GetRoomFlags.Response>>` updated beside the
+  existing flags revision bump (locate the flag store first).
+- Check every public fun the app will call for `Context`-typed parameters — app source
+  can't import `android.content.Context`. If any signature forces it, wrap those calls
+  in a small Context-free facade object in `:server` instead of changing callers.
+  (Expect none: `MatrixRepository` is an object holding its own context.)
+
+### 2. app — re-point `ChatClient.kt`
+
+- Replace each `callRemoteServiceMethod(...)` body with a direct `MatrixRepository`
+  call; public API stays identical so screens don't change.
+- Delete `waitForRoomListChange` / `waitForPageChange` / `waitForFlagChange` /
+  `roomListRevision` / `messagePageRevision` (screens stop using them in step 3).
+- Keep: `startPhotoSend` / `startVoiceNoteSend` (activity launching must stay
+  server-side via `startServerActivity`), notification-permission request path, and any
+  method whose server handler needs the activity context.
+- Keep `ChatServiceMethods.kt` + `LightSdkService` fully intact (vetted-tools contract,
+  `MainActivity` adb dev control, emulator pipeline) — they just stop being the UI's
+  hot path.
+
+### 3. app — convert the polling screens to flow collection
+
+- `ChatListScreen.kt`: ViewModel collects `MatrixRepository.roomList` +
+  `connectionState` (+ account state); delete the `waitForRoomListChange` loop. Contact
+  panel flags come from `roomFlags`; delete the per-row `waitForFlagChange` loop.
+- `ThreadScreen.kt`: newest page comes from `publishedPages[roomId]`; delete the page
+  revision loop and the quiet re-fetch loop. Pagination (older pages via
+  `beforeEventId`) stays a one-shot `getMessages(...)` call.
+- `SearchScreen.kt`: room list from the flow; delete its revision loop.
+- One-shot reads that have no flow (e2ee state, verification actions, media, voice
+  notes) become direct calls; no behavior change.
+
+### 4. Verify
+
+- `tools/build --dir chats :app:assembleDebug` (memory-guarded, no concurrent builds).
+- Install on the `lightos` emulator; exercise: incoming message appears without poll
+  delay, send echo/edit/react/unsend/mark-read/mute/pin/archived reflect immediately,
+  room list + badges update, pagination still loads older pages, photo/voice-note
+  activity launches still work, boot receiver + sync service unaffected.
+- Battery sanity: polling timers gone — strictly less wakeups; quick logcat check.
+- End-of-session gates: `lightos-design` skill pass on touched screens;
+  `tools/check-agents-size`; WORKLOG.md entry (rationale + Molly-Light/scan finding).
+
+## Risks
+
+- `bumpMessagePageRevision` also fires for outbox/pending-echo state changes — verify
+  the published page object is the served one (same source as `getMessages` returns) so
+  UI never shows a different page shape than today.
+- The service-method handlers stay compiled in; if any screen subtly still depends on
+  binder-side state initialization order, `ServerBootstrapProvider` already covers
+  process-start init.
+- If a needed `MatrixRepository` signature turns out Context-typed, the facade object in
+  step 1 is the fallback — plan does not require touching the SDK.

--- a/docs/SYNC-PERF-SPEC.md
+++ b/docs/SYNC-PERF-SPEC.md
@@ -99,6 +99,7 @@ Ceiling note (`ponytail:`): if ingest is still > 5 s after 1–3, the next step 
 
 - Emulator (Synapse, seeded multi-room): Phase 0 timers show each hop's ms; Phase 1 ingest < 5 s; Phase 2 row appears < 5 s after server-side event, cold restart shows list without re-crawl.
 - LP3: one instrumented logcat window before/after Phase 1 (read-only capture, user drives install). Battery: one overnight after Phase 3 vs 08-20 control night.
+  **DONE 2026-09-06 (WORKLOG, `chats-audit-2026-09-06/phaseI-window-full.log`):** post-Phase-1 window on the 1284-room account — ingest sub-second, 0 round gaps > 35 s, sends 35–68 ms; the ~20 s model is gone. Hop-2/3 stage lines never emitted in-window (paths didn't trigger) — one targeted re-check outstanding. Felt problems in the window are decryption-state bugs (null-content skip / cooldown park / unanswered key requests / gap backfill), see WORKLOG for the ranked fix list.
 - Design review (`lightos-design` skill) only if any UI touch (Phase 2.3 doesn't change UI).
 - `tools/check-agents-size` at the end; WORKLOG entry per session.
 

--- a/docs/UI-AS-VIEW-PLAN.md
+++ b/docs/UI-AS-VIEW-PLAN.md
@@ -1,6 +1,17 @@
 # Chats — UI as a view of a committed fact (branch plan)
 
-**Status: planned, NOT started. This work goes on a NEW BRANCH off main.**
+**Status: DONE on branch `ui-as-view` (2026-09-06), emulator-verified. Phases W
+and S were found already implemented by the SYNC-PERF 2.2 / optimistic-send
+commits that landed on main before this plan was written; the branch's real
+work was Phase C plus verification. Deviations: the two proposed
+WaitRoomListRevision/WaitMessagePageRevision methods were superseded by the
+shipped single `WaitForChange` with a `"rooms"`/`"page"`/`"flags"`/`"status"`
+scope string; `awaitOutboxAck` survives only on the voice-send path (off the
+composer critical path — removal would regress the SENDING-flicker fix).**
+**Phase C kept delays (audited):** animations/auto-dismisses, the voice
+playback-position tick, media-retry ×3 backoff, cold-start retry backoff, and
+the starting-sync dead-man (now plus a status-revision wake that clears
+"starting" the moment "syncing" commits).
 
 Sequencing vs the current line: main first resolves its open work — commit the
 SYNC-PERF Phase 1 ingest gate (implemented, emulator-verified, uncommitted as of

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 sdk-ui = { module = "com.thelightphone:sdk-ui", version.ref = "sdk" }
 sdk-client = { module = "com.thelightphone:sdk-client", version.ref = "sdk" }
 sdk-server = { module = "com.thelightphone:sdk-server", version.ref = "sdk" }
-sdk-shared = { module = "com.thelightphone:sdk-shared", version.ref = "sdk" }
 # UnifiedPush app-side connector (the SDK client depends on it too; needed here
 # directly for the probe service that captures LightOS's distributor endpoint).
 unifiedpush-connector = { module = "org.unifiedpush.android:connector", version.ref = "connector" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -63,8 +63,6 @@ dependencies {
     implementation(libs.trixnity.media.okio)
     implementation(libs.trixnity.cryptodriver.libolm) // libOlm driver — same pickle format as v4
     implementation(libs.ktor.client.okhttp)
-    implementation(libs.ktor.client.content.negotiation)
-    implementation(libs.ktor.serialization.json)
     // Room runtime for Trixnity's TrixnityRoomDatabase (session + event store).
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/server/src/main/kotlin/com/lightphone/chats/server/ChatServiceMethods.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ChatServiceMethods.kt
@@ -80,17 +80,9 @@ object ChatServiceMethods {
 
                 LightServiceMethod.SendMessage.id -> {
                     val request = LightServiceMethod.SendMessage.decodeRequest(payload!!)
-                    // Send-RPC timing (2026-09-03): the LP3 freeze evidence needs
-                    // the server-side send cost on the log; payload contents stay
-                    // out (privacy).
-                    val t0 = android.os.SystemClock.elapsedRealtime()
                     val response = runBlocking {
                         MatrixRepository.sendMessage(request.roomId, request.body, request.replyToEventId)
                     }
-                    android.util.Log.d(
-                        "ChatServiceMethods",
-                        "dispatch SendMessage took ${android.os.SystemClock.elapsedRealtime() - t0}ms",
-                    )
                     LightResult.Success(LightServiceMethod.SendMessage.encodeResponse(response))
                 }
 

--- a/server/src/main/kotlin/com/lightphone/chats/server/ChatServiceMethods.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ChatServiceMethods.kt
@@ -23,6 +23,8 @@ object ChatServiceMethods {
 
                 LightServiceMethod.SetAccount.id -> setAccount(payload!!)
 
+                LightServiceMethod.SetBeeperAccount.id -> setBeeperAccount(payload!!)
+
                 LightServiceMethod.BeeperRequestCode.id -> {
                     val request = LightServiceMethod.BeeperRequestCode.decodeRequest(payload!!)
                     val result = runBlocking { MatrixRepository.beeperRequestCode(request.email) }
@@ -39,222 +41,165 @@ object ChatServiceMethods {
                     )
                 }
 
-                LightServiceMethod.SetBeeperAccount.id -> setBeeperAccount(payload!!)
+                LightServiceMethod.GetAccountState.id ->
+                    handleNoRequest(LightServiceMethod.GetAccountState) {
+                        MatrixRepository.accountState()
+                    }
 
-                LightServiceMethod.GetAccountState.id -> {
-                    val response = MatrixRepository.accountState()
-                    LightResult.Success(LightServiceMethod.GetAccountState.encodeResponse(response))
-                }
-
-                LightServiceMethod.Logout.id -> {
+                LightServiceMethod.Logout.id -> handleNoRequest(LightServiceMethod.Logout) {
                     runBlocking { MatrixRepository.logout() }
-                    LightResult.Success(LightServiceMethod.Logout.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.GetRooms.id -> {
-                    val rooms = runBlocking { MatrixRepository.getRooms() }
-                    val response = LightServiceMethod.GetRooms.Response(rooms)
-                    LightResult.Success(LightServiceMethod.GetRooms.encodeResponse(response))
+                LightServiceMethod.GetRooms.id -> handleNoRequest(LightServiceMethod.GetRooms) {
+                    LightServiceMethod.GetRooms.Response(runBlocking { MatrixRepository.getRooms() })
                 }
 
-                LightServiceMethod.GetAllRooms.id -> {
-                    val rooms = runBlocking { MatrixRepository.getAllRooms() }
-                    val response = LightServiceMethod.GetRooms.Response(rooms)
-                    LightResult.Success(LightServiceMethod.GetRooms.encodeResponse(response))
+                LightServiceMethod.GetAllRooms.id -> handleNoRequest(LightServiceMethod.GetAllRooms) {
+                    LightServiceMethod.GetRooms.Response(runBlocking { MatrixRepository.getAllRooms() })
                 }
 
-                LightServiceMethod.GetMessages.id -> {
-                    val request = LightServiceMethod.GetMessages.decodeRequest(payload!!)
+                LightServiceMethod.GetMessages.id -> handle(LightServiceMethod.GetMessages, payload) { request ->
                     val page = runBlocking {
                         MatrixRepository.getMessages(request.roomId, request.beforeEventId, request.limit)
                     }
-                    val response = LightServiceMethod.GetMessages.Response(
+                    LightServiceMethod.GetMessages.Response(
                         messages = page.messages,
                         hasMore = page.hasMore,
                         encrypted = page.encrypted,
                         audioPlayingEventId = MatrixRepository.audioPlayingEventId(),
                         audioPositionMs = MatrixRepository.audioPositionMs(),
                     )
-                    LightResult.Success(LightServiceMethod.GetMessages.encodeResponse(response))
                 }
 
-                LightServiceMethod.SendMessage.id -> {
-                    val request = LightServiceMethod.SendMessage.decodeRequest(payload!!)
-                    val response = runBlocking {
+                LightServiceMethod.SendMessage.id -> handle(LightServiceMethod.SendMessage, payload) { request ->
+                    runBlocking {
                         MatrixRepository.sendMessage(request.roomId, request.body, request.replyToEventId)
                     }
-                    LightResult.Success(LightServiceMethod.SendMessage.encodeResponse(response))
                 }
 
-                LightServiceMethod.SendReaction.id -> {
-                    val request = LightServiceMethod.SendReaction.decodeRequest(payload!!)
+                LightServiceMethod.SendReaction.id -> handle(LightServiceMethod.SendReaction, payload) { request ->
                     runBlocking {
                         MatrixRepository.sendReaction(request.roomId, request.eventId, request.key)
                     }
-                    LightResult.Success(LightServiceMethod.SendReaction.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.UnsendReaction.id -> {
-                    val request = LightServiceMethod.UnsendReaction.decodeRequest(payload!!)
+                LightServiceMethod.UnsendReaction.id -> handle(LightServiceMethod.UnsendReaction, payload) { request ->
                     runBlocking {
                         MatrixRepository.unsendReaction(request.roomId, request.eventId, request.key)
                     }
-                    LightResult.Success(LightServiceMethod.UnsendReaction.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.EditMessage.id -> {
-                    val request = LightServiceMethod.EditMessage.decodeRequest(payload!!)
+                LightServiceMethod.EditMessage.id -> handle(LightServiceMethod.EditMessage, payload) { request ->
                     runBlocking {
                         MatrixRepository.editMessage(request.roomId, request.eventId, request.newBody)
                     }
-                    LightResult.Success(LightServiceMethod.EditMessage.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.UnsendMessage.id -> {
-                    val request = LightServiceMethod.UnsendMessage.decodeRequest(payload!!)
+                LightServiceMethod.UnsendMessage.id -> handle(LightServiceMethod.UnsendMessage, payload) { request ->
                     runBlocking {
                         MatrixRepository.unsendMessage(request.roomId, request.eventId)
                     }
-                    LightResult.Success(LightServiceMethod.UnsendMessage.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.RetrySend.id -> {
-                    val request = LightServiceMethod.RetrySend.decodeRequest(payload!!)
+                LightServiceMethod.RetrySend.id -> handle(LightServiceMethod.RetrySend, payload) { request ->
                     runBlocking {
                         MatrixRepository.retrySend(request.roomId, request.transactionId)
                     }
-                    LightResult.Success(LightServiceMethod.RetrySend.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.MarkRead.id -> {
-                    val request = LightServiceMethod.MarkRead.decodeRequest(payload!!)
+                LightServiceMethod.MarkRead.id -> handle(LightServiceMethod.MarkRead, payload) { request ->
                     runBlocking { MatrixRepository.markRead(request.roomId, request.eventId) }
-                    LightResult.Success(LightServiceMethod.MarkRead.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.SetTyping.id -> {
-                    val request = LightServiceMethod.SetTyping.decodeRequest(payload!!)
+                LightServiceMethod.SetTyping.id -> handle(LightServiceMethod.SetTyping, payload) { request ->
                     runBlocking { MatrixRepository.setTyping(request.roomId, request.active) }
-                    LightResult.Success(LightServiceMethod.SetTyping.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.SetRoomMuted.id -> {
-                    val request = LightServiceMethod.SetRoomMuted.decodeRequest(payload!!)
+                LightServiceMethod.SetRoomMuted.id -> handle(LightServiceMethod.SetRoomMuted, payload) { request ->
                     runBlocking { MatrixRepository.setRoomMuted(request.roomId, request.muted) }
-                    LightResult.Success(LightServiceMethod.SetRoomMuted.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.SetRoomPinned.id -> {
-                    val request = LightServiceMethod.SetRoomPinned.decodeRequest(payload!!)
+                LightServiceMethod.SetRoomPinned.id -> handle(LightServiceMethod.SetRoomPinned, payload) { request ->
                     runBlocking { MatrixRepository.setRoomPinned(request.roomId, request.pinned) }
-                    LightResult.Success(LightServiceMethod.SetRoomPinned.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.GetRoomFlags.id -> {
-                    val request = LightServiceMethod.GetRoomFlags.decodeRequest(payload!!)
+                LightServiceMethod.GetRoomFlags.id -> handle(LightServiceMethod.GetRoomFlags, payload) { request ->
                     val flags = runBlocking { MatrixRepository.getRoomFlags(request.roomId) }
-                    LightResult.Success(
-                        LightServiceMethod.GetRoomFlags.encodeResponse(
-                            LightServiceMethod.GetRoomFlags.Response(
-                                pinned = flags.pinned,
-                                muted = flags.muted,
-                                archived = flags.archived,
-                            ),
-                        ),
+                    LightServiceMethod.GetRoomFlags.Response(
+                        pinned = flags.pinned,
+                        muted = flags.muted,
+                        archived = flags.archived,
                     )
                 }
 
-                LightServiceMethod.SetRoomArchived.id -> {
-                    val request = LightServiceMethod.SetRoomArchived.decodeRequest(payload!!)
+                LightServiceMethod.SetRoomArchived.id -> handle(LightServiceMethod.SetRoomArchived, payload) { request ->
                     runBlocking { MatrixRepository.setRoomArchived(request.roomId, request.archived) }
-                    LightResult.Success(LightServiceMethod.SetRoomArchived.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.GetConnectionState.id -> {
-                    val response = MatrixRepository.connectionState()
-                    LightResult.Success(LightServiceMethod.GetConnectionState.encodeResponse(response))
+                LightServiceMethod.GetConnectionState.id ->
+                    handleNoRequest(LightServiceMethod.GetConnectionState) {
+                        MatrixRepository.connectionState()
+                    }
+
+                LightServiceMethod.GetE2eeState.id -> handleNoRequest(LightServiceMethod.GetE2eeState) {
+                    runBlocking { MatrixRepository.e2eeState() }
                 }
 
-                LightServiceMethod.GetE2eeState.id -> {
-                    val response = runBlocking { MatrixRepository.e2eeState() }
-                    LightResult.Success(LightServiceMethod.GetE2eeState.encodeResponse(response))
-                }
+                LightServiceMethod.StartDeviceVerification.id ->
+                    handleNoRequest(LightServiceMethod.StartDeviceVerification) {
+                        runBlocking { MatrixRepository.startDeviceVerification() }.fold(
+                            onSuccess = {
+                                LightServiceMethod.StartDeviceVerification.Response(started = true)
+                            },
+                            onFailure = { error ->
+                                LightServiceMethod.StartDeviceVerification.Response(
+                                    started = false,
+                                    error = error.message,
+                                )
+                            },
+                        )
+                    }
 
-                LightServiceMethod.StartDeviceVerification.id -> {
-                    val result = runBlocking { MatrixRepository.startDeviceVerification() }
-                    result.fold(
-                        onSuccess = {
-                            LightResult.Success(
-                                LightServiceMethod.StartDeviceVerification.encodeResponse(
-                                    LightServiceMethod.StartDeviceVerification.Response(started = true),
-                                ),
-                            )
-                        },
-                        onFailure = { error ->
-                            LightResult.Success(
-                                LightServiceMethod.StartDeviceVerification.encodeResponse(
-                                    LightServiceMethod.StartDeviceVerification.Response(
-                                        started = false,
-                                        error = error.message,
-                                    ),
-                                ),
-                            )
-                        },
-                    )
-                }
+                LightServiceMethod.GetVerificationState.id ->
+                    handleNoRequest(LightServiceMethod.GetVerificationState) {
+                        MatrixRepository.verificationState()
+                    }
 
-                LightServiceMethod.GetVerificationState.id -> {
-                    val response = MatrixRepository.verificationState()
-                    LightResult.Success(LightServiceMethod.GetVerificationState.encodeResponse(response))
-                }
-
-                LightServiceMethod.SetActiveRoom.id -> {
-                    val request = LightServiceMethod.SetActiveRoom.decodeRequest(payload!!)
+                LightServiceMethod.SetActiveRoom.id -> handle(LightServiceMethod.SetActiveRoom, payload) { request ->
                     MatrixRepository.setActiveRoom(request.roomId)
-                    LightResult.Success(LightServiceMethod.SetActiveRoom.encodeResponse(Unit))
                 }
 
-                LightServiceMethod.TakeNotifyRoom.id -> {
-                    val response = LightServiceMethod.TakeNotifyRoom.Response(
+                LightServiceMethod.TakeNotifyRoom.id -> handleNoRequest(LightServiceMethod.TakeNotifyRoom) {
+                    LightServiceMethod.TakeNotifyRoom.Response(
                         MatrixRepository.takeNotifyRoom(),
                     )
-                    LightResult.Success(LightServiceMethod.TakeNotifyRoom.encodeResponse(response))
                 }
 
-                LightServiceMethod.VerifyAction.id -> {
-                    val request = LightServiceMethod.VerifyAction.decodeRequest(payload!!)
-                    val result = runBlocking { MatrixRepository.verifyAction(request.action) }
-                    val response = result.fold(
+                LightServiceMethod.VerifyAction.id -> handle(LightServiceMethod.VerifyAction, payload) { request ->
+                    runBlocking { MatrixRepository.verifyAction(request.action) }.fold(
                         onSuccess = { LightServiceMethod.VerifyAction.Response(ok = true) },
                         onFailure = { error ->
                             LightServiceMethod.VerifyAction.Response(ok = false, error = error.message)
                         },
                     )
-                    LightResult.Success(LightServiceMethod.VerifyAction.encodeResponse(response))
                 }
 
-                LightServiceMethod.RecoverWithKey.id -> {
-                    val request = LightServiceMethod.RecoverWithKey.decodeRequest(payload!!)
-                    val result = runBlocking { MatrixRepository.recoverWithKey(request.recoveryKey) }
-                    val response = result.fold(
+                LightServiceMethod.RecoverWithKey.id -> handle(LightServiceMethod.RecoverWithKey, payload) { request ->
+                    runBlocking { MatrixRepository.recoverWithKey(request.recoveryKey) }.fold(
                         onSuccess = { LightServiceMethod.RecoverWithKey.Response(ok = true) },
                         onFailure = { error ->
                             LightServiceMethod.RecoverWithKey.Response(ok = false, error = error.message)
                         },
                     )
-                    LightResult.Success(LightServiceMethod.RecoverWithKey.encodeResponse(response))
                 }
 
-                LightServiceMethod.StartPhotoSend.id -> {
-                    val request = LightServiceMethod.StartPhotoSend.decodeRequest(payload!!)
-                    val response = LightServiceMethod.StartPhotoSend.Response(
+                LightServiceMethod.StartPhotoSend.id -> handle(LightServiceMethod.StartPhotoSend, payload) { request ->
+                    LightServiceMethod.StartPhotoSend.Response(
                         MatrixRepository.startPhotoSend(request.roomId),
                     )
-                    LightResult.Success(LightServiceMethod.StartPhotoSend.encodeResponse(response))
                 }
 
-                LightServiceMethod.GetMessageMedia.id -> {
-                    val request = LightServiceMethod.GetMessageMedia.decodeRequest(payload!!)
+                LightServiceMethod.GetMessageMedia.id -> handle(LightServiceMethod.GetMessageMedia, payload) { request ->
                     val bytes = runBlocking {
                         MatrixRepository.getMessageMedia(
                             request.roomId,
@@ -262,44 +207,31 @@ object ChatServiceMethods {
                             request.allowMobileData,
                         )
                     }
-                    LightResult.Success(
-                        LightServiceMethod.GetMessageMedia.encodeResponse(
-                            LightServiceMethod.GetMessageMedia.Response(bytes),
-                        ),
+                    LightServiceMethod.GetMessageMedia.Response(bytes)
+                }
+
+                LightServiceMethod.SaveMessageImage.id -> handle(LightServiceMethod.SaveMessageImage, payload) { request ->
+                    LightServiceMethod.SaveMessageImage.Response(
+                        runBlocking {
+                            MatrixRepository.saveMessageImage(request.roomId, request.eventId)
+                        },
                     )
                 }
 
-                LightServiceMethod.SaveMessageImage.id -> {
-                    val request = LightServiceMethod.SaveMessageImage.decodeRequest(payload!!)
-                    val ok = runBlocking {
-                        MatrixRepository.saveMessageImage(request.roomId, request.eventId)
-                    }
-                    LightResult.Success(
-                        LightServiceMethod.SaveMessageImage.encodeResponse(
-                            LightServiceMethod.SaveMessageImage.Response(ok),
-                        ),
-                    )
-                }
-
-                LightServiceMethod.PlayVoiceNote.id -> {
-                    val request = LightServiceMethod.PlayVoiceNote.decodeRequest(payload!!)
-                    val (playing, error) = runBlocking {
+                LightServiceMethod.PlayVoiceNote.id -> handle(LightServiceMethod.PlayVoiceNote, payload) { request ->
+                    runBlocking {
                         MatrixRepository.playVoiceNote(request.roomId, request.eventId)
+                    }.let { (playing, error) ->
+                        LightServiceMethod.PlayVoiceNote.Response(playing, error)
                     }
-                    LightResult.Success(
-                        LightServiceMethod.PlayVoiceNote.encodeResponse(
-                            LightServiceMethod.PlayVoiceNote.Response(playing, error),
-                        ),
-                    )
                 }
 
-                LightServiceMethod.StartVoiceNoteSend.id -> {
-                    val request = LightServiceMethod.StartVoiceNoteSend.decodeRequest(payload!!)
-                    val response = LightServiceMethod.StartVoiceNoteSend.Response(
-                        MatrixRepository.startVoiceNoteSend(request.roomId),
-                    )
-                    LightResult.Success(LightServiceMethod.StartVoiceNoteSend.encodeResponse(response))
-                }
+                LightServiceMethod.StartVoiceNoteSend.id ->
+                    handle(LightServiceMethod.StartVoiceNoteSend, payload) { request ->
+                        LightServiceMethod.StartVoiceNoteSend.Response(
+                            MatrixRepository.startVoiceNoteSend(request.roomId),
+                        )
+                    }
 
                 // Media volume for the tool's in-app volume panel (feedback
                 // 2026-08-30): the SDK routes GetVolumeLevel here via
@@ -313,43 +245,32 @@ object ChatServiceMethods {
                     }
                 }
 
-                LightServiceMethod.SetSyncEnabled.id -> {
-                    val request = LightServiceMethod.SetSyncEnabled.decodeRequest(payload!!)
+                LightServiceMethod.SetSyncEnabled.id -> handle(LightServiceMethod.SetSyncEnabled, payload) { request ->
                     runBlocking { MatrixRepository.setSyncEnabled(request.enabled) }
-                    LightResult.Success(
-                        LightServiceMethod.SetSyncEnabled.encodeResponse(
-                            LightServiceMethod.SetSyncEnabled.Response(ok = true),
-                        ),
-                    )
+                    LightServiceMethod.SetSyncEnabled.Response(ok = true)
                 }
 
-                LightServiceMethod.GetRoomListRevision.id -> {
-                    val response = LightServiceMethod.GetRoomListRevision.Response(
-                        MatrixRepository.roomListRevision(),
-                    )
-                    LightResult.Success(LightServiceMethod.GetRoomListRevision.encodeResponse(response))
-                }
+                LightServiceMethod.GetRoomListRevision.id ->
+                    handleNoRequest(LightServiceMethod.GetRoomListRevision) {
+                        LightServiceMethod.GetRoomListRevision.Response(
+                            MatrixRepository.roomListRevision(),
+                        )
+                    }
 
-                LightServiceMethod.GetMessagePageRevision.id -> {
-                    val request = LightServiceMethod.GetMessagePageRevision.decodeRequest(payload!!)
-                    val response = LightServiceMethod.GetMessagePageRevision.Response(
-                        MatrixRepository.messagePageRevision(request.roomId),
-                    )
-                    LightResult.Success(LightServiceMethod.GetMessagePageRevision.encodeResponse(response))
-                }
+                LightServiceMethod.GetMessagePageRevision.id ->
+                    handle(LightServiceMethod.GetMessagePageRevision, payload) { request ->
+                        LightServiceMethod.GetMessagePageRevision.Response(
+                            MatrixRepository.messagePageRevision(request.roomId),
+                        )
+                    }
 
-                LightServiceMethod.WaitForChange.id -> {
-                    val request = LightServiceMethod.WaitForChange.decodeRequest(payload!!)
+                LightServiceMethod.WaitForChange.id -> handle(LightServiceMethod.WaitForChange, payload) { request ->
                     val revision = runBlocking {
                         MatrixRepository.waitForChange(
                             request.watch, request.roomId, request.lastSeen, request.timeoutMs,
                         )
                     }
-                    LightResult.Success(
-                        LightServiceMethod.WaitForChange.encodeResponse(
-                            LightServiceMethod.WaitForChange.Response(revision),
-                        )
-                    )
+                    LightServiceMethod.WaitForChange.Response(revision)
                 }
 
                 else -> LightResult.Error(
@@ -361,6 +282,19 @@ object ChatServiceMethods {
             android.util.Log.e("ChatServiceMethods", "dispatch failed for $methodId", e)
             LightResult.Error(LightResult.ErrorCode.Unknown, e.message ?: "error handling $methodId")
         }
+
+    private inline fun <Req : Any, Resp : Any> handle(
+        method: LightServiceMethod<Req, Resp>,
+        payload: String?,
+        block: (Req) -> Resp,
+    ): LightResult<String> =
+        LightResult.Success(method.encodeResponse(block(method.decodeRequest(payload!!))))
+
+    private inline fun <Resp : Any> handleNoRequest(
+        method: LightServiceMethod<Unit, Resp>,
+        block: () -> Resp,
+    ): LightResult<String> =
+        LightResult.Success(method.encodeResponse(block()))
 
     private fun setAccount(payload: String): LightResult<String> {
         val request = LightServiceMethod.SetAccount.decodeRequest(payload)

--- a/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
@@ -34,11 +34,12 @@ class ChatSyncService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Settings → Sync pause: never start the loop or
-        // hold the FGS while paused — a sticky restart must not defeat the
-        // user's choice.
-        if (!MatrixRepository.isSyncEnabled) {
-            Log.d(TAG, "sync disabled by user — not starting")
+        // Battery saver: never start the loop or
+        // hold the FGS while the screen is dark — a sticky restart must not
+        // defeat the user's choice. With the screen on, foreground sync runs
+        // even under battery saver.
+        if (!MatrixRepository.isSyncEnabled && !MatrixRepository.isScreenOn) {
+            Log.d(TAG, "battery saver — not starting")
             stopSelf()
             return START_NOT_STICKY
         }

--- a/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ChatSyncService.kt
@@ -34,7 +34,7 @@ class ChatSyncService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Settings → Sync pause (audit 2026-08-14): never start the loop or
+        // Settings → Sync pause: never start the loop or
         // hold the FGS while paused — a sticky restart must not defeat the
         // user's choice.
         if (!MatrixRepository.isSyncEnabled) {
@@ -46,7 +46,7 @@ class ChatSyncService : Service() {
         startForeground(NOTIFICATION_ID, buildNotification(this))
         serviceScope.launch {
             val c = MatrixRepository.ensureClient() ?: return@launch
-            // Screen-state-aware sync start (battery 2026-08-19 audit): a
+            // Screen-state-aware sync start: a
             // service restart while the screen is dark must not long-poll —
             // apply the screen → cadence decision first, and only start a
             // long-poll here when the screen is actually on (slow-sync grace
@@ -95,8 +95,7 @@ class ChatSyncService : Service() {
         var lastState: SyncState? = null
         c.syncState.collect { state ->
             // One line per state CHANGE (rare — a handful per night), so a
-            // silently dead loop leaves a visible last-state trail (audit
-            // 2026-08-23: long-polls stopped for hours with no logged cause).
+            // silently dead loop leaves a visible last-state trail.
             if (state != lastState) {
                 lastState = state
                 Log.d(
@@ -119,8 +118,7 @@ class ChatSyncService : Service() {
                 return@collect
             }
             if (stuckSinceMs == 0L) stuckSinceMs = now
-            // Never restart the long-poll while the screen is dark (battery
-            // 2026-08-19 audit): slow-sync owns sync then, and a restart would
+            // Never restart the long-poll while the screen is dark: slow-sync owns sync then, and a restart would
             // defeat the whole screen → cadence gate.
             if (syncedClient === c && now - stuckSinceMs >= SYNC_RESTART_AFTER_MS && MatrixRepository.isScreenOn) {
                 Log.w(TAG, "sync stuck in $state for ${SYNC_RESTART_AFTER_MS / 1000}s — restarting sync loop")

--- a/server/src/main/kotlin/com/lightphone/chats/server/MainActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MainActivity.kt
@@ -57,13 +57,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         // Dev toggle for the companion's verbose logging (Trixnity FINE +
         // HTTP-TRAFFIC): `--es debugLog 1` persists the flag before init, so
-        // it applies from the very first log call. Default off (efficiency
-        // audit 2026-08-14 — both were always-on and burned standby CPU).
+        // it applies from the very first log call. Default off — both were
+        // always-on and burned standby CPU.
         intent?.getStringExtra("debugLog")?.let {
             getSharedPreferences("chats_account", MODE_PRIVATE).edit()
                 .putBoolean("debug_logging", it == "1" || it.equals("true", ignoreCase = true)).apply()
         }
-        // Dev-only push channel overrides (2026-08-16, chats/push/README.md):
+        // Dev-only push channel overrides:
         // --es pushsse <url>    the SSE subscription URL (from the phone's side)
         // --es pushnotify <url> the pusher data.url (from the homeserver's side)
         // --es pushkey <url>    the pusher pushkey — ntfy routing needs it to

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -80,7 +80,9 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import de.connect2x.trixnity.clientserverapi.model.push.SetPushRule
 import de.connect2x.trixnity.clientserverapi.model.user.Filters
+import de.connect2x.trixnity.core.ClientEventEmitter
 import de.connect2x.trixnity.core.MatrixServerException
+import de.connect2x.trixnity.core.subscribeAsFlow
 import de.connect2x.trixnity.core.model.events.MessageEventContent
 import de.connect2x.trixnity.core.model.events.RoomAccountDataEventContent
 import de.connect2x.trixnity.core.model.events.m.PushRulesEventContent
@@ -99,6 +101,7 @@ import de.connect2x.trixnity.client.MatrixClient
 import de.connect2x.trixnity.clientserverapi.client.ClassicMatrixClientAuthProviderData
 import de.connect2x.trixnity.clientserverapi.client.MatrixClientAuthProviderData
 import de.connect2x.trixnity.client.MatrixClientConfiguration
+import de.connect2x.trixnity.client.MatrixClientConfiguration.DeleteRooms
 import de.connect2x.trixnity.client.MediaStoreModule
 import de.connect2x.trixnity.client.RepositoriesModule
 import de.connect2x.trixnity.client.create
@@ -123,6 +126,8 @@ import de.connect2x.trixnity.client.room.message.reply
 import de.connect2x.trixnity.client.room.message.replace
 import de.connect2x.trixnity.client.room.message.text
 import de.connect2x.trixnity.client.serverDiscovery
+import de.connect2x.trixnity.client.store.Account
+import de.connect2x.trixnity.client.store.AccountStore
 import de.connect2x.trixnity.client.store.GlobalAccountDataStore
 import de.connect2x.trixnity.client.store.KeyStore
 import de.connect2x.trixnity.client.store.OlmCryptoStore
@@ -510,6 +515,33 @@ object MatrixRepository {
      *  group member's reads POST one push, and each syncOnce costs ~30-50 s of
      *  CPU on this account (battery 2026-08-17 audit). */
     private var lastPushWakeSyncAtMs = 0L
+
+    // --- Verification-first sync (LP3 2026-09-06) ----------------------------
+
+    /**
+     * True between a fresh login and the device-verification outcome: while
+     * set, [clientConfiguration] hands the client the ultra-slim
+     * [verificationSyncFilters] so the initial sync ingests ~300 room-list
+     * bones instead of 6902 events (~180 s of serialized emit on the LP3) —
+     * the SAS emoji round-trips must not be stuck behind it. Set by the login
+     * paths before the client is built (the configuration is read at build
+     * time; [finishLogin] runs too late), cleared by [swapToFullSync] and on
+     * teardown paths. Stale-true degrades to a slim-rooms session, never a
+     * broken one (the next login re-arms the full swap).
+     */
+    @Volatile
+    private var pendingVerificationPhase = false
+
+    /** The MatrixClientConfiguration captured while the current client was
+     *  built ([clientConfiguration]'s receiver). Its filter properties are
+     *  `var` (MatrixClientConfiguration.kt, Trixnity 5.8), so [swapToFullSync]
+     *  mutates it in place instead of rebuilding the client. Cleared with the
+     *  session, re-captured on every client build. */
+    @Volatile
+    private var activeClientConfig: MatrixClientConfiguration? = null
+
+    /** Guards [swapToFullSync] — one swap per login (reset by the login paths). */
+    private val verificationSyncSwapped = java.util.concurrent.atomic.AtomicBoolean(false)
 
     /** The default network dropped — the next [networkCallback] onAvailable
      *  resets the sync loop (Beeper's `networkChanged`/`resetNetworkConnections`,
@@ -1285,6 +1317,11 @@ object MatrixRepository {
             // The raw ktor client (used for Beeper's provision API, see
             // [bridgeContacts]) does not attach the bearer — persist it here.
             val accessToken = (authProviderData as? ClassicMatrixClientAuthProviderData)?.accessToken
+            // Verification-first sync: the configuration lambda is read at
+            // client build time, so the phase flag must be armed BEFORE
+            // create (finishLogin runs too late — see [pendingVerificationPhase]).
+            pendingVerificationPhase = true
+            verificationSyncSwapped.set(false)
             val loginResult = authProviderData
                 .let { authProviderData ->
                     MatrixClient.create(
@@ -1293,7 +1330,7 @@ object MatrixRepository {
                         cryptoDriverModule = CryptoDriverModule.libOlm(),
                         authProviderData = authProviderData,
                         configuration = clientConfiguration("chats"),
-                    ).getOrThrow()
+                    ).onFailure { pendingVerificationPhase = false }.getOrThrow()
                 }
             ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
                 .edit()
@@ -1393,6 +1430,9 @@ object MatrixRepository {
                 initialDeviceDisplayName = "Chats (Light Phone)",
             ).getOrThrow()
             val accessToken = (authProviderData as? ClassicMatrixClientAuthProviderData)?.accessToken
+            // Verification-first sync — see the homeserver [login] path.
+            pendingVerificationPhase = true
+            verificationSyncSwapped.set(false)
             val loginResult = authProviderData
                 .let { authProviderData ->
                     MatrixClient.create(
@@ -1401,7 +1441,7 @@ object MatrixRepository {
                         cryptoDriverModule = CryptoDriverModule.libOlm(),
                         authProviderData = authProviderData,
                         configuration = clientConfiguration("chats-beeper"),
-                    ).getOrThrow()
+                    ).onFailure { pendingVerificationPhase = false }.getOrThrow()
                 }
             prefs.edit()
                 .putString(KEY_HOMESERVER, BEEPER_HOMESERVER)
@@ -1447,8 +1487,33 @@ object MatrixRepository {
         if (lastLoginNeedsVerification) {
             runCatching { startDeviceVerification() }
                 .onFailure { android.util.Log.w(TAG, "post-login verification auto-start failed: ${it.message}") }
+        } else {
+            // Nothing to verify (fresh account / no other device / already
+            // trusted) — leave the verification-phase slim sync immediately.
+            swapToFullSync()
         }
         return newClient
+    }
+
+    /** Restore-path counterpart of [finishLogin]'s E2EE wiring: a verified
+     *  restored session kicks the key-backup crawl (its own cooldown guards
+     *  the cost); an unverified one flows into device verification like a
+     *  fresh login — [postLoginNeedsVerification]'s false-bail behavior
+     *  (cross-signing absent / no other devices) keeps this a no-op for
+     *  accounts with nothing to verify. */
+    private suspend fun armRestoreVerification(c: MatrixClient) {
+        if (isDeviceVerified(c)) {
+            if (!restoreAttempted) {
+                restoreAttempted = true
+                restoreMegolmSessions()
+            }
+        } else {
+            lastLoginNeedsVerification = postLoginNeedsVerification(c)
+            if (lastLoginNeedsVerification) {
+                runCatching { startDeviceVerification() }
+                    .onFailure { android.util.Log.w(TAG, "post-restore verification auto-start failed: ${it.message}") }
+            }
+        }
     }
 
     /** Whether the most recent login ended with device verification pending —
@@ -1534,6 +1599,132 @@ object MatrixRepository {
             android.util.Log.w(TAG, "sync-filter migration failed: ${e.message}")
         }
     }
+
+    /**
+     * Ends the verification-phase slim sync (see [pendingVerificationPhase]):
+     * swaps the captured configuration's filters to the full set, re-uploads
+     * them, stores the fresh ids in the Account row, and restarts the sync
+     * loop so the long-poll picks up the full sync filter (background
+     * syncOnce rounds read the stored id per round). Called from the
+     * verification Done branch, its timeout branch, and [finishLogin] when no
+     * verification is needed. Idempotent — one swap per login, one retry.
+     *
+     * Trixnity 5.8 uploads filters exactly once, in the client's init
+     * coroutine (MatrixClient.kt: the `filter == null || eventTypesHash
+     * changed` gate); startSync/syncOnce only read the STORED ids — so the
+     * [migrateSyncFilterIfNeeded] trick (clear the ids, restart) cannot work
+     * on a live client: startSync checkNotNulls the stored syncFilterId and
+     * the upload never re-runs. The swap therefore uploads the full filters
+     * itself — replicating the private MatrixClient.applyDefaultFilter merge
+     * over the CLIENT's own [EventContentSerializerMappings] — and writes the
+     * ids through the client's AccountStore (raw SQL would desync its
+     * in-memory cache). The upload+store happens AFTER the client's `started`
+     * flag flips (the init coroutine's last act, after it stores its own ids),
+     * so the swap always wins over the init store even when they race
+     * (emulator 2026-09-06: a swap before `started` left the slim ids stored).
+     */
+    private suspend fun swapToFullSync() {
+        if (!verificationSyncSwapped.compareAndSet(false, true)) return
+        pendingVerificationPhase = false
+        android.util.Log.i(TAG, "sync: verification phase done — swapping to full sync filter, restarting loop")
+        swapOnceToFullSync()
+            .onFailure { e ->
+                android.util.Log.w(TAG, "full-sync swap failed (${e.message}) — retrying once in ${SYNC_SWAP_RETRY_MS / 1000} s")
+                delay(SYNC_SWAP_RETRY_MS)
+                swapOnceToFullSync().onFailure {
+                    android.util.Log.w(TAG, "full-sync swap retry failed: ${it.message} — session stays on the slim verification filters until re-login")
+                }
+            }
+    }
+
+    private suspend fun swapOnceToFullSync(): Result<Unit> = runCatching {
+        val c = client ?: error("client gone")
+        val config = activeClientConfig ?: error("no captured client configuration")
+        config.syncFilter = fullSyncFilters
+        config.syncOnceFilter = fullSyncOnceFilters
+        // The init upload reads the config BEFORE its network calls and stores
+        // the ids after — a swap racing it could otherwise read filter==null,
+        // skip, and let the init store the SLIM ids right after (measured on
+        // the emulator 2026-09-06). `started` flips only AFTER the init store,
+        // so waiting for it makes the stored ids final; we then overwrite them
+        // with the full pair. Bounded: an init that never completes (dead
+        // network) degrades to uploading with an empty eventTypesHash, which
+        // simply forces a re-upload on the next client start.
+        withTimeoutOrNull(SYNC_SWAP_INIT_WAIT_MS) { c.started.first { it } }
+        // Stop the slim loop BEFORE nulling the batch token: the old loop's
+        // in-flight round writes its token on completion, and a token landing
+        // after our null turns the restarted loop into incremental rounds —
+        // the state-bearing initial sync never runs (LP3 2026-09-06: rooms
+        // "Chat" forever AND megolm decrypt refuses on the missing
+        // m.room.encryption state, so history stays [Encrypted] despite a
+        // successful backup-key restore).
+        runCatching { c.stopSync() }
+        inProcessSyncRunning = false
+        val accountStore = c.di.get<AccountStore>()
+        val mappings = c.di.get<EventContentSerializerMappings>()
+        val storedHash = accountStore.getAccount()?.filter?.eventTypesHash
+        val syncFilterId = c.api.user.setFilter(c.userId, fullSyncFilters.applyDefaultFilter(mappings, config)).getOrThrow()
+        val syncOnceFilterId = c.api.user.setFilter(c.userId, fullSyncOnceFilters.applyDefaultFilter(mappings, config)).getOrThrow()
+        c.di.get<StoreTransactionManager>().writeTransaction {
+            accountStore.updateAccount {
+                // syncBatchToken = null is essential: the slim verification
+                // phase ADVANCED the batch token past all room state/timeline
+                // (limit 1, state notTypes="*"), and an incremental restart
+                // never re-delivers what the token passed — rooms render
+                // nameless ("Chat…") and history stays "Encrypted" forever
+                // (LP3 2026-09-06). Nulling the token makes the restarted loop
+                // do a true full initial sync under the full filter — same
+                // reasoning as sync-filter migration v4 (2026-08-28).
+                it?.copy(
+                    filter = Account.Filter(syncFilterId, syncOnceFilterId, storedHash ?: ""),
+                    syncBatchToken = null,
+                )
+            }
+        }
+        // Restart the loop through the shared cadence entry points (same shape
+        // as the network-recovery reset): a dark screen must not start a
+        // long-poll — it goes through the screen → cadence decision instead.
+        if (isScreenInteractive() && syncEnabled) {
+            startSyncLoop(appContext ?: error("companion not initialized"))
+        } else {
+            applySyncModeForScreenState()
+        }
+    }
+
+    /**
+     * Replica of Trixnity's private `MatrixClientImpl.Filters.applyDefaultFilter`
+     * (5.8) — it merges Trixnity's type whitelists (from the CLIENT's [mappings])
+     * over [this], keeping `notTypes`, and enables lazy member loading.
+     * [swapToFullSync] uploads with it; if Trixnity's version changes, this
+     * must follow, or the swapped-in filter silently diverges from what the
+     * init upload would have stored (verified against MatrixClient.kt 5.8.0).
+     */
+    private fun Filters.applyDefaultFilter(mappings: EventContentSerializerMappings, config: MatrixClientConfiguration): Filters =
+        copy(
+            accountData =
+                (accountData ?: Filters.EventFilter()).copy(types = mappings.globalAccountData.map { it.type }.toSet()),
+            room =
+                (room ?: Filters.RoomFilter()).copy(
+                    accountData =
+                        (room?.accountData ?: Filters.RoomFilter.RoomEventFilter()).copy(
+                            types = mappings.roomAccountData.map { it.type }.toSet()
+                        ),
+                    ephemeral =
+                        (room?.ephemeral ?: Filters.RoomFilter.RoomEventFilter()).copy(
+                            types = mappings.ephemeral.map { it.type }.toSet()
+                        ),
+                    state =
+                        (room?.state ?: Filters.RoomFilter.RoomEventFilter()).copy(
+                            lazyLoadMembers = true,
+                            types = mappings.state.map { it.type }.toSet(),
+                        ),
+                    timeline =
+                        (room?.timeline ?: Filters.RoomFilter.RoomEventFilter()).copy(
+                            types = (mappings.message + mappings.state).map { it.type }.toSet()
+                        ),
+                    includeLeave = config.deleteRooms !is DeleteRooms.OnLeave,
+                ),
+        )
 
     /**
      * Verifies this device non-interactively with the account's recovery key
@@ -1721,6 +1912,7 @@ object MatrixRepository {
                 runCatching { request.cancel() }
                 verificationCollectJob?.cancel()
                 setVerificationUi(VerificationUi.Error("Verification timed out — try your recovery key"))
+                swapToFullSync() // verification-first sync — see [pendingVerificationPhase]
             }
         }
     }
@@ -1822,13 +2014,22 @@ object MatrixRepository {
                 // key arrived ~2s later, restore skipped by the stale cooldown).
                 scope.launch {
                     val prefs = appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE) ?: return@launch
-                    repeat(3) { attempt ->
-                        delay(10_000L * (attempt + 1))
+                    // The backup secret's arrival is out of our control: another
+                    // device answers the secret request whenever it does — 25 s
+                    // in the working run, never (5+ min) in the two failing
+                    // logins (LP3 2026-09-06/07). The old 3-try/90 s ladder
+                    // gave up before late answers could land. Each attempt
+                    // re-requests the missing secrets internally (see
+                    // [restoreMegolmSessions]); a success stamps the cooldown
+                    // and later attempts no-op cheaply.
+                    listOf(10L, 30L, 60L, 120L, 300L, 600L, 1200L).forEach { delayS ->
+                        delay(delayS * 1000)
                         prefs.edit().remove(KEY_RESTORE_LAST_RUN_MS).apply()
                         restoreMegolmSessions()
                     }
                 }
                 markRoomListDirty() // newly verified device → unread counts recompute
+                scope.launch { swapToFullSync() } // verification-first sync — see [pendingVerificationPhase]
                 VerificationUi.Done
             }
             else -> {
@@ -1908,6 +2109,17 @@ object MatrixRepository {
      */
     private suspend fun reRequestMissingSecrets(c: MatrixClient): Boolean = runCatching {
         val keyStore = c.di.get<KeyStore>(KeyStore::class)
+        val tm = c.di.get<StoreTransactionManager>(StoreTransactionManager::class)
+        // An unanswered request must not block the retry ladder (2026-09-07:
+        // Trixnity only drops pending requests after 1 day, so without this the
+        // 10s/30s/60s… ladder re-sent nothing after the first attempt). Purge
+        // pending requests and re-send — a late answer still matches by request
+        // id at accept time, so purging is safe.
+        keyStore.getAllSecretKeyRequests().forEach { req ->
+            req.content.requestId?.let { id ->
+                tm.writeTransaction { keyStore.deleteSecretKeyRequest(id) }
+            }
+        }
         val missing = SecretType.entries.filter { it.cacheable }
             .subtract(keyStore.getSecrets().keys)
             .subtract(
@@ -1916,19 +2128,33 @@ object MatrixRepository {
                     .toSet()
             )
         if (missing.isEmpty()) return@runCatching false
-        // Answers only come back Olm-encrypted from devices that have the
-        // secret — i.e. our own verified devices.
-        val receivers = keyStore.getDeviceKeys(c.userId).first().orEmpty()
-            .filter {
-                it.value.trustLevel.isVerified &&
-                    it.value.value.signed.deviceId != c.deviceId
+        // The local device-key store only knows devices a previous flow happened
+        // to fetch — after repeated logout/logins that's mostly our own dead
+        // past sessions, while the live Beeper clients (which hold the secrets)
+        // were never asked (2026-09-07, the history-stays-encrypted bug).
+        // mautrix/Beeper requests from ALL own devices ("*" semantics). Refresh
+        // own keys from the server first: OutdatedKeysHandler fetches /keys/query
+        // and computes trust for every current device when the user is marked
+        // outdated — poll briefly for new devices to land, then ask them all.
+        val knownBefore = keyStore.getDeviceKeys(c.userId).first().orEmpty().keys
+        c.di.get<StoreTransactionManager>(StoreTransactionManager::class).writeTransaction {
+            keyStore.updateOutdatedKeys { it + c.userId }
+        }
+        withTimeoutOrNull(15_000) {
+            while (keyStore.getDeviceKeys(c.userId).first().orEmpty().keys.size <= knownBefore.size) {
+                delay(500)
             }
-            .map { it.value.value.signed.deviceId }
-            .toSet()
-        if (receivers.isEmpty()) {
-            android.util.Log.w(TAG, "restore: no verified device to re-request secrets from")
+        }
+        val receiverDevices = keyStore.getDeviceKeys(c.userId).first().orEmpty()
+            .filterKeys { it != c.deviceId }
+        if (receiverDevices.isEmpty()) {
+            android.util.Log.w(TAG, "restore: no own device to re-request secrets from")
             return@runCatching false
         }
+        receiverDevices.forEach { (id, dk) ->
+            android.util.Log.i(TAG, "restore: secret-request receiver $id trust=${dk.trustLevel}")
+        }
+        val receivers = receiverDevices.keys
         missing.forEach { secret ->
             val request = SecretKeyRequestEventContent(
                 name = secret.id,
@@ -1939,10 +2165,10 @@ object MatrixRepository {
             c.api.user
                 .sendToDevice(mapOf(c.userId to receivers.associateWith { request }))
                 .getOrThrow()
-            c.di.get<StoreTransactionManager>(StoreTransactionManager::class).writeTransaction {
+            tm.writeTransaction {
                 keyStore.addSecretKeyRequest(StoredSecretKeyRequest(request, receivers, Clock.System.now()))
             }
-            android.util.Log.i(TAG, "restore: re-requested secret ${secret.id} from $receivers")
+            android.util.Log.i(TAG, "restore: re-requested secret ${secret.id} from ${receivers.size} devices")
         }
         true
     }.onFailure {
@@ -1992,8 +2218,6 @@ object MatrixRepository {
             }
             android.util.Log.w(TAG, "restore: cooldown active but backup secret missing — re-running to re-request it")
         }
-        // Written on START: even a scan that dies mid-run won't re-run for a day.
-        prefs.edit().putLong(KEY_RESTORE_LAST_RUN_MS, now).apply()
         // Trixnity's version flow emits its current value immediately — null
         // until the service has actually fetched /room_keys/version. A process
         // restart before that fetch reads as "no backup configured" and stuck
@@ -2039,10 +2263,11 @@ object MatrixRepository {
                 if (scanned % 200 == 0) {
                     android.util.Log.d(TAG, "restore: $scanned/${rooms.size} rooms scanned, $roomsTouched with encrypted content")
                 }
-                // Parked rooms stay parked until the 4h park expires (the
-                // preview/ghost paths re-check them then) — no point re-scanning
-                // them on the daily crawl too (battery 2026-08-17 audit).
-                if (inDecryptRestoreCooldown(roomId)) continue
+                // The futile-restore cooldown no longer skips the room here
+                // (2026-09-07): parked rooms are exactly the ones with stuck
+                // rows, and restoreRoomSessions' local-first re-decrypt is
+                // free (no backup round-trip) — the cooldown gates only the
+                // backup part inside it, so parking stays effective.
                 val events = collectNewestEvents(c, roomId, { maxSize = RESTORE_ROOM_EVENTS }, RESTORE_ROOM_BUDGET_MS)
                     ?: continue
                 val hasEncrypted = events.any {
@@ -2064,6 +2289,12 @@ object MatrixRepository {
             _restoreProgress.value = _restoreProgress.value.copy(scanning = false)
         }
         android.util.Log.d(TAG, "restore: done — $roomsTouched rooms with encrypted content")
+        // Written on COMPLETION: a crawl killed mid-run (update install,
+        // process death) must be able to re-run — stamping at start stranded
+        // a 21:20 crawl killed by the 21:26 update behind the 24h cooldown
+        // (LP3 2026-09-06). The scan is idempotent; re-running costs the
+        // skipped-room re-reads only.
+        prefs.edit().putLong(KEY_RESTORE_LAST_RUN_MS, System.currentTimeMillis()).apply()
         _restoreProgress.value = RestoreProgress(scanned = scanned, roomsTotal = rooms.size, completed = true)
         // Persist (2026-09-01): the in-memory flag dies with the process and
         // the 24h gate keeps the next crawl a no-op, so without this the
@@ -2087,6 +2318,11 @@ object MatrixRepository {
             syncMode = SyncMode.ACTIVE
             inProcessSyncRunning = false
             observedClient = null
+            // Verification-first sync: a torn-down session must not leak the
+            // slim phase into the next one (the next login re-arms it anyway).
+            pendingVerificationPhase = false
+            activeClientConfig = null
+            verificationSyncSwapped.set(false)
             resetVerification()
             e2eeStateCache = null // logged out — no stale verified state
             activeRoomId = null
@@ -2104,6 +2340,13 @@ object MatrixRepository {
             old?.let { runCatching { PushChannel.unregister(ctx, it) } }
             ChatNotifier.clearAll(ctx)
             runCatching { old?.logout() } // API logout + clears Trixnity's store
+                .onFailure {
+                    // A skipped/failed API logout leaks the device server-side
+                    // (2026-09-07: 5 stale "Chats (Light Phone)" devices, one per
+                    // force-killed/expired session — they poisoned the secret-
+                    // request receiver list). Make the leak visible.
+                    android.util.Log.w(TAG, "logout: API logout failed — device stays registered: ${it.message}")
+                }
             runCatching { old?.closeSuspending() }
             ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
             ctx.deleteDatabase(DB_NAME)
@@ -2142,6 +2385,12 @@ object MatrixRepository {
             return if (restored != null) {
                 client = restored
                 observeClient(restored)
+                // Restore path (process restart / update install) mirrors
+                // finishLogin's E2EE wiring: login-only wiring left updated
+                // installs with no verification and no key-backup crawl
+                // (LP3 2026-09-06: the 21:26 update killed the 21:20 crawl
+                // mid-run and nothing on this path ever re-triggered it).
+                scope.launch { armRestoreVerification(restored) }
                 // Show the last-known chats immediately while the resolver's
                 // first pass warms the store (Phase 14 disk cache).
                 if (_roomList.value.isEmpty()) preloadRoomListFromDisk()
@@ -2564,7 +2813,7 @@ object MatrixRepository {
                 RoomListEntry(
                     room = room,
                     nameResolved = room.name != ROOM_NAME_PLACEHOLDER && room.name.isNotBlank() &&
-                        !nameIsGhostLocalpart,
+                        room.name != ROOM_NAME_FALLBACK && !nameIsGhostLocalpart,
                     previewResolved = room.lastMessage.isNotBlank() &&
                         !room.lastMessage.startsWith("[Encrypted"),
                     previewRetryAtMs = 0L,
@@ -3607,7 +3856,10 @@ object MatrixRepository {
             // Restore only when the page still has undecryptable events — an
             // all-decrypted room needs no priming, so skip the parse entirely
             // (battery 2026-08-17: the seed restore ran on every page read).
-            if (seed.any { it.content?.isFailure == true } && !inDecryptRestoreCooldown(matrixRoomId)) {
+            // The futile-restore cooldown now guards only the backup round-trip
+            // inside [restoreRoomSessions] — the local-first re-decrypt of
+            // already-held sessions must run regardless (2026-09-07).
+            if (seed.any { it.content?.isFailure == true }) {
                 // Park genuinely undecryptable pages too — the same futility signal
                 // as the page-build path, so opening a doomed room doesn't re-seed
                 // a restore on every read (battery 2026-08-17 audit).
@@ -4531,7 +4783,31 @@ object MatrixRepository {
         val encryptionService = c.di.get<RoomEventEncryptionService>(
             org.koin.core.qualifier.named<MegolmRoomEventEncryptionService>(),
         )
-        sessionIds.forEach { sessionId ->
+        // Local-first pass (2026-09-07): a row whose megolm session is already
+        // in the olm store but whose stored content is a cached failure only
+        // needs a re-decrypt — getTimelineEvent never retries (drive 5), and
+        // the futile-restore cooldown was parking exactly these rooms (Fen and
+        // Friends: messageIndex 2 of a session holding indexes 0,1,3 — key
+        // present, row stuck). Free and local: no backup round-trip, no
+        // cooldown. The cooldown keeps guarding the network part below.
+        val olmStore = c.di.get<OlmCryptoStore>(OlmCryptoStore::class)
+        var resolvedLocal = 0
+        val backupSessionIds = sessionIds.filter { sessionId ->
+            if (olmStore.getInboundMegolmSession(sessionId, matrixRoomId).firstOrNull() != null) {
+                resolvedLocal += reDecryptSessionEvents(
+                    matrixRoomId, sessionId, stuckRowsForSession(c, matrixRoomId, sessionId)
+                        .ifEmpty { sessionToEvents[sessionId].orEmpty() },
+                    timelineStore, tm, encryptionService,
+                )
+                false
+            } else true
+        }
+        if (backupSessionIds.isEmpty()) {
+            android.util.Log.d(TAG, "restoreRoomSessions: $matrixRoomId — all ${sessionIds.size} session(s) local, re-decrypted $resolvedLocal event(s), no backup needed")
+            return resolvedLocal
+        }
+        if (inDecryptRestoreCooldown(matrixRoomId)) return resolvedLocal
+        backupSessionIds.forEach { sessionId ->
             try {
                 val ok = withTimeoutOrNull(KEY_BACKUP_LOAD_TIMEOUT_MS) {
                     keyBackup.loadMegolmSession(matrixRoomId, sessionId)
@@ -4541,25 +4817,15 @@ object MatrixRepository {
                     // Re-decrypt + re-persist: getTimelineEvent only reads the
                     // store's cached result, so a freshly loaded session never
                     // reaches the stored rows through it (drive 5, 2026-09-06:
-                    // loaded 1/1, then 49/50 events still stuck). Run the megolm
-                    // service directly and write the result back.
-                    var resolved = 0
-                    val sessionEvents = sessionToEvents[sessionId].orEmpty()
-                    sessionEvents.forEach { te ->
-                        val messageEvent = te.event as? ClientEvent.RoomEvent.MessageEvent<*>
-                        if (messageEvent == null) return@forEach
-                        val decrypted = runCatching { encryptionService.decrypt(messageEvent) }
-                            .getOrNull()?.getOrNull() ?: return@forEach
-                        tm.writeTransaction {
-                            timelineStore.update(te.event.id, matrixRoomId) { old ->
-                                old?.copy(content = Result.success(decrypted))
-                            }
-                        }
-                        resolved++
-                    }
+                    // loaded 1/1, then 49/50 events still stuck).
+                    resolvedLocal += reDecryptSessionEvents(
+                        matrixRoomId, sessionId, stuckRowsForSession(c, matrixRoomId, sessionId)
+                            .ifEmpty { sessionToEvents[sessionId].orEmpty() },
+                        timelineStore, tm, encryptionService,
+                    )
                     android.util.Log.d(
                         TAG,
-                        "restoreRoomSessions: re-decrypted $resolved/${sessionEvents.size} events for $matrixRoomId / $sessionId",
+                        "restoreRoomSessions: loaded session $sessionId for $matrixRoomId (${sessionToEvents[sessionId]?.size ?: 0} event(s))",
                     )
                 } else {
                     android.util.Log.w(TAG, "restoreRoomSessions: loadMegolmSession timed out for $matrixRoomId / $sessionId")
@@ -4569,7 +4835,73 @@ object MatrixRepository {
             }
         }
         android.util.Log.d(TAG, "restoreRoomSessions: loaded $loaded/${sessionIds.size} sessions for $matrixRoomId")
-        return loaded
+        return resolvedLocal
+    }
+
+    /** All timeline rows of [matrixRoomId] encrypted with [sessionId] whose
+     *  stored content is still unresolved (null or failure). The re-decrypt
+     *  passes used to cover only the collected page window, so the older rows
+     *  of an already-loaded session stayed stuck after a fresh login (the
+     *  room's oldest messages, 2026-09-07). Plain LIKE scan — bounded by the
+     *  room's row count, only runs while unresolved rows exist. */
+    private suspend fun stuckRowsForSession(
+        c: MatrixClient,
+        matrixRoomId: RoomId,
+        sessionId: String,
+    ): List<TimelineEvent> {
+        val db = runCatching { c.di.get<TrixnityRoomDatabase>(TrixnityRoomDatabase::class) }.getOrNull()
+            ?: return emptyList()
+        val json = runCatching { c.di.get<Json>() }.getOrNull() ?: return emptyList()
+        return chainDbSemaphore.withPermit {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    db.openHelper.writableDatabase.query(
+                        "SELECT value FROM TimelineEvent WHERE roomId = ? AND value LIKE ?",
+                        arrayOf<Any>(matrixRoomId.full, "%$sessionId%"),
+                    ).use { cursor ->
+                        buildList {
+                            while (cursor.moveToNext()) {
+                                val value = cursor.getString(0) ?: continue
+                                val te = runCatching { json.decodeFromString<TimelineEvent>(value) }.getOrNull() ?: continue
+                                val content = te.event.content as? EncryptedMessageEventContent.MegolmEncryptedMessageEventContent
+                                if (content?.sessionId != sessionId) continue
+                                if (te.content?.getOrNull() != null) continue // already resolved
+                                add(te)
+                            }
+                        }
+                    }
+                }.getOrDefault(emptyList())
+            }
+        }
+    }
+
+    /** Re-decrypts [events] with the megolm service and persists the plaintext
+     *  back into the timeline store — the shared tail of the local-first and
+     *  backup-restored passes of [restoreRoomSessions]. Returns the count of
+     *  events that decrypted. */
+    private suspend fun reDecryptSessionEvents(
+        matrixRoomId: RoomId,
+        sessionId: String,
+        sessionEvents: List<TimelineEvent>,
+        timelineStore: RoomTimelineStore,
+        tm: StoreTransactionManager,
+        encryptionService: RoomEventEncryptionService,
+    ): Int {
+        var resolved = 0
+        sessionEvents.forEach { te ->
+            val messageEvent = te.event as? ClientEvent.RoomEvent.MessageEvent<*>
+            if (messageEvent == null) return@forEach
+            val decrypted = runCatching { encryptionService.decrypt(messageEvent) }
+                .getOrNull()?.getOrNull() ?: return@forEach
+            tm.writeTransaction {
+                timelineStore.update(te.event.id, matrixRoomId) { old ->
+                    old?.copy(content = Result.success(decrypted))
+                }
+            }
+            resolved++
+        }
+        android.util.Log.d(TAG, "restoreRoomSessions: re-decrypted $resolved/${sessionEvents.size} events for $matrixRoomId / $sessionId")
+        return resolved
     }
 
     /** Asks our own other devices for the megolm sessions of undecryptable
@@ -6657,6 +6989,31 @@ object MatrixRepository {
                     android.util.Log.w(TAG, "notification watcher: sync-state collector ended: ${e.message}")
                 }
             }.also { notificationWatcherJobs.add(it) }
+            // Server unread counts (2026-09-07): the sync response carries the
+            // server-computed per-room unread_notifications.notification_count —
+            // the same account-wide unread truth the Beeper clients show. Trixnity
+            // only stores it as an unencrypted-room cap (and its own badge state
+            // machine dies on fresh logins — see [localReceiptUnread]), so collect
+            // it directly here. Incremental syncs only include changed rooms, which
+            // is exactly when a count can move.
+            scope.launch {
+                try {
+                    c.api.sync.subscribeAsFlow().collect { syncEvents ->
+                        val join = syncEvents.syncResponse.room?.join ?: return@collect
+                        var changed = false
+                        for ((roomId, joinedRoom) in join) {
+                            val count = joinedRoom.unreadNotifications?.notificationCount?.toInt() ?: 0
+                            if (serverUnreadCounts[roomId.full] != count) {
+                                serverUnreadCounts[roomId.full] = count
+                                changed = true
+                            }
+                        }
+                        if (changed) markRoomListDirty()
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.w(TAG, "server-unread collector ended: ${e.message}")
+                }
+            }.also { notificationWatcherJobs.add(it) }
             try {
                 // roomId.full -> last relevant event id seen so far ("" = none yet).
                 val seen = java.util.concurrent.ConcurrentHashMap<String, String>()
@@ -6949,7 +7306,11 @@ object MatrixRepository {
             ) null else senderNameOf(c, roomId, te.event.sender),
             preview = preview,
             direct = room.isDirect,
-            unreadCount = unreadCounts[roomId.full]?.toLong() ?: 0L,
+            unreadCount = maxOf(
+                unreadCounts[roomId.full]?.toLong() ?: 0L,
+                serverUnreadCounts[roomId.full]?.toLong() ?: 0L,
+                localReceiptUnread(c, roomId.full),
+            ),
         )
         // Persist "alerted this event" so a later watcher registration (new
         // process) doesn't re-alert it — the registration-time notify gate.
@@ -7347,6 +7708,15 @@ object MatrixRepository {
     private val unreadCounts = java.util.concurrent.ConcurrentHashMap<String, Int>()
 
     /**
+     * Server-computed per-room unread notification counts, captured straight
+     * from the sync response (see the collector in [observeNotifications]).
+     * Trixnity's own badge pipeline is empty after a fresh login, so this —
+     * the account-wide truth every other Beeper client shows — is the primary
+     * badge source; the local receipt comparison is the last fallback.
+     */
+    private val serverUnreadCounts = java.util.concurrent.ConcurrentHashMap<String, Int>()
+
+    /**
      * Unread count to show in the list. While a MarkRead is pending (the
      * store hasn't echoed it yet — see [pendingReadClear]) the count reads 0;
      * the suppression lifts when the echo confirms (notification count 0) or
@@ -7373,12 +7743,55 @@ object MatrixRepository {
         }
     }
 
+    /**
+     * Local unread fallback (2026-09-07): Trixnity's notification count is
+     * dead after a fresh login — its state machine defaults rooms to "read"
+     * when the last message isn't in the local timeline (our battery-thin
+     * sync leaves most rooms with 0-1 timeline rows) and only re-checks when
+     * a NEW event lands, so the badge never appears for exactly the rooms
+     * with unread history. Fallback: compare the account's own read receipt
+     * against the newest receipt from other members (the bridge posts each
+     * sender's receipt at their own last event, so max(other ts) tracks the
+     * newest non-self activity). Ours older → something unread. Fully local,
+     * one indexed lookup; the badge is boolean, so the count is 1.
+     * ponytail: heuristic — non-bridged rooms where senders never post
+     * receipts can under-report; upgrade to a bounded chain walk if seen.
+     */
+    private suspend fun localReceiptUnread(c: MatrixClient, roomId: String): Long {
+        val db = runCatching { c.di.get<TrixnityRoomDatabase>(TrixnityRoomDatabase::class) }.getOrNull()
+            ?: return 0L
+        return chainDbSemaphore.withPermit {
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    db.openHelper.writableDatabase.query(
+                        "SELECT userId, MAX(je.value) FROM RoomUserReceipts, " +
+                            "json_tree(RoomUserReceipts.value) je " +
+                            "WHERE RoomUserReceipts.roomId=? AND je.key='ts' AND je.type='integer' " +
+                            "GROUP BY userId",
+                        arrayOf(roomId),
+                    ).use { cur ->
+                        var own = -1L
+                        var othersMax = -1L
+                        while (cur.moveToNext()) {
+                            if (cur.isNull(1)) continue
+                            val ts = cur.getLong(1)
+                            if (cur.getString(0) == c.userId.full) own = maxOf(own, ts)
+                            else othersMax = maxOf(othersMax, ts)
+                        }
+                        if (own >= 0 && othersMax > own) 1L else 0L
+                    }
+                }.getOrDefault(0L)
+            }
+        }
+    }
+
     private fun resetRoomList() {
         roomListCache.clear()
         roomSigSeen.clear()
         bridgeBotByRoom.clear()
         pendingReadClear.clear()
         unreadCounts.clear()
+        serverUnreadCounts.clear()
         effectiveLastCache.clear()
         ghostResolveInFlight.clear()
         _roomList.value = emptyList()
@@ -7807,8 +8220,17 @@ object MatrixRepository {
             null -> ts
         }
         // An unverified device can't decrypt — suppress unread for encrypted
-        // rooms only; unencrypted ones stay readable.
-        val storeUnread = if (verified || !room.encrypted) (unreadCounts[key]?.toLong() ?: 0L) else 0
+        // rooms only; unencrypted ones stay readable. Local receipt fallback
+        // (2026-09-07): Trixnity's notification count is empty after a fresh
+        // login (its state machine marks timeline-less rooms read) — the
+        // own-receipt-vs-others comparison catches those.
+        val storeUnread = if (verified || !room.encrypted) {
+            maxOf(
+                unreadCounts[key]?.toLong() ?: 0L,
+                serverUnreadCounts[key]?.toLong() ?: 0L,
+                localReceiptUnread(c, key),
+            )
+        } else 0
         val cleared = pendingReadClear[key]
         val unread = servedUnread(
             key,
@@ -7828,10 +8250,21 @@ object MatrixRepository {
         val newMessageArrived = lastEventId != null && lastEventId != prev?.room?.lastEventId
 
         val nameResolved = prev?.nameResolved == true && !stateChanged
-        val name = if (nameResolved) {
+        val freshName = if (nameResolved) {
             prev.room.name
         } else {
             resolveRoomName(c, roomId, room, nameMemo)
+        }
+        // Flash guard (2026-09-07): on a cold start the first passes run before
+        // the sync has delivered member state — resolveRoomName falls through
+        // to the "Chat" placeholder, and publishing it overwrote the disk
+        // cache's previously resolved names (the user-visible name flash when
+        // the list opens). Keep the previous resolved name and stay unresolved;
+        // a later pass with real heroes replaces it.
+        val name = if (freshName == ROOM_NAME_FALLBACK && prev?.nameResolved == true) {
+            prev.room.name
+        } else {
+            freshName
         }
 
         val preview: String
@@ -7917,7 +8350,10 @@ object MatrixRepository {
                 pinned = flags[key]?.pinned ?: false,
                 muted = flags[key]?.muted ?: false,
             ),
-            nameResolved = true,
+            // The fallback isn't a resolution: heroes may still be on their way
+            // (the full initial sync lands after the slim-phase rooms did) —
+            // keep re-resolving so the row upgrades when they arrive.
+            nameResolved = name != ROOM_NAME_FALLBACK,
             previewResolved = previewResolved,
             previewRetryAtMs = previewRetryAtMs,
         )
@@ -8196,7 +8632,7 @@ object MatrixRepository {
             }.filter { it.isNotBlank() }
             if (names.isNotEmpty()) return names.joinToString(", ")
         }
-        return "Chat"
+        return ROOM_NAME_FALLBACK
     }
 
     /** A hero's display name, or its localpart when the user lookup times out. */
@@ -9076,6 +9512,73 @@ object MatrixRepository {
         addInterceptor(claimFailuresFixInterceptor)
     }.also { android.util.Log.d(TAG, "HTTP-TRAFFIC: generic engine armed") }
 
+    // Steady-state sync filters. Sync payload slimming (PLAN §8.1,
+    // 2026-08-28): the default filter ships every presence update + a huge
+    // per-room timeline on the 1284-room account (30-50 s CPU per /sync).
+    // Presence is never displayed — set_presence=offline only stops OUR
+    // updates, this filter stops receiving theirs — and the timeline limit
+    // bounds each room's per-sync window. Trixnity's applyDefaultFilter()
+    // merges over it, keeping lazy-load members + the event-type whitelists.
+    //
+    // Ephemeral slimming (2026-08-31): applyDefaultFilter REPLACES types with
+    // its own whitelist, so narrowing must go through notTypes, which
+    // survives the merge. Nothing renders incoming typing (the composer only
+    // sends it), and it is the noisiest per-sync element in active rooms —
+    // both filters drop m.typing. The syncOnce filter (background rounds +
+    // push wakes) also drops m.receipt: seen/delivered only matter while the
+    // tool is open, and the long-poll (syncFilter) delivers them fresh the
+    // moment it is.
+    private val fullSyncFilters = Filters(
+        presence = Filters.EventFilter(notTypes = setOf("*")),
+        room = Filters.RoomFilter(
+            timeline = Filters.RoomFilter.RoomEventFilter(limit = SYNC_TIMELINE_LIMIT),
+            ephemeral = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("m.typing")),
+        ),
+    )
+
+    // SYNC-PERF-SPEC §Phase 1 lever 3, partially reverted (LP3 2026-09-06):
+    // this filter once stripped room state (`state = notTypes="*"`). That is
+    // only safe while the DB already holds state from an earlier initial
+    // sync — but the initial sync can run under THIS filter: the
+    // verification-phase swap nulls the batch token, and a slow-sync round /
+    // push wake can win the queue and consume the one-shot initial sync
+    // (measured: 302 rooms × 20-timeline stored, zero m.room.name/create/
+    // power_levels → every room "Chat" forever, LP3 2026-09-06). State
+    // DELTAS in background rounds are rare (name/membership changes) — keep
+    // state here so an initial sync is always correct. The ephemeral
+    // slimming (m.typing/m.receipt) stays. Invites are unaffected:
+    // rooms.invite carries stripped invite_state.
+    private val fullSyncOnceFilters = Filters(
+        presence = Filters.EventFilter(notTypes = setOf("*")),
+        room = Filters.RoomFilter(
+            timeline = Filters.RoomFilter.RoomEventFilter(limit = SYNC_TIMELINE_LIMIT_BACKGROUND),
+            ephemeral = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("m.typing", "m.receipt")),
+        ),
+    )
+
+    /**
+     * Verification-phase variant of both sync filters (verification-first
+     * sync, LP3 2026-09-06): a fresh login that will run device verification
+     * must not let the initial sync outrun the SAS emoji round-trips. Under
+     * the full background filter the initial sync ingests 6902 events (301
+     * rooms × 20 timeline + state) over ~180 s of serialized emit, and the
+     * partner's accept — a to-device event — only lands on the sync round
+     * AFTER the initial sync, so the emoji screen appeared ~3 min late.
+     * Timeline limit 1 + no state/ephemeral/presence shrinks the same sync to
+     * ~300 room-list bones; to-device events (the whole verification chain)
+     * and the room-list bones still flow. [swapToFullSync] restores
+     * [fullSyncFilters]/[fullSyncOnceFilters] once verification completes, is
+     * skipped, or times out.
+     */
+    private val verificationSyncFilters = Filters(
+        presence = Filters.EventFilter(notTypes = setOf("*")),
+        room = Filters.RoomFilter(
+            timeline = Filters.RoomFilter.RoomEventFilter(limit = 1L),
+            ephemeral = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("*")),
+            state = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("*")),
+        ),
+    )
+
     /** Client configuration, differing only in the client name (the Beeper
      *  profile identifies as "chats-beeper" so its device appears distinctly).
      *  Qualified `httpClientEngine`: inside the receiver lambda, the
@@ -9083,51 +9586,20 @@ object MatrixRepository {
      *  a silent no-op that left the client on Ktor's default engine (no
      *  logging/claim interceptors). */
     private fun clientConfiguration(name: String): MatrixClientConfiguration.() -> Unit = {
+        // Capture the configuration being built — its filter properties are
+        // `var`, so [swapToFullSync] can switch them without a client rebuild.
+        activeClientConfig = this
         this.name = name
         httpClientEngine = this@MatrixRepository.httpClientEngine
         modulesFactories = createTrixnityDefaultModuleFactories() + ::plaintextVerificationModule + ::archiveMappingsModule + ::permissiveKeyRequestModule
-        // Sync payload slimming (PLAN §8.1, 2026-08-28): the default filter
-        // ships every presence update + a huge per-room timeline on the
-        // 1284-room account (30-50 s CPU per /sync). Presence is never
-        // displayed — set_presence=offline only stops OUR updates, this filter
-        // stops receiving theirs — and the timeline limit bounds each room's
-        // per-sync window. Trixnity's applyDefaultFilter() merges over it,
-        // keeping lazy-load members + the event-type whitelists.
-        //
-        // Ephemeral slimming (2026-08-31): applyDefaultFilter REPLACES types
-        // with its own whitelist, so narrowing must go through notTypes, which
-        // survives the merge. Nothing renders incoming typing (the composer
-        // only sends it), and it is the noisiest per-sync element in active
-        // rooms — both filters drop m.typing. The syncOnce filter (background
-        // rounds + push wakes) also drops m.receipt: seen/delivered only matter
-        // while the tool is open, and the long-poll (syncFilter) delivers them
-        // fresh the moment it is.
-        syncFilter = Filters(
-            presence = Filters.EventFilter(notTypes = setOf("*")),
-            room = Filters.RoomFilter(
-                timeline = Filters.RoomFilter.RoomEventFilter(limit = SYNC_TIMELINE_LIMIT),
-                ephemeral = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("m.typing")),
-            ),
-        )
-        syncOnceFilter = Filters(
-            presence = Filters.EventFilter(notTypes = setOf("*")),
-            room = Filters.RoomFilter(
-                timeline = Filters.RoomFilter.RoomEventFilter(limit = SYNC_TIMELINE_LIMIT_BACKGROUND),
-                ephemeral = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("m.typing", "m.receipt")),
-                // SYNC-PERF-SPEC §Phase 1 lever 3: state deltas are pure
-                // overhead in background rounds — the UI reads the local store,
-                // and the active long-poll (syncFilter keeps state) catches up
-                // names/membership the moment the screen is on. notTypes="*"
-                // survives applyDefaultFilter's merge (same mechanism as the
-                // ephemeral slimming above — Trixnity replaces `types`, not
-                // `notTypes`). Invites are unaffected: rooms.invite carries
-                // stripped invite_state, which the state filter doesn't govern.
-                // Gap-fill trade-off: a `limited` background timeline no longer
-                // carries the gap's state delta (member events in a >20 burst
-                // gap arrive on the next active round instead).
-                state = Filters.RoomFilter.RoomEventFilter(notTypes = setOf("*")),
-            ),
-        )
+        // Verification-first sync: a login that will verify (see
+        // [pendingVerificationPhase]) builds with the slim filters on BOTH the
+        // long-poll and the background/initial filter — measured 6902-event /
+        // 180 s initial ingest on a fresh install (LP3 2026-09-06), with the
+        // SAS emoji stuck behind it. The swap back to the full set happens in
+        // [swapToFullSync] once the verification outcome is known.
+        syncFilter = if (pendingVerificationPhase) verificationSyncFilters else fullSyncFilters
+        syncOnceFilter = if (pendingVerificationPhase) verificationSyncFilters else fullSyncOnceFilters
         // Room "last relevant event" = actual messages only (reference-messenger
         // shape): m.replace edits (Beeper's re-import wall) and reactions no
         // longer advance lastRelevantEventId — so they don't wake the
@@ -9362,22 +9834,6 @@ object MatrixRepository {
                 ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
             }
         }, SYNC_STOP_DELAY_MS)
-    }
-
-    private suspend fun roomDisplayName(c: MatrixClient, roomId: RoomId, room: MatrixRoom): String {
-        room.name?.explicitName?.takeIf { it.isNotBlank() }?.let { return it }
-        val heroes = titleHeroesOf(c, roomId, room)
-        if (heroes.isNotEmpty()) {
-            val names = heroes.mapNotNull { hero ->
-                withTimeoutOrNull(ROOM_BUDGET_MS) {
-                    c.user.getById(roomId, hero).firstOrNull()?.name
-                }?.takeIf { it.isNotBlank() }
-                    ?: bridgeContactNameOf(hero)
-                    ?: hero.localpart
-            }.filter { it.isNotBlank() }
-            if (names.isNotEmpty()) return names.joinToString(", ")
-        }
-        return "Chat"
     }
 
     /** True for m.replace edit events — Beeper re-imports old media as edits
@@ -9810,6 +10266,11 @@ object MatrixRepository {
 
     // Room-list resolver (Phase 5).
     private const val ROOM_NAME_PLACEHOLDER = "…"
+    /** [resolveRoomName]'s dead-end fallback — a row showing this is NOT a
+     *  resolved name and must be re-resolved on a later pass (heroes land
+     *  with the full initial sync, after the slim-phase pass stamped "Chat"
+     *  as resolved forever, LP3 2026-09-06). */
+    private const val ROOM_NAME_FALLBACK = "Chat"
     /** Per-pass time budget; the resolver loops until the list is settled. */
     private const val ROOM_LIST_PASS_BUDGET_MS = 12_000L
     /** Breather between passes; a settled pass itself takes milliseconds. */
@@ -9852,6 +10313,14 @@ object MatrixRepository {
      *  timer cancels it (Trixnity's own timeout events are not surfaced — see
      *  onVerificationState). */
     private const val VERIFICATION_TIMEOUT_MS = 10 * 60_000L
+
+    /** Verification-first sync: delay before the single [swapToFullSync] retry. */
+    private const val SYNC_SWAP_RETRY_MS = 5_000L
+
+    /** Verification-first sync: how long [swapToFullSync] waits for the client
+     *  init coroutine to finish its one-time filter upload (`started` flag). */
+    private const val SYNC_SWAP_INIT_WAIT_MS = 30_000L
+
     /** Grace window after their SAS start in which an m.unexpected_message
      *  cancel is read as a fan-out collision (two devices answered at once),
      *  not a real cancel — see the Cancel branch in onVerificationState. */

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -7742,7 +7742,13 @@ object MatrixRepository {
                             "AND json_extract(TimelineEvent.value,'$.event.type') " +
                             "  IN ('m.room.message','m.room.encrypted') " +
                             "AND json_extract(TimelineEvent.value,'$.event.sender') != ? " +
-                            "AND json_extract(TimelineEvent.value,'$.event.origin_server_ts') > ? " +
+                            // CAST: query() binds selection args as TEXT, and an
+                            // INTEGER column never compares greater than a TEXT
+                            // value in SQLite — the un-cast version silently
+                            // counted 0 for every room (LP3: Jasmine/Rose
+                            // genuinely-unread badges vanished).
+                            "AND json_extract(TimelineEvent.value,'$.event.origin_server_ts') " +
+                            "  > CAST(? AS INTEGER) " +
                             "LIMIT 99)",
                         arrayOf(roomId, c.userId.full, own.toString()),
                     ).use { cur -> if (cur.moveToFirst()) cur.getLong(0) else 0L }

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -3361,16 +3361,10 @@ object MatrixRepository {
     private fun isFloodGhost(c: MatrixClient, te: TimelineEvent, context: List<TimelineEvent>): Boolean {
         if (txnIdOf(te) == null) return false
         val ts = te.event.originTimestamp
-        var nearby = 0
-        for (other in context) {
-            if (other.event.id == te.event.id) continue
-            if (txnIdOf(other) == null) continue
-            if (kotlin.math.abs(other.event.originTimestamp - ts) < GHOST_BURST_WINDOW_MS) {
-                nearby++
-                if (nearby >= GHOST_FLOOD_THRESHOLD) return true
-            }
-        }
-        return false
+        return context.count { other ->
+            other.event.id != te.event.id && txnIdOf(other) != null &&
+                kotlin.math.abs(other.event.originTimestamp - ts) < GHOST_BURST_WINDOW_MS
+        } >= GHOST_FLOOD_THRESHOLD
     }
 
     /**
@@ -3536,14 +3530,8 @@ object MatrixRepository {
     /** First occurrence of each content signature in [raw] (chain order,
      *  newest first). Events without readable content fall back to their
      *  event id, so they pass through untouched. */
-    private fun dedupeChain(c: MatrixClient, raw: List<TimelineEvent>): List<TimelineEvent> {
-        val seen = HashSet<String>()
-        val out = ArrayList<TimelineEvent>(raw.size)
-        for (te in raw) {
-            if (seen.add(contentSignature(c, te) ?: te.event.id.full)) out += te
-        }
-        return out
-    }
+    private fun dedupeChain(c: MatrixClient, raw: List<TimelineEvent>): List<TimelineEvent> =
+        raw.distinctBy { contentSignature(c, it) ?: it.event.id.full }
 
     /** Bounds concurrent [readTimelineChainFromDb] walks — see the comment there. */
     private val chainDbSemaphore = Semaphore(permits = 2)
@@ -6002,11 +5990,8 @@ object MatrixRepository {
 
     /** Drops the oldest cached notes past [VOICE_CACHE_MAX_FILES]. */
     private fun trimVoiceCache(dir: java.io.File) {
-        val files = dir.listFiles()?.toMutableList() ?: return
-        files.sortBy { it.lastModified() }
-        while (files.size > VOICE_CACHE_MAX_FILES) {
-            runCatching { files.removeAt(0).delete() }
-        }
+        dir.listFiles()?.sortedBy { it.lastModified() }?.dropLast(VOICE_CACHE_MAX_FILES)
+            ?.forEach { runCatching { it.delete() } }
     }
 
     /**
@@ -7820,13 +7805,8 @@ object MatrixRepository {
      */
     private fun hasPendingResolveWork(): Boolean {
         val now = android.os.SystemClock.elapsedRealtime()
-        for (e in roomListCache.values) {
-            if (!e.previewResolved && now >= e.previewRetryAtMs) return true
-        }
-        for (e in effectiveLastCache.values) {
-            if (e.retryAtMs > 0L && now >= e.retryAtMs) return true
-        }
-        return false
+        return roomListCache.values.any { !it.previewResolved && now >= it.previewRetryAtMs } ||
+            effectiveLastCache.values.any { it.retryAtMs > 0L && now >= it.retryAtMs }
     }
 
     private fun startRoomListResolver(c: MatrixClient) {
@@ -8374,19 +8354,20 @@ object MatrixRepository {
         withTimeoutOrNull(NETWORK_MAP_BUDGET_MS) {
             // Every space id (account spaces AND community/group spaces): an
             // account space's child that is itself a space is a sub-space
-            // whose own children still belong to the same network.
+            // whose own children still belong to the same network. The single
+            // pass below also collects the spaces for the labeling pass.
             val spaceIds = HashSet<String>()
             val spaceNameBySpaceId = HashMap<String, String>()
+            val spaces = ArrayList<Pair<RoomId, MatrixRoom>>()
             for ((spaceId, spaceFlow) in rooms) {
                 val space = spaceFlow.filterNotNull().firstOrNull() ?: continue
                 if (space.createEventContent?.type is CreateEventContent.RoomType.Space) {
                     spaceIds += spaceId.full
                     spaceNameBySpaceId[spaceId.full] = space.name?.explicitName.orEmpty()
+                    spaces += spaceId to space
                 }
             }
-            for ((spaceId, spaceFlow) in rooms) {
-                val space = spaceFlow.filterNotNull().firstOrNull() ?: continue
-                if (space.createEventContent?.type !is CreateEventContent.RoomType.Space) continue
+            for ((spaceId, space) in spaces) {
                 val spaceName = space.name?.explicitName.orEmpty()
                 if (!isAccountSpace(spaceName, space.name?.heroes.orEmpty())) continue
                 val label = networkLabelOf(spaceName)

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -1859,15 +1859,15 @@ object MatrixRepository {
         val c = client ?: return com.thelightphone.sdk.shared.LightServiceMethod.GetE2eeState.Response(
             verified = false, canVerify = false, detail = "not logged in",
         )
+        fun response(verified: Boolean, devices: Int) =
+            com.thelightphone.sdk.shared.LightServiceMethod.GetE2eeState.Response(
+                verified = verified,
+                canVerify = devices > 0,
+                detail = if (verified) null else "not verified",
+            )
         val now = android.os.SystemClock.elapsedRealtime()
         e2eeStateCache?.let { (fetchedAt, verified, devices) ->
-            if (now - fetchedAt < E2EE_STATE_TTL_MS) {
-                return com.thelightphone.sdk.shared.LightServiceMethod.GetE2eeState.Response(
-                    verified = verified,
-                    canVerify = devices > 0,
-                    detail = if (verified) null else "not verified",
-                )
-            }
+            if (now - fetchedAt < E2EE_STATE_TTL_MS) return response(verified, devices)
         }
         // Same policy as [isDeviceVerified]: a timed-out trust read must NOT
         // read as "unverified" — on the LP3 the first read after opening the
@@ -1884,11 +1884,7 @@ object MatrixRepository {
             c.api.device.getDevices().getOrNull()?.map { it.deviceId }?.filter { it != c.deviceId }?.size ?: 0
         }.getOrDefault(0)
         e2eeStateCache = Triple(now, verified, devices)
-        return com.thelightphone.sdk.shared.LightServiceMethod.GetE2eeState.Response(
-            verified = verified,
-            canVerify = devices > 0,
-            detail = if (verified) null else "not verified",
-        )
+        return response(verified, devices)
     }
 
     /** Starts SAS verification with the account's other devices (their Beeper app responds). */
@@ -2279,7 +2275,7 @@ object MatrixRepository {
                     // nothing to load) — an all-decrypted room must not have its
                     // restore suppressed for the next 4h.
                     if (loaded == 0 && events.any { it.content?.isFailure == true }) {
-                        parkFutileRestore(roomId)
+                        decryptRestoreCooldown.park(roomId.full, DECRYPT_RESTORE_COOLDOWN_MS)
                     }
                     roomsTouched++
                 }
@@ -2565,52 +2561,46 @@ object MatrixRepository {
         }
     }
 
-    /** Room → elapsed-realtime timestamp until which the futile key-backup
-     *  restore is suppressed. */
-    private val decryptRestoreCooldown = java.util.concurrent.ConcurrentHashMap<String, Long>()
+    /** key → elapsed-realtime timestamp until which an action is suppressed
+     *  (park now, re-check later). ConcurrentHashMap-backed like the raw maps
+     *  it replaces. */
+    private class CooldownMap {
+        private val untilByKey = java.util.concurrent.ConcurrentHashMap<String, Long>()
 
-    /** True while the room's key-backup restore is in the futile cooldown. */
-    private fun inDecryptRestoreCooldown(matrixRoomId: RoomId): Boolean {
-        val until = decryptRestoreCooldown[matrixRoomId.full] ?: return false
-        return android.os.SystemClock.elapsedRealtime() < until
+        fun park(key: String, durationMs: Long) {
+            untilByKey[key] = android.os.SystemClock.elapsedRealtime() + durationMs
+        }
+
+        /** True when the cooldown has elapsed (or was never parked). */
+        fun allowed(key: String): Boolean =
+            android.os.SystemClock.elapsedRealtime() >= (untilByKey[key] ?: 0L)
+
+        /** The parked retry timestamp, 0 when none is parked. */
+        fun until(key: String): Long = untilByKey[key] ?: 0L
+
+        fun remove(key: String) {
+            untilByKey.remove(key)
+        }
     }
 
-    /** Room → elapsed-realtime until which the quiet-room guard skips the
-     *  API-resolve attempts for still-unresolved reactions (battery: a key
-     *  that never arrives must not turn the 3 s guard into a decrypt loop —
-     *  see [patchReactionTags]). */
-    private val reactionResolveRetryAt = java.util.concurrent.ConcurrentHashMap<String, Long>()
-
-    /** Parks a room whose key-backup restore found nothing to load: every retry
-     *  path (preview, ghost walk, page build, daily crawl) stops re-attempting
-     *  until the park expires. In-band sync decryption is unaffected, so a real
-     *  session arriving mid-park still decrypts events. (Battery
+    /** Suppresses the futile key-backup restore per room: every retry path
+     *  (preview, ghost walk, page build, daily crawl) stops re-attempting
+     *  until the park expires. In-band sync decryption is unaffected, so a
+     *  real session arriving mid-park still decrypts events. (Battery
      *  audit — the pre-verification history on this account never gets its
      *  sessions back, yet the retry paths re-ran doomed restores every 60-120 s,
      *  ~3 cores continuously.) */
-    private fun parkFutileRestore(matrixRoomId: RoomId) {
-        decryptRestoreCooldown[matrixRoomId.full] =
-            android.os.SystemClock.elapsedRealtime() + DECRYPT_RESTORE_COOLDOWN_MS
-    }
+    private val decryptRestoreCooldown = CooldownMap()
 
-    /** Room → elapsed-realtime until which a failed gap backfill is suppressed
-     *  (battery: a fill that errored (network, token) is retried at most once
-     *  per [GAP_BACKFILL_COOLDOWN_MS], and only while the room is active). */
-    private val gapBackfillCooldown = java.util.concurrent.ConcurrentHashMap<String, Long>()
+    /** Suppresses the quiet-room guard's API-resolve attempts for
+     *  still-unresolved reactions (battery: a key that never arrives must not
+     *  turn the 3 s guard into a decrypt loop — see [patchReactionTags]). */
+    private val reactionResolveRetryAt = CooldownMap()
 
-    /** True when a gap backfill is allowed for this room: the user must be
-     *  looking at it (throttle — the fill is a network + store + decrypt cost)
-     *  and a previous failed fill's cooldown must have elapsed. */
-    private fun isGapBackfillAllowed(matrixRoomId: RoomId): Boolean {
-        if (activeRoomId != matrixRoomId.full) return false
-        val until = gapBackfillCooldown[matrixRoomId.full] ?: return true
-        return android.os.SystemClock.elapsedRealtime() >= until
-    }
-
-    private fun parkGapBackfill(matrixRoomId: RoomId) {
-        gapBackfillCooldown[matrixRoomId.full] =
-            android.os.SystemClock.elapsedRealtime() + GAP_BACKFILL_COOLDOWN_MS
-    }
+    /** Suppresses a failed gap backfill per room (battery: a fill that errored
+     *  (network, token) is retried at most once per [GAP_BACKFILL_COOLDOWN_MS],
+     *  and only while the room is active). */
+    private val gapBackfillCooldown = CooldownMap()
 
     /** Fills a room's timeline gap from the server (Trixnity's
      *  [de.connect2x.trixnity.client.room.TimelineEventHandler.unsafeFillTimelineGaps]
@@ -2653,7 +2643,7 @@ object MatrixRepository {
             )
         } ?: "timeout after ${budget / 1000}ms"
         if (failure.isNotEmpty()) {
-            parkGapBackfill(matrixRoomId)
+            gapBackfillCooldown.park(matrixRoomId.full, GAP_BACKFILL_COOLDOWN_MS)
             android.util.Log.d(
                 TAG,
                 "gap backfill failed for $matrixRoomId ($failure) — retrying in ${GAP_BACKFILL_COOLDOWN_MS / 1000}s",
@@ -2818,6 +2808,13 @@ object MatrixRepository {
     private var activeRoomRefreshJob: Job? = null
 
     /** Recomputes and re-stores a room's newest page in the background. */
+    /** Shared timeout config for the [MatrixClient.room.getTimelineEvent]
+     *  re-reads that nudge a decrypt to land. */
+    private val timelineEventConfig: GetTimelineEventConfig.() -> Unit = {
+        fetchTimeout = FETCH_TIMEOUT_SECONDS.seconds
+        decryptionTimeout = FETCH_TIMEOUT_SECONDS.seconds
+    }
+
     private fun refreshMessagePage(roomId: String, limit: Int = THREAD_PAGE_SIZE) {
         // Battery: never pile up refreshes — a tick that
         // finds one already in flight is a no-op (the 2s ticker used to launch
@@ -2839,6 +2836,15 @@ object MatrixRepository {
                 // skipped the rebuild — the anni-room misorder stayed on the
                 // LP3 screen long after the page build was fixed.
                 val cached = messagePageCache[roomId]
+
+                fun publish(page: MessagesPage, limit: Int, advanceHead: Boolean) {
+                    messagePageCache[roomId] = MessagePageEntry(
+                        page, limit, android.os.SystemClock.elapsedRealtime(),
+                    )
+                    if (advanceHead) lastRefreshedEventId[roomId] = lastId
+                    saveMessagePageToDisk(roomId, page)
+                    bumpMessagePageRevision(roomId)
+                }
                 if (cached != null && cached.limit >= limit && lastRefreshedEventId[roomId] == lastId) {
                     // Read receipts are ephemeral — they never move the room's
                     // last TIMELINE event, so this quiet-room guard would freeze
@@ -2851,11 +2857,7 @@ object MatrixRepository {
                     // and disk stay untouched.
                     runCatching {
                         patchQuietPage(c, roomId, cached)?.let { updated ->
-                            messagePageCache[roomId] = MessagePageEntry(
-                                updated, cached.limit, android.os.SystemClock.elapsedRealtime(),
-                            )
-                            saveMessagePageToDisk(roomId, updated)
-                            bumpMessagePageRevision(roomId)
+                            publish(updated, cached.limit, advanceHead = false)
                         }
                     }
                     return@launch
@@ -2872,25 +2874,11 @@ object MatrixRepository {
                     runCatching { incrementMessagePage(c, roomId, prevId, lastId, cached) }.getOrNull()
                 } else null
                 if (updated != null) {
-                    messagePageCache[roomId] = MessagePageEntry(
-                        updated,
-                        cached!!.limit,
-                        android.os.SystemClock.elapsedRealtime(),
-                    )
-                    lastRefreshedEventId[roomId] = lastId
-                    saveMessagePageToDisk(roomId, updated)
-                    bumpMessagePageRevision(roomId)
+                    publish(updated, cached!!.limit, advanceHead = true)
                 } else {
                     runCatching {
                         val page = computeMessagesPage(roomId, null, limit)
-                        messagePageCache[roomId] = MessagePageEntry(
-                            page,
-                            limit,
-                            android.os.SystemClock.elapsedRealtime(),
-                        )
-                        lastRefreshedEventId[roomId] = lastId
-                        saveMessagePageToDisk(roomId, page)
-                        bumpMessagePageRevision(roomId)
+                        publish(page, limit, advanceHead = true)
                     }
                 }
             } finally {
@@ -3011,22 +2999,17 @@ object MatrixRepository {
         }
         val resolved = mutableListOf<TimelineEvent>()
         if (unresolved.isNotEmpty()) {
-            val now = android.os.SystemClock.elapsedRealtime()
-            if (now >= (reactionResolveRetryAt[roomId] ?: 0L)) {
-                val config: GetTimelineEventConfig.() -> Unit = {
-                    fetchTimeout = FETCH_TIMEOUT_SECONDS.seconds
-                    decryptionTimeout = FETCH_TIMEOUT_SECONDS.seconds
-                }
+            if (reactionResolveRetryAt.allowed(roomId)) {
                 for (te in unresolved.take(REACTION_RESOLVE_MAX)) {
                     withTimeoutOrNull(DECRYPT_WAIT_MS) {
-                        c.room.getTimelineEvent(matrixRoomId, te.event.id, config)
+                        c.room.getTimelineEvent(matrixRoomId, te.event.id, timelineEventConfig)
                             .filterNotNull().firstOrNull { it.content?.getOrNull() != null }
                     }?.let { resolved.add(it) }
                 }
                 // A dry pass backs the resolve attempts off — the walk below
                 // still picks the tag up the moment sync lands the key and the
                 // store row resolves on its own.
-                if (resolved.isEmpty()) reactionResolveRetryAt[roomId] = now + REACTION_RESOLVE_RETRY_MS
+                if (resolved.isEmpty()) reactionResolveRetryAt.park(roomId, REACTION_RESOLVE_RETRY_MS)
                 else reactionResolveRetryAt.remove(roomId)
             }
         }
@@ -3456,7 +3439,9 @@ object MatrixRepository {
         // instant. A gap on the room's newest event (the walk's head) is
         // skipped: the next sync naturally picks up those events, and
         // Trixnity's fill no-ops it anyway.
-        if (!fast && isGapBackfillAllowed(matrixRoomId)) {
+        // Active room only (throttle — the fill is a network + store + decrypt
+        // cost) and a previous failed fill's cooldown must have elapsed.
+        if (!fast && activeRoomId == matrixRoomId.full && gapBackfillCooldown.allowed(matrixRoomId.full)) {
             val head = events.firstOrNull()
             val gapEvent = events.firstOrNull { it.gap != null && it !== head }
             if (gapEvent != null) {
@@ -3495,18 +3480,13 @@ object MatrixRepository {
                 // nothing to load, back off for a cooldown — the normal sync path
                 // decrypts in-band the moment real sessions do arrive.
                 val roomKey = matrixRoomId.full
-                val cooldownUntil = decryptRestoreCooldown[roomKey]
-                if (cooldownUntil == null || android.os.SystemClock.elapsedRealtime() >= cooldownUntil) {
+                if (decryptRestoreCooldown.allowed(roomKey)) {
                     val loaded = restoreRoomSessions(c, matrixRoomId, undecrypted)
-                    if (loaded == 0) parkFutileRestore(matrixRoomId)
-                    val config: GetTimelineEventConfig.() -> Unit = {
-                        fetchTimeout = FETCH_TIMEOUT_SECONDS.seconds
-                        decryptionTimeout = FETCH_TIMEOUT_SECONDS.seconds
-                    }
+                    if (loaded == 0) decryptRestoreCooldown.park(roomKey, DECRYPT_RESTORE_COOLDOWN_MS)
                     val resolved = HashMap<String, TimelineEvent>()
                     undecrypted.forEach { te ->
                         withTimeoutOrNull(DECRYPT_WAIT_MS) {
-                            c.room.getTimelineEvent(matrixRoomId, te.event.id, config).firstOrNull()
+                            c.room.getTimelineEvent(matrixRoomId, te.event.id, timelineEventConfig).firstOrNull()
                                 ?.takeIf { it.content?.getOrNull() != null }
                         }?.let { resolved[te.event.id.full] = it }
                     }
@@ -3626,12 +3606,8 @@ object MatrixRepository {
     ): TimelineEvent? {
         val echo = events.firstOrNull { txnIdOf(it) == txnId } ?: return null
         if (echo.content?.getOrNull() != null) return echo
-        val config: GetTimelineEventConfig.() -> Unit = {
-            fetchTimeout = FETCH_TIMEOUT_SECONDS.seconds
-            decryptionTimeout = FETCH_TIMEOUT_SECONDS.seconds
-        }
         return withTimeoutOrNull(DECRYPT_WAIT_MS) {
-            c.room.getTimelineEvent(matrixRoomId, echo.event.id, config)
+            c.room.getTimelineEvent(matrixRoomId, echo.event.id, timelineEventConfig)
                 .filterNotNull().firstOrNull { it.content?.getOrNull() != null }
         }
     }
@@ -3828,7 +3804,7 @@ object MatrixRepository {
                 // as the page-build path, so opening a doomed room doesn't re-seed
                 // a restore on every read.
                 if (restoreRoomSessions(c, matrixRoomId, seed) == 0) {
-                    parkFutileRestore(matrixRoomId)
+                    decryptRestoreCooldown.park(matrixRoomId.full, DECRYPT_RESTORE_COOLDOWN_MS)
                 }
             }
         }
@@ -3846,7 +3822,7 @@ object MatrixRepository {
         // the restore cooldown they can't succeed — skip them (battery audit);
         // the fast first-page path skips them too (the background refresh
         // re-reads with full decrypt handling).
-        if (!fast && !inDecryptRestoreCooldown(matrixRoomId)) {
+        if (!fast && decryptRestoreCooldown.allowed(matrixRoomId.full)) {
             repeat(DECRYPT_RETRIES) {
                 val stillEncrypted = events.any { it.content?.isFailure == true }
                 if (!stillEncrypted) return@repeat
@@ -4301,6 +4277,14 @@ object MatrixRepository {
      *  its own stale map. */
     private val reactionCache = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, Map<String, List<String>>>>()
 
+    /** Value in a room-keyed TTL cache ([key] → fetchedAt elapsedRealtime to
+     *  value) when its fetch is within [ttlMs] of [now], else null. */
+    private fun <V> java.util.concurrent.ConcurrentHashMap<String, Pair<Long, V>>.fresh(
+        key: String,
+        ttlMs: Long,
+        now: Long,
+    ): V? = this[key]?.takeIf { (fetchedAt, _) -> now - fetchedAt < ttlMs }?.second
+
     /** [sendStatusByEventId] with a per-room TTL cache — statuses must reach
      *  messages on ANY page (the FAIL marker disappearing once a message
      *  scrolled past the newest page read as "sent but not delivered"),
@@ -4311,9 +4295,7 @@ object MatrixRepository {
     ): Map<String, String> {
         val key = matrixRoomId.full
         val now = android.os.SystemClock.elapsedRealtime()
-        sendStatusCache[key]?.let { (fetchedAt, map) ->
-            if (now - fetchedAt < SEND_STATUS_CACHE_TTL_MS) return map
-        }
+        sendStatusCache.fresh(key, SEND_STATUS_CACHE_TTL_MS, now)?.let { return it }
         val map = sendStatusByEventId(c, matrixRoomId)
         sendStatusCache[key] = now to map
         return map
@@ -4410,9 +4392,7 @@ object MatrixRepository {
     ): Map<String, List<String>> {
         val key = matrixRoomId.full
         val now = android.os.SystemClock.elapsedRealtime()
-        reactionCache[key]?.let { (fetchedAt, map) ->
-            if (now - fetchedAt < SEND_STATUS_CACHE_TTL_MS) return map
-        }
+        reactionCache.fresh(key, SEND_STATUS_CACHE_TTL_MS, now)?.let { return it }
         val map = reactionLabelsByEvent(c, matrixRoomId)
         if (map == null) {
             // Head read timed out — stale tags beat no tags (they self-heal on
@@ -4748,7 +4728,7 @@ object MatrixRepository {
             android.util.Log.d(TAG, "restoreRoomSessions: $matrixRoomId — all ${sessionIds.size} session(s) local, re-decrypted $resolvedLocal event(s), no backup needed")
             return resolvedLocal
         }
-        if (inDecryptRestoreCooldown(matrixRoomId)) return resolvedLocal
+        if (decryptRestoreCooldown.allowed(matrixRoomId.full)) return resolvedLocal
         backupSessionIds.forEach { sessionId ->
             try {
                 val ok = withTimeoutOrNull(KEY_BACKUP_LOAD_TIMEOUT_MS) {
@@ -5598,31 +5578,24 @@ object MatrixRepository {
             if (current != null && current !== c) c = current
         }
         val matrixRoomId = RoomId(roomId)
-        val te = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-            var event: TimelineEvent? = null
-            repeat(MEDIA_CONTENT_RETRIES) {
-                event = c.room.getTimelineEvent(matrixRoomId, EventId(eventId)).firstOrNull()
-                if (event?.content?.getOrNull() != null) return@withTimeoutOrNull event
-                // An older note's megolm session is often not in the local
-                // store (sessions load lazily per room, mostly via getMessages)
-                // — the content stays encrypted and the note silently "doesn't
-                // play". Pull the session from the key
-                // backup, then re-read so decryption can land. Retried on every
-                // iteration (unless parked): a session the backup index hadn't
-                // caught up with on the first try may be there a moment later.
-                // EXPLICIT play bypasses the futile-restore park: a
-                // freshly-arrived note whose session isn't cached yet would
-                // otherwise be unrecoverable for 4h. Parking
-                // still fires on failure, so repeated taps on a genuinely
-                // undecryptable note keep backing off (other paths honor it).
-                if (event?.content?.isFailure == true) {
-                    if (restoreRoomSessions(c, matrixRoomId, listOf(event)) == 0) {
-                        parkFutileRestore(matrixRoomId)
-                    }
+        val te = resolvedTimelineEvent(c, matrixRoomId, eventId) { event ->
+            // An older note's megolm session is often not in the local
+            // store (sessions load lazily per room, mostly via getMessages)
+            // — the content stays encrypted and the note silently "doesn't
+            // play". Pull the session from the key
+            // backup, then re-read so decryption can land. Retried on every
+            // iteration (unless parked): a session the backup index hadn't
+            // caught up with on the first try may be there a moment later.
+            // EXPLICIT play bypasses the futile-restore park: a
+            // freshly-arrived note whose session isn't cached yet would
+            // otherwise be unrecoverable for 4h. Parking
+            // still fires on failure, so repeated taps on a genuinely
+            // undecryptable note keep backing off (other paths honor it).
+            if (event?.content?.isFailure == true) {
+                if (restoreRoomSessions(c, matrixRoomId, listOf(event)) == 0) {
+                    decryptRestoreCooldown.park(matrixRoomId.full, DECRYPT_RESTORE_COOLDOWN_MS)
                 }
-                delay(MEDIA_CONTENT_RETRY_DELAY_MS)
             }
-            event
         }
         val content = te?.content?.getOrNull()
         if (content == null && te?.content?.isFailure == true) {
@@ -5848,14 +5821,7 @@ object MatrixRepository {
      * calls [stopAudioPlayback]).
      */
     private fun releaseFinishedPlayback() {
-        playingAudioEventId = null
-        pausedAudioEventId = null
-        playingAudioRoomId = null
-        runCatching { audioPlayer?.stop() }
-        runCatching { audioPlayer?.release() }
-        audioPlayer = null
-        audioPlayerFile?.delete()
-        audioPlayerFile = null
+        stopAudioPlayback(releaseFocus = false)
     }
 
     /**
@@ -5949,8 +5915,10 @@ object MatrixRepository {
         return out
     }
 
-    /** Stops any in-flight voice-note playback and clears its state. */
-    private fun stopAudioPlayback() {
+    /** Stops any in-flight voice-note playback and clears its state. The audio
+     *  focus is kept when [releaseFocus] is false (natural completion — see
+     *  [releaseFinishedPlayback]). */
+    private fun stopAudioPlayback(releaseFocus: Boolean = true) {
         playingAudioEventId = null
         pausedAudioEventId = null
         playingAudioRoomId = null
@@ -5959,6 +5927,7 @@ object MatrixRepository {
         audioPlayer = null
         audioPlayerFile?.delete()
         audioPlayerFile = null
+        if (!releaseFocus) return
         audioFocusRequest?.let { focus ->
             runCatching {
                 (appContext?.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager)
@@ -6294,6 +6263,29 @@ object MatrixRepository {
     }
 
     /**
+     * Re-reads an event until its content resolves (the decrypt is async on
+     * encrypted rooms — the first read can lag) or [MEDIA_CONTENT_RETRIES]
+     * attempts pass, bounded by [MEDIA_BUDGET_MS]. [onStillEncrypted] runs per
+     * unresolved attempt (playback uses it to pull the megolm session from the
+     * key backup); the last (possibly unresolved) event is returned.
+     */
+    private suspend fun resolvedTimelineEvent(
+        c: MatrixClient,
+        matrixRoomId: RoomId,
+        eventId: String,
+        onStillEncrypted: suspend (TimelineEvent?) -> Unit = {},
+    ): TimelineEvent? = withTimeoutOrNull(MEDIA_BUDGET_MS) {
+        var event: TimelineEvent? = null
+        repeat(MEDIA_CONTENT_RETRIES) {
+            event = c.room.getTimelineEvent(matrixRoomId, EventId(eventId)).firstOrNull()
+            if (event?.content?.getOrNull() != null) return@withTimeoutOrNull event
+            onStillEncrypted(event)
+            delay(MEDIA_CONTENT_RETRY_DELAY_MS)
+        }
+        event
+    }
+
+    /**
      * Display-ready JPEG for an image message: reads the event from the store,
      * downloads its media (decrypting when the room is encrypted — the
      * timeline content carries the EncryptedFile), compresses to a
@@ -6324,15 +6316,7 @@ object MatrixRepository {
         // The event's content can lag its first read on encrypted rooms (the
         // decrypt is async) — re-read a few times before giving up, or the row
         // stays on its text fallback even though the media exists.
-        val te = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-            var event: TimelineEvent? = null
-            repeat(MEDIA_CONTENT_RETRIES) {
-                event = c.room.getTimelineEvent(matrixRoomId, EventId(eventId)).firstOrNull()
-                if (event?.content?.getOrNull() != null) return@withTimeoutOrNull event
-                delay(MEDIA_CONTENT_RETRY_DELAY_MS)
-            }
-            event
-        }
+        val te = resolvedTimelineEvent(c, matrixRoomId, eventId)
         val content = when (val raw = te?.content?.getOrNull()) {
             // Beeper's RCS bridge sends direct photos as m.file with an image/*
             // mimetype instead of m.image — accept both,
@@ -6394,15 +6378,7 @@ object MatrixRepository {
         if (eventId.startsWith(LOCAL_PENDING_ID_PREFIX)) return false
         val ctx = appContext ?: return false
         val matrixRoomId = RoomId(roomId)
-        val te = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-            var event: TimelineEvent? = null
-            repeat(MEDIA_CONTENT_RETRIES) {
-                event = c.room.getTimelineEvent(matrixRoomId, EventId(eventId)).firstOrNull()
-                if (event?.content?.getOrNull() != null) return@withTimeoutOrNull event
-                delay(MEDIA_CONTENT_RETRY_DELAY_MS)
-            }
-            event
-        }
+        val te = resolvedTimelineEvent(c, matrixRoomId, eventId)
         val content = when (val raw = te?.content?.getOrNull()) {
             is RoomMessageEventContent.FileBased.Image -> raw
             is RoomMessageEventContent.FileBased.File ->
@@ -9072,14 +9048,15 @@ object MatrixRepository {
         // background with a session restore (the copies' originals are old
         // messages whose keys load from the backup — slow, so not on the
         // resolver's critical path). Keep the server's values until it lands.
-        if (inDecryptRestoreCooldown(matrixRoomId)) {
+        if (decryptRestoreCooldown.allowed(matrixRoomId.full)) {
             // Parked room (futile restore): a ghost walk can't resolve it
             // either — the originals' sessions are gone, so the dedup can't
             // identify the real event. Retry at the park's end, not in 2
             // minutes.
             effectiveLastCache[key] = EffectiveLast(
                 serverLastId, prev?.effectiveEventId ?: serverLastId, prev?.effectiveTs ?: serverTs,
-                retryAtMs = decryptRestoreCooldown[key] ?: (now + GHOST_WALK_RETRY_MS),
+                retryAtMs = decryptRestoreCooldown.until(key).takeIf { it > 0L }
+                    ?: (now + GHOST_WALK_RETRY_MS),
             )
             return (prev?.effectiveEventId ?: serverLastId) to (prev?.effectiveTs ?: serverTs)
         }
@@ -9209,8 +9186,8 @@ object MatrixRepository {
             // room's state change re-resolves this preview fresh. Park the
             // room instead of re-attempting every 60 s forever; the park also
             // lets the resolver's pass loop idle (no pending work to wake for).
-            parkFutileRestore(roomId)
-            return Triple("", false, decryptRestoreCooldown[roomId.full] ?: 0L)
+            decryptRestoreCooldown.park(roomId.full, DECRYPT_RESTORE_COOLDOWN_MS)
+            return Triple("", false, decryptRestoreCooldown.until(roomId.full))
         }
         val text = previewText(te) ?: ""
         val encrypted = text.startsWith("[Encrypted")
@@ -9232,8 +9209,8 @@ object MatrixRepository {
             preview,
             !encrypted,
             if (encrypted) {
-                parkFutileRestore(roomId)
-                decryptRestoreCooldown[roomId.full] ?: 0L
+                decryptRestoreCooldown.park(roomId.full, DECRYPT_RESTORE_COOLDOWN_MS)
+                decryptRestoreCooldown.until(roomId.full)
             } else 0L,
         )
     }

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
@@ -9079,26 +9078,20 @@ object MatrixRepository {
             )
             return null to 0L
         }
-        // Suspicious (dropped by the dedup, or inside a flood): resolve in the
-        // background with a session restore (the copies' originals are old
-        // messages whose keys load from the backup — slow, so not on the
-        // resolver's critical path). Keep the server's values until it lands.
+        // Suspicious (dropped by the dedup, or inside a flood): keep the
+        // last-known-good (or the raw head — only reachable for renderable
+        // heads now that the park above runs first) until the background
+        // walk lands. The walk is skipped while a futile-restore park is
+        // active (the originals' sessions are gone — it can't resolve);
+        // the retry then aligns with the park's end instead of the default
+        // GHOST_WALK_RETRY_MS.
         if (decryptRestoreCooldown.allowed(matrixRoomId.full)) {
-            // Parked room (futile restore): a ghost walk can't resolve it
-            // either — the originals' sessions are gone, so the dedup can't
-            // identify the real event. Retry at the park's end, not in 2
-            // minutes.
-            effectiveLastCache[key] = EffectiveLast(
-                serverLastId, prev?.effectiveEventId ?: serverLastId, prev?.effectiveTs ?: serverTs,
-                retryAtMs = decryptRestoreCooldown.until(key).takeIf { it > 0L }
-                    ?: (now + GHOST_WALK_RETRY_MS),
-            )
-            return (prev?.effectiveEventId ?: serverLastId) to (prev?.effectiveTs ?: serverTs)
+            enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
         }
-        enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
         effectiveLastCache[key] = EffectiveLast(
             serverLastId, prev?.effectiveEventId ?: serverLastId, prev?.effectiveTs ?: serverTs,
-            retryAtMs = now + GHOST_WALK_RETRY_MS,
+            retryAtMs = decryptRestoreCooldown.until(key).takeIf { it > 0L }
+                ?: (now + GHOST_WALK_RETRY_MS),
         )
         return (prev?.effectiveEventId ?: serverLastId) to (prev?.effectiveTs ?: serverTs)
     }

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -1266,6 +1266,62 @@ object MatrixRepository {
         }
     }
 
+    /**
+     * Login-path session teardown: stops the old client's sync loop and clears
+     * the stale in-process-sync state (a stale flag would silently kill the
+     * new session's sync — re-login after restore/expiry). Runs inside
+     * [initMutex] BEFORE the new credentials are exchanged, so a failed
+     * exchange leaves the old session stopped.
+     */
+    private suspend fun stopPreviousSession() {
+        client?.let { old ->
+            runCatching { old.stopSync() }
+            client = null
+        }
+        inProcessSyncJob?.cancel()
+        inProcessSyncJob = null
+        inProcessSyncRunning = false
+        setConnectionState(ChatConnectionState.Connecting)
+    }
+
+    /**
+     * The client build + session-prefs tail shared by [login] and
+     * [beeperLogin]. The verification-first sync configuration is read at
+     * client build time, so the phase flag must be armed BEFORE create
+     * (finishLogin runs too late — see [pendingVerificationPhase]).
+     * Call after [stopPreviousSession], inside [initMutex].
+     */
+    private suspend fun createAndStoreClient(
+        ctx: Context,
+        authProviderData: MatrixClientAuthProviderData,
+        configName: String,
+        baseUrl: String,
+        loginMode: String,
+        removeKeys: List<String> = emptyList(),
+    ): MatrixClient {
+        // The raw ktor client (used for Beeper's provision API, see
+        // [bridgeContacts]) does not attach the bearer — persist it here.
+        val accessToken = (authProviderData as? ClassicMatrixClientAuthProviderData)?.accessToken
+        pendingVerificationPhase = true
+        verificationSyncSwapped.set(false)
+        val loginResult = MatrixClient.create(
+            repositoriesModule = RepositoriesModule.room(databaseBuilder(ctx)),
+            mediaStoreModule = MediaStoreModule.okio(mediaDir(ctx)),
+            cryptoDriverModule = CryptoDriverModule.libOlm(),
+            authProviderData = authProviderData,
+            configuration = clientConfiguration(configName),
+        ).onFailure { pendingVerificationPhase = false }.getOrThrow()
+        ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_HOMESERVER, baseUrl)
+            .putString(KEY_USER_ID, loginResult.userId.full)
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_LOGIN_MODE, loginMode)
+            .also { editor -> removeKeys.forEach { key -> editor.remove(key) } }
+            .apply()
+        return loginResult
+    }
+
     suspend fun login(
         homeserver: String,
         user: String,
@@ -1274,16 +1330,7 @@ object MatrixRepository {
     ): Result<MatrixClient> = runCatching {
         val ctx = appContext ?: error("companion not initialized")
         initMutex.withLock {
-            client?.let { old ->
-                runCatching { old.stopSync() }
-                client = null
-            }
-            // The old client's loop is stopped; a stale flag would silently
-            // kill the new session's sync (re-login after restore/expiry).
-            inProcessSyncJob?.cancel()
-            inProcessSyncJob = null
-            inProcessSyncRunning = false
-            setConnectionState(ChatConnectionState.Connecting)
+            stopPreviousSession()
 
             // Accept a bare domain ("matrix.org") or a full URL; .well-known
             // discovery runs when the host serves one, else the URL is used as-is.
@@ -1297,31 +1344,12 @@ object MatrixRepository {
                 loginType = if (tokenLogin) LoginType.Token() else LoginType.Password,
                 initialDeviceDisplayName = "Chats (Light Phone)",
             ).getOrThrow()
-            // The raw ktor client (used for Beeper's provision API, see
-            // [bridgeContacts]) does not attach the bearer — persist it here.
-            val accessToken = (authProviderData as? ClassicMatrixClientAuthProviderData)?.accessToken
-            // Verification-first sync: the configuration lambda is read at
-            // client build time, so the phase flag must be armed BEFORE
-            // create (finishLogin runs too late — see [pendingVerificationPhase]).
-            pendingVerificationPhase = true
-            verificationSyncSwapped.set(false)
-            val loginResult = authProviderData
-                .let { authProviderData ->
-                    MatrixClient.create(
-                        repositoriesModule = RepositoriesModule.room(databaseBuilder(ctx)),
-                        mediaStoreModule = MediaStoreModule.okio(mediaDir(ctx)),
-                        cryptoDriverModule = CryptoDriverModule.libOlm(),
-                        authProviderData = authProviderData,
-                        configuration = clientConfiguration("chats"),
-                    ).onFailure { pendingVerificationPhase = false }.getOrThrow()
-                }
-            ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-                .edit()
-                .putString(KEY_HOMESERVER, baseUrl.toString())
-                .putString(KEY_USER_ID, loginResult.userId.full)
-                .putString(KEY_ACCESS_TOKEN, accessToken)
-                .putString(KEY_LOGIN_MODE, "homeserver")
-                .apply()
+            val loginResult = createAndStoreClient(
+                ctx, authProviderData,
+                configName = "chats",
+                baseUrl = baseUrl.toString(),
+                loginMode = "homeserver",
+            )
             finishLogin(ctx, loginResult)
         }
     }
@@ -1387,14 +1415,7 @@ object MatrixRepository {
     suspend fun beeperLogin(email: String, code: String): Result<MatrixClient> = runCatching {
         val ctx = appContext ?: error("companion not initialized")
         initMutex.withLock {
-            client?.let { old ->
-                runCatching { old.stopSync() }
-                client = null
-            }
-            inProcessSyncJob?.cancel()
-            inProcessSyncJob = null
-            inProcessSyncRunning = false
-            setConnectionState(ChatConnectionState.Connecting)
+            stopPreviousSession()
 
             val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             val requestId = prefs.getString(KEY_BEEPER_REQUEST_ID, null)
@@ -1428,27 +1449,13 @@ object MatrixRepository {
                 loginType = LoginType.Unknown("org.matrix.login.jwt", buildJsonObject {}),
                 initialDeviceDisplayName = "Chats (Light Phone)",
             ).getOrThrow()
-            val accessToken = (authProviderData as? ClassicMatrixClientAuthProviderData)?.accessToken
-            // Verification-first sync — see the homeserver [login] path.
-            pendingVerificationPhase = true
-            verificationSyncSwapped.set(false)
-            val loginResult = authProviderData
-                .let { authProviderData ->
-                    MatrixClient.create(
-                        repositoriesModule = RepositoriesModule.room(databaseBuilder(ctx)),
-                        mediaStoreModule = MediaStoreModule.okio(mediaDir(ctx)),
-                        cryptoDriverModule = CryptoDriverModule.libOlm(),
-                        authProviderData = authProviderData,
-                        configuration = clientConfiguration("chats-beeper"),
-                    ).onFailure { pendingVerificationPhase = false }.getOrThrow()
-                }
-            prefs.edit()
-                .putString(KEY_HOMESERVER, BEEPER_HOMESERVER)
-                .putString(KEY_USER_ID, loginResult.userId.full)
-                .putString(KEY_ACCESS_TOKEN, accessToken)
-                .putString(KEY_LOGIN_MODE, "beeper")
-                .remove(KEY_BEEPER_REQUEST_ID)
-                .apply()
+            val loginResult = createAndStoreClient(
+                ctx, authProviderData,
+                configName = "chats-beeper",
+                baseUrl = BEEPER_HOMESERVER,
+                loginMode = "beeper",
+                removeKeys = listOf(KEY_BEEPER_REQUEST_ID),
+            )
             finishLogin(ctx, loginResult)
         }
     }

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -6892,19 +6892,26 @@ object MatrixRepository {
      */
     private fun observeNotifications(c: MatrixClient) {
         android.util.Log.d(TAG, "notification watcher starting for ${c.userId.full}")
+        // The per-collector scaffold: launch, swallow+log the collector's end
+        // (a dead flow must not kill the watcher), register the job.
+        fun watch(name: String, block: suspend () -> Unit) {
+            scope.launch {
+                try {
+                    block()
+                } catch (e: Exception) {
+                    android.util.Log.w(TAG, "$name: ${e.message}")
+                }
+            }.also { notificationWatcherJobs.add(it) }
+        }
         val watcher = scope.launch {
             // Flag-change watcher: a global push-rule
             // change (any device toggled mute) re-reads the flags cache so the
             // room list / contact panel reflect it within seconds instead of on
             // the next TTL rebuild. The first emission is the baseline.
-            scope.launch {
-                try {
-                    c.di.get<GlobalAccountDataStore>(GlobalAccountDataStore::class)
-                        .get(PushRulesEventContent::class).collect { invalidateAllRoomFlags() }
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "flag watcher: push-rule collector ended: ${e.message}")
-                }
-            }.also { notificationWatcherJobs.add(it) }
+            watch("flag watcher: push-rule collector ended") {
+                c.di.get<GlobalAccountDataStore>(GlobalAccountDataStore::class)
+                    .get(PushRulesEventContent::class).collect { invalidateAllRoomFlags() }
+            }
             // Settle flags (first-message ping drop fix): a room whose
             // newest message is already unread when its collector starts — or whose
             // first message arrives right after (it registered empty) — may notify
@@ -6918,20 +6925,16 @@ object MatrixRepository {
             // per-room collectors below on other threads.
             val seenInitialSync = java.util.concurrent.atomic.AtomicBoolean(false)
             val settled = java.util.concurrent.atomic.AtomicBoolean(false)
-            scope.launch {
-                try {
-                    c.syncState.collect { state ->
-                        when (state) {
-                            SyncState.INITIAL_SYNC -> seenInitialSync.set(true)
-                            SyncState.RUNNING -> settled.set(true)
-                            SyncState.STARTED -> if (!seenInitialSync.get()) settled.set(true)
-                            else -> {}
-                        }
+            watch("notification watcher: sync-state collector ended") {
+                c.syncState.collect { state ->
+                    when (state) {
+                        SyncState.INITIAL_SYNC -> seenInitialSync.set(true)
+                        SyncState.RUNNING -> settled.set(true)
+                        SyncState.STARTED -> if (!seenInitialSync.get()) settled.set(true)
+                        else -> {}
                     }
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "notification watcher: sync-state collector ended: ${e.message}")
                 }
-            }.also { notificationWatcherJobs.add(it) }
+            }
             // Server unread counts: the sync response carries the
             // server-computed per-room unread_notifications.notification_count —
             // the same account-wide unread truth the Beeper clients show. Trixnity
@@ -6939,24 +6942,20 @@ object MatrixRepository {
             // machine dies on fresh logins — see [localReceiptUnread]), so collect
             // it directly here. Incremental syncs only include changed rooms, which
             // is exactly when a count can move.
-            scope.launch {
-                try {
-                    c.api.sync.subscribeAsFlow().collect { syncEvents ->
-                        val join = syncEvents.syncResponse.room?.join ?: return@collect
-                        var changed = false
-                        for ((roomId, joinedRoom) in join) {
-                            val count = joinedRoom.unreadNotifications?.notificationCount?.toInt() ?: 0
-                            if (serverUnreadCounts[roomId.full] != count) {
-                                serverUnreadCounts[roomId.full] = count
-                                changed = true
-                            }
+            watch("server-unread collector ended") {
+                c.api.sync.subscribeAsFlow().collect { syncEvents ->
+                    val join = syncEvents.syncResponse.room?.join ?: return@collect
+                    var changed = false
+                    for ((roomId, joinedRoom) in join) {
+                        val count = joinedRoom.unreadNotifications?.notificationCount?.toInt() ?: 0
+                        if (serverUnreadCounts[roomId.full] != count) {
+                            serverUnreadCounts[roomId.full] = count
+                            changed = true
                         }
-                        if (changed) markRoomListDirty()
                     }
-                } catch (e: Exception) {
-                    android.util.Log.w(TAG, "server-unread collector ended: ${e.message}")
+                    if (changed) markRoomListDirty()
                 }
-            }.also { notificationWatcherJobs.add(it) }
+            }
             try {
                 // roomId.full -> last relevant event id seen so far ("" = none yet).
                 val seen = java.util.concurrent.ConcurrentHashMap<String, String>()

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -6953,11 +6953,11 @@ object MatrixRepository {
                 }
             }
             // Server unread counts: the sync response carries the
-            // server-computed per-room unread_notifications.notification_count —
-            // the same account-wide unread truth the Beeper clients show. Trixnity
-            // only stores it as an unencrypted-room cap (and its own badge state
-            // machine dies on fresh logins — see [localReceiptUnread]), so collect
-            // it directly here. Incremental syncs only include changed rooms, which
+            // server-computed per-room unread_notifications.notification_count.
+            // It's the fallback badge while a room's own receipt hasn't synced
+            // yet ([receiptCursorUnread] is primary) — it counts non-message
+            // classes our client never renders, so it must not override the
+            // cursor. Incremental syncs only include changed rooms, which
             // is exactly when a count can move.
             watch("server-unread collector ended") {
                 c.api.sync.subscribeAsFlow().collect { syncEvents ->
@@ -6993,23 +6993,7 @@ object MatrixRepository {
                         if (!registered.add(key)) continue
                         val job = scope.launch {
                             try {
-                                // The v5 badge feed: room.unreadMessageCount is
-                                // gone, so the notification service's per-room
-                                // notification count drives the list badge. Its
-                                // first emission is a cache read; changes mark
-                                // the resolver dirty (skip-gate).
-                                // Tied to this job via coroutineScope so a room
-                                // collector ending (or failing) drops both.
-                                coroutineScope {
-                                    launch {
-                                        c.notification.getCount(roomId).collect { count ->
-                                            if (unreadCounts[key] != count) {
-                                                unreadCounts[key] = count
-                                                markRoomListDirty()
-                                            }
-                                        }
-                                    }
-                                    // First-message ping drop:
+                                // First-message ping drop:
                                     // a room whose newest message is ALREADY in the
                                     // store when its collector starts — the room was
                                     // created by that first message (bridge/RCS first
@@ -7131,7 +7115,6 @@ object MatrixRepository {
                                             notifyForEvent(c, roomId, lastId, updated)
                                         }
                                     }
-                                }
                             } catch (e: Exception) {
                                 android.util.Log.w(TAG, "notification watcher: room collector ended for $key: ${e.message}")
                             }
@@ -7268,11 +7251,8 @@ object MatrixRepository {
             ) null else senderNameOf(c, roomId, te.event.sender),
             preview = preview,
             direct = room.isDirect,
-            unreadCount = maxOf(
-                unreadCounts[roomId.full]?.toLong() ?: 0L,
-                serverUnreadCounts[roomId.full]?.toLong() ?: 0L,
-                localReceiptUnread(c, roomId.full),
-            ),
+            unreadCount = receiptCursorUnread(c, roomId.full)
+                ?: (serverUnreadCounts[roomId.full]?.toLong() ?: 0L),
         )
         // Persist "alerted this event" so a later watcher registration (new
         // process) doesn't re-alert it — the registration-time notify gate.
@@ -7688,15 +7668,6 @@ object MatrixRepository {
     )
 
     /**
-     * Per-room unread badge source (v5: `room.unreadMessageCount` is gone).
-     * Fed by `c.notification.getCount(roomId)` — the v5 NotificationService's
-     * per-room notification count (not a message count; badge semantics are
-     * boolean/notification-count from here on). The collector runs in
-     * [observeNotifications] per joined room.
-     */
-    private val unreadCounts = java.util.concurrent.ConcurrentHashMap<String, Int>()
-
-    /**
      * Server-computed per-room unread notification counts, captured straight
      * from the sync response (see the collector in [observeNotifications]).
      * Trixnity's own badge pipeline is empty after a fresh login, so this —
@@ -7736,52 +7707,46 @@ object MatrixRepository {
     }
 
     /**
-     * Local unread fallback: Trixnity's notification count is
-     * dead after a fresh login — its state machine defaults rooms to "read"
-     * when the last message isn't in the local timeline (our battery-thin
-     * sync leaves most rooms with 0-1 timeline rows) and only re-checks when
-     * a NEW event lands, so the badge never appears for exactly the rooms
-     * with unread history. Fallback: compare the account's own read receipt
-     * against the newest receipt from other members (the bridge posts each
-     * sender's receipt at their own last event, so max(other ts) tracks the
-     * newest non-self activity). Ours older → something unread. Fully local,
-     * one indexed lookup; the badge is boolean, so the count is 1.
-     * ponytail: heuristic — non-bridged rooms where senders never post
-     * receipts can under-report; upgrade to a bounded chain walk if seen.
+     * Cursor-based unread (the Beeper app's model — replaces the old own-vs-
+     * others receipt comparison): the cursor is the account's own m.read
+     * receipt (synced account-wide — a read on any device moves it), and
+     * unread = COUNT(message-class, not-ours timeline events strictly after
+     * it). Never compared against the server's notification_count, whose
+     * non-message accounting (reactions, member churn, send-status echoes our
+     * client never renders) flags fully-read rooms (LP3: 1€ Doc Chat, JobV,
+     * +16315652210, +4917668998995).
+     * Null when no own receipt has synced yet — callers fall back to the
+     * server count.
+     * ponytail: ts cursor over the thin-sync timeline — same-second boundary
+     * events and still-encrypted member copies can skew the count; the row
+     * badge renders boolean, so only the false-positive direction matters.
+     * Stored per-event position (Beeper's Messages.order) if that ever bites.
      */
-    private suspend fun localReceiptUnread(c: MatrixClient, roomId: String): Long {
+    private suspend fun receiptCursorUnread(c: MatrixClient, roomId: String): Long? {
         val db = runCatching { c.di.get<TrixnityRoomDatabase>(TrixnityRoomDatabase::class) }.getOrNull()
-            ?: return 0L
+            ?: return null
         return chainDbSemaphore.withPermit {
             withContext(Dispatchers.IO) {
-                runCatching {
-                    db.openHelper.writableDatabase.query(
-                        "SELECT userId, MAX(je.value) FROM RoomUserReceipts, " +
+                runCatching<Long?> {
+                    val own = db.openHelper.writableDatabase.query(
+                        "SELECT MAX(je.value) FROM RoomUserReceipts, " +
                             "json_tree(RoomUserReceipts.value) je " +
-                            "WHERE RoomUserReceipts.roomId=? AND je.key='ts' AND je.type='integer' " +
-                            // Bridge bot accounts (@whatsappbot, @telegrambot, …)
-                            // "read" their own delivery-status events instantly,
-                            // so their receipt is always the newest in an active
-                            // room and this fallback read every busy bridged room
-                            // as unread.
-                            // ponytail: localpart-suffix heuristic — a human
-                            // literally named "…bot" would be excluded; switch
-                            // to a rendered-message join if that bites.
-                            "AND RoomUserReceipts.userId NOT LIKE '%bot:%' " +
-                            "GROUP BY userId",
-                        arrayOf(roomId),
-                    ).use { cur ->
-                        var own = -1L
-                        var othersMax = -1L
-                        while (cur.moveToNext()) {
-                            if (cur.isNull(1)) continue
-                            val ts = cur.getLong(1)
-                            if (cur.getString(0) == c.userId.full) own = maxOf(own, ts)
-                            else othersMax = maxOf(othersMax, ts)
-                        }
-                        if (own >= 0 && othersMax > own) 1L else 0L
-                    }
-                }.getOrDefault(0L)
+                            "WHERE RoomUserReceipts.roomId=? AND RoomUserReceipts.userId=? " +
+                            "AND je.key='ts' AND je.type='integer'",
+                        arrayOf(roomId, c.userId.full),
+                    ).use { cur -> if (cur.moveToFirst() && !cur.isNull(0)) cur.getLong(0) else -1L }
+                    if (own < 0) return@runCatching null
+                    db.openHelper.writableDatabase.query(
+                        "SELECT COUNT(*) FROM (SELECT 1 FROM TimelineEvent " +
+                            "WHERE TimelineEvent.roomId=? " +
+                            "AND json_extract(TimelineEvent.value,'$.event.type') " +
+                            "  IN ('m.room.message','m.room.encrypted') " +
+                            "AND json_extract(TimelineEvent.value,'$.event.sender') != ? " +
+                            "AND json_extract(TimelineEvent.value,'$.event.origin_server_ts') > ? " +
+                            "LIMIT 99)",
+                        arrayOf(roomId, c.userId.full, own.toString()),
+                    ).use { cur -> if (cur.moveToFirst()) cur.getLong(0) else 0L }
+                }.getOrNull()
             }
         }
     }
@@ -7791,7 +7756,6 @@ object MatrixRepository {
         roomSigSeen.clear()
         bridgeBotByRoom.clear()
         pendingReadClear.clear()
-        unreadCounts.clear()
         serverUnreadCounts.clear()
         effectiveLastCache.clear()
         ghostResolveInFlight.clear()
@@ -8064,7 +8028,7 @@ object MatrixRepository {
                         key,
                         cleared?.second,
                         room.lastRelevantEventTimestamp?.toEpochMilliseconds(),
-                        if (verified || !room.encrypted) (unreadCounts[key]?.toLong() ?: 0L) else 0,
+                        if (verified || !room.encrypted) (serverUnreadCounts[key]?.toLong() ?: 0L) else 0,
                     ),
                     lastTimestampMs = room.lastRelevantEventTimestamp?.toEpochMilliseconds() ?: 0L,
                     lastEventId = room.lastRelevantEventId?.full,
@@ -8204,17 +8168,12 @@ object MatrixRepository {
             is PendingImageSend -> maxOf(ts, p.timestampMs)
             null -> ts
         }
-        // An unverified device can't decrypt — suppress unread for encrypted
-        // rooms only; unencrypted ones stay readable. Local receipt fallback:
-        // Trixnity's notification count is empty after a fresh
-        // login (its state machine marks timeline-less rooms read) — the
-        // own-receipt-vs-others comparison catches those.
+        // Cursor-based unread (receiptCursorUnread): message-class events after
+        // the own read receipt; server notification_count only until the first
+        // receipt syncs (it counts non-message classes our client never
+        // renders — false flags on fully-read rooms).
         val storeUnread = if (verified || !room.encrypted) {
-            maxOf(
-                unreadCounts[key]?.toLong() ?: 0L,
-                serverUnreadCounts[key]?.toLong() ?: 0L,
-                localReceiptUnread(c, key),
-            )
+            receiptCursorUnread(c, key) ?: (serverUnreadCounts[key]?.toLong() ?: 0L)
         } else 0
         val cleared = pendingReadClear[key]
         val unread = servedUnread(
@@ -9073,7 +9032,20 @@ object MatrixRepository {
         // below still runs so the preview heals once content resolves; member
         // -join/ack heads keep the no-fake-time park.
         if (serverLast != null && isMessageClassHead(serverLast) && !inFlood) {
-            effectiveLastCache[key] = EffectiveLast(serverLastId, serverLastId, serverTs)
+            // A RESOLVED message head (plaintext or decrypted payload) is real
+            // activity — pin permanently. An encryption-FAILED head (isFailure)
+            // is only ASSUMED to be a message: it may never decrypt, or decrypt
+            // to member/state churn (bridges push megolm member joins — LP3:
+            // the empty "Josh Schiff" room was stamped by its own join event
+            // and stuck at the list top). So failed heads pin tentatively and
+            // re-classify after the retry window; a genuine message keeps the
+            // bump across retries.
+            val headResolved = serverLast.content?.getOrNull() != null
+            if (!headResolved) enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
+            effectiveLastCache[key] = EffectiveLast(
+                serverLastId, serverLastId, serverTs,
+                retryAtMs = if (headResolved) 0L else now + GHOST_WALK_RETRY_MS,
+            )
             return serverLastId to serverTs
         }
         // The server's newest event renders as nothing — a dropped edit, a

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -1360,7 +1360,7 @@ object MatrixRepository {
                 contentType(ContentType.Application.Json)
             }
             if (init.status.value !in 200..299) error("Beeper login init failed (HTTP ${init.status.value})")
-            val requestId = Json { ignoreUnknownKeys = true }
+            val requestId = pushQueueJson
                 .parseToJsonElement(init.bodyAsText())
                 .jsonObject["request"]?.jsonPrimitive?.content
                 ?: error("missing request id")
@@ -1412,7 +1412,7 @@ object MatrixRepository {
                 if (resp.status.value !in 200..299) {
                     error("Beeper code verification failed (HTTP ${resp.status.value})")
                 }
-                val json = Json { ignoreUnknownKeys = true }.parseToJsonElement(resp.bodyAsText()).jsonObject
+                val json = pushQueueJson.parseToJsonElement(resp.bodyAsText()).jsonObject
                 val whoami = json["whoami"]?.jsonObject ?: error("missing whoami")
                 val userInfo = whoami["userInfo"]?.jsonObject ?: error("missing userInfo")
                 username = userInfo["username"]?.jsonPrimitive?.content ?: error("missing username")
@@ -6812,7 +6812,7 @@ object MatrixRepository {
             when {
                 status == 200 -> {
                     val obj = runCatching {
-                        Json { ignoreUnknownKeys = true }.parseToJsonElement(resp.bodyAsText()).jsonObject
+                        pushQueueJson.parseToJsonElement(resp.bodyAsText()).jsonObject
                     }.getOrNull()
                     // Content is the body directly (spec); tolerate a wrap.
                     val content = (obj ?: JsonObject(emptyMap())).let {
@@ -7605,7 +7605,6 @@ object MatrixRepository {
                 runCatching {
                     resolveRoomListEntry(
                         c, roomId, room, HashMap(),
-                        resolvePreview = true,
                         verified = isDeviceVerified(c),
                         // The network maps are TTL caches built by the pass over the
                         // FULL room map — never call networkByRoom with a single-room
@@ -7964,7 +7963,6 @@ object MatrixRepository {
                         yieldToSyncIngest()
                         resolveRoomListEntry(
                             c, roomId, room, nameMemo,
-                            resolvePreview = true,
                             verified = verified,
                             networks = networks,
                             communities = communities,
@@ -8117,7 +8115,6 @@ object MatrixRepository {
         roomId: RoomId,
         room: MatrixRoom,
         nameMemo: MutableMap<String, String>,
-        resolvePreview: Boolean,
         verified: Boolean,
         networks: Map<String, String>,
         communities: Map<String, String>,
@@ -8283,13 +8280,6 @@ object MatrixRepository {
                     }
                 }
                 previewResolved = true
-                previewRetryAtMs = 0L
-            }
-            !resolvePreview && prev?.previewResolved != true -> {
-                // Outside the preview window and never resolved: keep the name
-                // row without a preview. Opening the thread fills it in.
-                preview = ""
-                previewResolved = false
                 previewRetryAtMs = 0L
             }
             prev != null && prev.previewResolved && !stateChanged -> {
@@ -8655,19 +8645,6 @@ object MatrixRepository {
             )
         }
         return storeName ?: bridgeName ?: hero.localpart
-    }
-
-    /** The provision contact list's name for a bridge ghost. WhatsApp's
-     *  privacy-LID migration re-keys DM heroes to @whatsapp_lid-… ghosts whose
-     *  member event carries no displayname (the bridge only surfaces the name
-     *  via the provision API — invisible to room data, see [bridgeContacts]),
-     *  and the localpart fallback then titles the room "whatsapp_lid-27358…"
-     *  (pinned active DM, LP3 2026-09-05). Cache read only: the resolver pass
-     *  prefetches each bridge's list (see the [bridgeContacts] loop); a cold
-     *  cache keeps the previous fallback. */
-    private fun bridgeContactNameOf(hero: UserId): String? {
-        val bridgeId = bridgeIdOf(hero.full) ?: return null
-        return bridgeContactsCache[bridgeId]?.get(hero.full)?.name?.takeIf { it.isNotBlank() }
     }
 
     /**

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -5496,6 +5496,79 @@ object MatrixRepository {
 
     // --- Voice notes ---------------------------------------------
 
+    /** The [EncryptedFile, mxc url] fetch source for file-based message
+     *  content, or null when the event carries no fetchable media uri (the
+     *  common failure mode: a client posts an m.image with an empty url). */
+    private fun mediaSourceOf(
+        content: RoomMessageEventContent.FileBased,
+    ): Pair<EncryptedFile?, String?>? {
+        val file = content.file?.takeIf { !it.url.isNullOrBlank() }
+        val url = content.url?.takeIf { it.isNotBlank() }
+        return if (file == null && url == null) null else file to url
+    }
+
+    /** The shared single-shot media fetch (encrypted when the timeline
+     *  carries an [EncryptedFile], plain otherwise), bounded by
+     *  [MEDIA_BUDGET_MS]; a failure is logged under [logLabel]. */
+    private suspend fun fetchMedia(
+        c: MatrixClient,
+        file: EncryptedFile?,
+        url: String?,
+        saveToCache: Boolean,
+        logLabel: String,
+        eventId: String,
+    ): ByteArray? = withTimeoutOrNull(MEDIA_BUDGET_MS) {
+        val mediaService = c.di.get<MediaService>(MediaService::class)
+        val result = when {
+            file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = saveToCache)
+            url != null -> mediaService.getMedia(url, maxSize = null, saveToCache = saveToCache)
+            else -> return@withTimeoutOrNull null
+        }
+        if (result.isFailure) {
+            android.util.Log.w(TAG, "$logLabel: fetch failed for $eventId", result.exceptionOrNull())
+        }
+        result.getOrNull()?.toByteArray()
+    }
+
+    /** [playVoiceNote]/[downloadVoiceNoteToCache]'s two-attempt fetch with the
+     *  wedge self-heal hooks ([noteMediaFetchTimeout]/[noteMediaFetchSuccess]);
+     *  the per-attempt logging stays at the call sites. Null bytes when both
+     *  attempts fail. */
+    private suspend fun fetchMediaRetrying(
+        c: MatrixClient,
+        file: EncryptedFile?,
+        url: String?,
+        eventId: String,
+        timeoutLog: (attempt: Int) -> Unit = {},
+        failureLog: (attempt: Int, exception: Throwable?) -> Unit,
+    ): ByteArray? {
+        val mediaService = c.di.get<MediaService>(MediaService::class)
+        var download: Result<de.connect2x.trixnity.client.media.PlatformMedia>? = null
+        for (attempt in 1..2) {
+            val result = withTimeoutOrNull(MEDIA_BUDGET_MS) {
+                when {
+                    file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = false)
+                    url != null -> mediaService.getMedia(url, maxSize = null, saveToCache = false)
+                    else -> return@withTimeoutOrNull null
+                }
+            }
+            if (result == null) {
+                timeoutLog(attempt)
+                noteMediaFetchTimeout()
+                continue
+            }
+            if (result.isFailure) {
+                failureLog(attempt, result.exceptionOrNull())
+                noteMediaFetchSuccess()
+                continue
+            }
+            noteMediaFetchSuccess()
+            download = result
+            break
+        }
+        return download?.getOrNull()?.toByteArray()?.takeIf { it.isNotEmpty() }
+    }
+
     /**
      * Toggles playback of an m.audio message: stops any current playback and
      * plays [eventId], or stops it if it is already the one playing. Downloads
@@ -5615,23 +5688,13 @@ object MatrixRepository {
             )
             return false to "not an audio message"
         }
-        val file = content.file?.takeIf { !it.url.isNullOrBlank() }
-        val url = content.url?.takeIf { it.isNotBlank() }
-        if (file == null && url == null) return false to "no audio file"
-        val mediaService = c.di.get<MediaService>(MediaService::class)
+        val (file, url) = mediaSourceOf(content) ?: return false to "no audio file"
         // One retry: a single flaky fetch failing once shouldn't fail playback
         // outright — the first attempt can hit a slow window.
         // Each attempt is logged separately so a silent tap maps to one cause.
-        var download: Result<de.connect2x.trixnity.client.media.PlatformMedia>? = null
-        for (attempt in 1..2) {
-            val result = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-                when {
-                    file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = false)
-                    url != null -> mediaService.getMedia(url, maxSize = null, saveToCache = false)
-                    else -> return@withTimeoutOrNull null
-                }
-            }
-            if (result == null) {
+        val bytes = fetchMediaRetrying(
+            c, file, url, eventId,
+            timeoutLog = { attempt ->
                 // withTimeoutOrNull fired — the fetch itself exceeded the
                 // budget (MEDIA_BUDGET_MS). Kept separate from the failure log
                 // so a silent tap maps to exactly one cause.
@@ -5643,10 +5706,8 @@ object MatrixRepository {
                 // A timeout is the wedge signature: count it and
                 // self-heal once consecutive stalls + a healthy network say the
                 // shared HTTP engine is stuck (see [noteMediaFetchTimeout]).
-                noteMediaFetchTimeout()
-                continue
-            }
-            if (result.isFailure) {
+            },
+            failureLog = { attempt, exception ->
                 // Diagnosis hook for the LP3: this stage was silent — the common failure (the
                 // media fetch) must log what actually went wrong (network
                 // error, missing sha256 on the EncryptedFile →
@@ -5655,18 +5716,11 @@ object MatrixRepository {
                     TAG,
                     "playVoiceNote: download failed for $eventId (attempt $attempt/2, encrypted=${file != null}, " +
                         "url=${url ?: "null"}, size=${content.info?.size})",
-                    result.exceptionOrNull(),
+                    exception,
                 )
                 // A fast failure proves the engine answers — not a wedge.
-                noteMediaFetchSuccess()
-                continue
-            }
-            noteMediaFetchSuccess()
-            download = result
-            break
-        }
-        val bytes = (download?.getOrNull()?.toByteArray()?.takeIf { it.isNotEmpty() })
-            ?: return false to "audio download failed"
+            },
+        ) ?: return false to "audio download failed"
         // The temp file must carry the ACTUAL format: MediaPlayer's file-source
         // path uses the extension as an extractor hint, and Beeper/WhatsApp
         // audio files (ogg/opus, mp3, aac…) mislabeled ".m4a" fail to prepare.
@@ -5965,8 +6019,8 @@ object MatrixRepository {
 
     /**
      * Downloads [eventId]'s audio into the on-disk cache and returns the
-     * cached file. Mirrors [playVoiceNote]'s fetch/repair tail so both the
-     * prefetch and the first-tap path share it.
+     * cached file. Shares [playVoiceNote]'s fetch tail via
+     * [fetchMediaRetrying] so the prefetch and the first-tap path match.
      */
     private suspend fun downloadVoiceNoteToCache(
         c: MatrixClient,
@@ -5975,38 +6029,17 @@ object MatrixRepository {
         content: RoomMessageEventContent.FileBased.Audio,
     ): java.io.File? {
         val ctx = appContext ?: return null
-        val file = content.file?.takeIf { !it.url.isNullOrBlank() }
-        val url = content.url?.takeIf { it.isNotBlank() }
-        if (file == null && url == null) return null
-        val mediaService = c.di.get<MediaService>(MediaService::class)
-        var download: Result<de.connect2x.trixnity.client.media.PlatformMedia>? = null
-        for (attempt in 1..2) {
-            val result = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-                when {
-                    file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = false)
-                    url != null -> mediaService.getMedia(url, maxSize = null, saveToCache = false)
-                    else -> return@withTimeoutOrNull null
-                }
-            }
-            if (result == null) {
-                noteMediaFetchTimeout()
-                continue
-            }
-            if (result.isFailure) {
-                noteMediaFetchSuccess()
+        val (file, url) = mediaSourceOf(content) ?: return null
+        val bytes = fetchMediaRetrying(
+            c, file, url, eventId,
+            failureLog = { attempt, exception ->
                 android.util.Log.w(
                     TAG,
                     "voice download failed for $eventId (attempt $attempt/2)",
-                    result.exceptionOrNull(),
+                    exception,
                 )
-                continue
-            }
-            noteMediaFetchSuccess()
-            download = result
-            break
-        }
-        val bytes = (download?.getOrNull()?.toByteArray()?.takeIf { it.isNotEmpty() })
-            ?: return null
+            },
+        ) ?: return null
         val repaired = repairOgg(bytes)
         val dir = voiceCacheDir() ?: return null
         val ext = sniffAudioExtension(repaired, content.info?.mimeType?.lowercase().orEmpty())
@@ -6331,12 +6364,16 @@ object MatrixRepository {
         // uri here keeps the fetch branch below from calling
         // MediaService.getMedia("") (IllegalArgumentException, which used to
         // fail the whole row instead of falling back to its text).
-        val file = content.file?.takeIf { !it.url.isNullOrBlank() }
-        val url = content.url?.takeIf { it.isNotBlank() }
-        if (file == null && url == null) {
-            android.util.Log.d(TAG, "getMessageMedia: $eventId has no media uri (url=$url) — unfetchable")
+        val source = mediaSourceOf(content)
+        if (source == null) {
+            android.util.Log.d(
+                TAG,
+                "getMessageMedia: $eventId has no media uri " +
+                    "(url=${content.url?.takeIf { it.isNotBlank() }}) — unfetchable",
+            )
             return null
         }
+        val (file, url) = source
         // Media this device already has (sent from here, or previously
         // downloaded) renders on any connection — the mobile-data gate only
         // blocks downloads that would hit the network.
@@ -6349,18 +6386,12 @@ object MatrixRepository {
             android.util.Log.d(TAG, "getMessageMedia: $eventId skipped (mobile data, allow=$allowMobileData)")
             return null
         }
-        val mediaService = c.di.get<MediaService>(MediaService::class)
-        val bytes = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-            val result = when {
-                file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = true)
-                url != null -> mediaService.getMedia(url, maxSize = null, saveToCache = true)
-                else -> return@withTimeoutOrNull null
-            }
-            if (result.isFailure) {
-                android.util.Log.w(TAG, "getMessageMedia: fetch failed for $eventId", result.exceptionOrNull())
-            }
-            result.getOrNull()?.toByteArray()
-        }?.takeIf { it.isNotEmpty() } ?: return null
+        val bytes = fetchMedia(
+            c, file, url,
+            saveToCache = true,
+            logLabel = "getMessageMedia",
+            eventId = eventId,
+        )?.takeIf { it.isNotEmpty() } ?: return null
         val jpeg = compressImage(bytes, DISPLAY_MAX_DIMENSION, DISPLAY_JPEG_QUALITY) ?: return null
         mediaCache[cacheKey] = jpeg
         return jpeg
@@ -6385,20 +6416,13 @@ object MatrixRepository {
                 if (raw.info?.mimeType?.startsWith("image/", ignoreCase = true) == true) raw else null
             else -> null
         } ?: return false
-        val file = content.file?.takeIf { !it.url.isNullOrBlank() }
-        val url = content.url?.takeIf { it.isNotBlank() }
-        if (file == null && url == null) return false
-        val mediaService = c.di.get<MediaService>(MediaService::class)
-        val bytes = withTimeoutOrNull(MEDIA_BUDGET_MS) {
-            val result = when {
-                file != null -> mediaService.getEncryptedMedia(file, maxSize = null, saveToCache = true)
-                else -> mediaService.getMedia(url!!, maxSize = null, saveToCache = true)
-            }
-            if (result.isFailure) {
-                android.util.Log.w(TAG, "saveMessageImage: fetch failed for $eventId", result.exceptionOrNull())
-            }
-            result.getOrNull()?.toByteArray()
-        }?.takeIf { it.isNotEmpty() } ?: return false
+        val (file, url) = mediaSourceOf(content) ?: return false
+        val bytes = fetchMedia(
+            c, file, url,
+            saveToCache = true,
+            logLabel = "saveMessageImage",
+            eventId = eventId,
+        )?.takeIf { it.isNotEmpty() } ?: return false
 
         val mime = content.info?.mimeType ?: "image/jpeg"
         val ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime) ?: "jpg"

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -803,7 +803,7 @@ object MatrixRepository {
                     // zero latency — see PushChannel.
                     PushChannel.start(app, client!!)
                 } else {
-                    _connectionState.value = ChatConnectionState.Offline("sync paused")
+                    setConnectionState(ChatConnectionState.Offline("sync paused"))
                     android.util.Log.d(TAG, "sync disabled by preference — session restored, no sync loop")
                 }
             }
@@ -839,7 +839,7 @@ object MatrixRepository {
             activeRoomRefreshJob = null
             PushChannel.stop()
             ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
-            _connectionState.value = ChatConnectionState.Offline("sync paused")
+            setConnectionState(ChatConnectionState.Offline("sync paused"))
             android.util.Log.d(TAG, "sync paused by user")
         } else {
             if (c == null) {
@@ -953,12 +953,12 @@ object MatrixRepository {
         val t0 = android.os.SystemClock.elapsedRealtime()
         val result = runCatching { c.syncOnce(Presence.OFFLINE).getOrThrow() }
             .onSuccess {
-                _connectionState.value = ChatConnectionState.Syncing
+                setConnectionState(ChatConnectionState.Syncing)
                 // Any successful sync means the "checking failed" signal (if
                 // any) is stale (WAKE-COMPARISON.md #3).
                 appContext?.let { ChatNotifier.clearSyncPending(it) }
             }
-            .onFailure { _connectionState.value = ChatConnectionState.Offline("sync failed") }
+            .onFailure { setConnectionState(ChatConnectionState.Offline("sync failed")) }
         // The round's ingest (parse/decrypt/store) is done once syncOnce
         // returns — release the sync-ingest gate here. In slow mode no further
         // /sync request follows for minutes, so without this stamp the gate
@@ -1264,7 +1264,7 @@ object MatrixRepository {
             inProcessSyncJob?.cancel()
             inProcessSyncJob = null
             inProcessSyncRunning = false
-            _connectionState.value = ChatConnectionState.Connecting
+            setConnectionState(ChatConnectionState.Connecting)
 
             // Accept a bare domain ("matrix.org") or a full URL; .well-known
             // discovery runs when the host serves one, else the URL is used as-is.
@@ -1354,7 +1354,7 @@ object MatrixRepository {
             inProcessSyncJob?.cancel()
             inProcessSyncJob = null
             inProcessSyncRunning = false
-            _connectionState.value = ChatConnectionState.Connecting
+            setConnectionState(ChatConnectionState.Connecting)
 
             val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             val requestId = prefs.getString(KEY_BEEPER_REQUEST_ID, null)
@@ -1704,7 +1704,7 @@ object MatrixRepository {
         // verification events); Trixnity's own state machine drives the rest.
         val request = c.verification.createDeviceVerificationRequest(c.userId, otherDevices).getOrThrow()
         activeVerification = request
-        _verification.value = VerificationUi.Waiting
+        setVerificationUi(VerificationUi.Waiting)
         verificationCollectJob?.cancel()
         verificationCollectJob = scope.launch {
             request.state.collectLatest { state -> onVerificationState(state) }
@@ -1716,7 +1716,7 @@ object MatrixRepository {
                 android.util.Log.w(TAG, "verification timed out after ${VERIFICATION_TIMEOUT_MS / 60_000L} min — cancelling")
                 runCatching { request.cancel() }
                 verificationCollectJob?.cancel()
-                _verification.value = VerificationUi.Error("Verification timed out — try your recovery key")
+                setVerificationUi(VerificationUi.Error("Verification timed out — try your recovery key"))
             }
         }
     }
@@ -1781,12 +1781,13 @@ object MatrixRepository {
         pendingTheirSasStart = null
         pendingCompare = null
         theirSasStartAtMs = 0L
-        _verification.value = VerificationUi.Idle
+        setVerificationUi(VerificationUi.Idle)
     }
 
     private suspend fun onVerificationState(state: ActiveVerificationState) {
         android.util.Log.i(TAG, "verify: top-level state -> ${state::class.simpleName}")
-        _verification.value = when (state) {
+        setVerificationUi(
+            when (state) {
             is ActiveVerificationState.OwnRequest -> VerificationUi.Waiting
             is ActiveVerificationState.TheirRequest -> {
                 pendingTheirRequest = state
@@ -1858,12 +1859,14 @@ object MatrixRepository {
                     VerificationUi.Waiting
                 }
             }
-        }
+        },
+    )
     }
 
     private suspend fun onSasState(state: ActiveSasVerificationState) {
         android.util.Log.i(TAG, "verify: SAS state -> ${state::class.simpleName}")
-        _verification.value = when (state) {
+        setVerificationUi(
+            when (state) {
             is ActiveSasVerificationState.OwnSasStart -> VerificationUi.Verifying
             is ActiveSasVerificationState.TheirSasStart -> {
                 pendingTheirSasStart = state
@@ -1884,7 +1887,8 @@ object MatrixRepository {
             // WaitForKeys / WaitForMacs are exchange progress — "Verifying…",
             // not "waiting for the other device to accept".
             else -> VerificationUi.Verifying
-        }
+            },
+        )
     }
 
     /**
@@ -2104,7 +2108,7 @@ object MatrixRepository {
             clearDiskCache()
             sessionExpired = false
             manualLogout = false
-            _connectionState.value = ChatConnectionState.LoggedOut
+            setConnectionState(ChatConnectionState.LoggedOut)
         }
     }
 
@@ -6324,7 +6328,8 @@ object MatrixRepository {
 
     /** The room's effective pinned/muted/archived flags (optimistic writes win;
      *  the store collectors keep the cache fresh within seconds of a
-     *  Beeper-side change — the contact panel polls this, 2026-08-28). */
+     *  Beeper-side change — the flag loops wait on the flags revision and
+     *  refetch this, 2026-08-28). */
     suspend fun getRoomFlags(roomId: String): RoomFlags =
         roomFlagsOverlay[roomId] ?: roomFlagsCache[roomId] ?: RoomFlags()
 
@@ -6339,6 +6344,7 @@ object MatrixRepository {
         val updated = transform(base)
         roomFlagsCache = roomFlagsCache + (roomId to updated)
         roomFlagsOverlay = roomFlagsOverlay + (roomId to updated)
+        bumpRoomFlagsRevision() // the flag-wait loops refetch immediately
         flagsOnlyWake = true
         markRoomListDirty()
         wakeRoomList()
@@ -6899,6 +6905,48 @@ object MatrixRepository {
     }
 
     /**
+     * Monotonic revision of the room-flags cache (Phase C, 2026-09-06):
+     * bumped where the flags fact commits — optimistic writes
+     * ([updateRoomFlagsLocal]) and store-fresh rebuilds ([roomFlagsByRoom]).
+     * The thread/contact-panel flag loops wait on it ("flags" scope) instead
+     * of polling [getRoomFlags] on a timer.
+     */
+    @Volatile
+    private var roomFlagsRevision = 0L
+
+    private fun bumpRoomFlagsRevision() {
+        roomFlagsRevision++
+        changeSignal.tryEmit(Unit)
+    }
+
+    /**
+     * Monotonic revision of the tool-visible account/connection/verification
+     * status facts (Phase C, 2026-09-06): bumped beside every
+     * [_connectionState] and [_verification] commit. The Account/Verification/
+     * Settings screens wait on it ("status" scope) instead of polling
+     * [accountState]/[connectionState]/[verificationState] on a timer.
+     */
+    @Volatile
+    private var statusRevision = 0L
+
+    private fun bumpStatusRevision() {
+        statusRevision++
+        changeSignal.tryEmit(Unit)
+    }
+
+    /** Commits [_connectionState] and wakes the status waiters. */
+    private fun setConnectionState(state: ChatConnectionState) {
+        _connectionState.value = state
+        bumpStatusRevision()
+    }
+
+    /** Commits [_verification] and wakes the status waiters. */
+    private fun setVerificationUi(ui: VerificationUi) {
+        _verification.value = ui
+        bumpStatusRevision()
+    }
+
+    /**
      * Holds the caller until a watched revision moves past [lastSeen] or
      * [timeoutMs] elapses (the server half of [LightServiceMethod.WaitForChange]
      * — the tool's poll ticks became this). Returns the current revision either
@@ -6906,8 +6954,12 @@ object MatrixRepository {
      * moved revision (raced signal) returns immediately.
      */
     suspend fun waitForChange(watch: String, roomId: String?, lastSeen: Long, timeoutMs: Long): Long {
-        fun current(): Long =
-            if (watch == "rooms") roomListRevision else messagePageRevision[roomId] ?: 0L
+        fun current(): Long = when (watch) {
+            "rooms" -> roomListRevision
+            "flags" -> roomFlagsRevision
+            "status" -> statusRevision
+            else -> messagePageRevision[roomId] ?: 0L
+        }
         val deadline = android.os.SystemClock.elapsedRealtime() + timeoutMs
         while (true) {
             val now = current()
@@ -7917,6 +7969,10 @@ object MatrixRepository {
         result.putAll(roomFlagsOverlay)
         roomFlagsCache = result
         roomFlagsBuiltAtMs = now
+        // Only reached on a real rebuild (the TTL fast path returned early) —
+        // the fresh flags just committed; wake the flag-wait loops. A rebuild
+        // without flag changes wakes them into a same-value refetch: harmless.
+        bumpRoomFlagsRevision()
         return roomFlagsCache + roomFlagsOverlay
     }
 
@@ -8986,25 +9042,27 @@ object MatrixRepository {
     private fun observeSyncState(c: MatrixClient) {
         scope.launch {
             c.syncState.collect { state ->
-                _connectionState.value = when (state) {
-                    SyncState.INITIAL_SYNC -> ChatConnectionState.Connecting
-                    SyncState.STARTED, SyncState.RUNNING -> ChatConnectionState.Syncing
-                    SyncState.ERROR, SyncState.TIMEOUT -> ChatConnectionState.Offline("sync $state")
-                    SyncState.STOPPED -> when {
-                        // Slow sync (screen off) stops the long-poll between
-                        // periodic syncOnce rounds — that's still "syncing",
-                        // not an outage.
-                        isSlowSyncing -> ChatConnectionState.Syncing
-                        // The sync toggle is the source of truth while paused —
-                        // the restored client reports STOPPED until resumed, and
-                        // that must read as "paused", not "stopped" (or, worse,
-                        // the race with init's explicit assignment).
-                        !syncEnabled -> ChatConnectionState.Offline("sync paused")
-                        c.loginState.value == MatrixClient.LoginState.LOGGED_IN -> ChatConnectionState.Offline("sync stopped")
-                        sessionExpired -> ChatConnectionState.Offline("session expired — sign in again")
-                        else -> ChatConnectionState.LoggedOut
-                    }
-                }
+                setConnectionState(
+                    when (state) {
+                        SyncState.INITIAL_SYNC -> ChatConnectionState.Connecting
+                        SyncState.STARTED, SyncState.RUNNING -> ChatConnectionState.Syncing
+                        SyncState.ERROR, SyncState.TIMEOUT -> ChatConnectionState.Offline("sync $state")
+                        SyncState.STOPPED -> when {
+                            // Slow sync (screen off) stops the long-poll between
+                            // periodic syncOnce rounds — that's still "syncing",
+                            // not an outage.
+                            isSlowSyncing -> ChatConnectionState.Syncing
+                            // The sync toggle is the source of truth while paused —
+                            // the restored client reports STOPPED until resumed, and
+                            // that must read as "paused", not "stopped" (or, worse,
+                            // the race with init's explicit assignment).
+                            !syncEnabled -> ChatConnectionState.Offline("sync paused")
+                            c.loginState.value == MatrixClient.LoginState.LOGGED_IN -> ChatConnectionState.Offline("sync stopped")
+                            sessionExpired -> ChatConnectionState.Offline("session expired — sign in again")
+                            else -> ChatConnectionState.LoggedOut
+                        }
+                    },
+                )
             }
         }
     }
@@ -9033,7 +9091,7 @@ object MatrixRepository {
                 sessionExpired = true
                 PushChannel.stop()
                 android.util.Log.w(TAG, "session no longer logged in ($state) — treating as expired")
-                _connectionState.value = ChatConnectionState.Offline("session expired — sign in again")
+                setConnectionState(ChatConnectionState.Offline("session expired — sign in again"))
                 scheduleSyncStop()
             }
         }
@@ -9537,12 +9595,13 @@ object MatrixRepository {
     private const val UNSENT_MARKER_MAX = 256
     /** Local outbox read for the pending-row state (event id / send error). */
     private const val OUTBOX_READ_TIMEOUT_MS = 500L
-    /** Bounded wait for the homeserver ack of a text send ([awaitOutboxAck]) —
-     *  the /send 200 typically lands ~1 s after enqueue on the wake round. */
-    /** The composer hold for the homeserver ack. 2 s timed out unconfirmed on
-     *  every send during crawl load (LP3 2026-09-05: "compose hangs then it
-     *  sends" — the optimistic row shows instantly anyway), so the hold is
-     *  now just the ultra-warm case; slower acks confirm via the sync echo. */
+    /** Bounded wait for the homeserver ack of a send ([awaitOutboxAck]) —
+     *  kept for voice sends only: the recording activity's "sending" state
+     *  holds until the RPC returns, and caching the acked id keeps the
+     *  pending row from flickering back to SENDING (2026-09-02). Text sends
+     *  no longer wait (LP3 2026-09-05: "compose hangs then it sends" — the
+     *  optimistic row shows instantly anyway; slower acks confirm via the
+     *  sync echo). */
     private const val SEND_ACK_WAIT_MS = 500L
     /** Poll cadence on the outbox row while awaiting the ack. */
     private const val SEND_ACK_POLL_INTERVAL_MS = 100L

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -2508,6 +2508,21 @@ object MatrixRepository {
         val encrypted: Boolean = false,
     )
 
+    /**
+     * The patch tail shared by the quiet-page patches ([patchReadReceipts],
+     * [patchSendStatuses], [patchReactionTags]): maps this page's messages
+     * through [f] — return a copy to change a row, null to keep it. Null
+     * when no row changed, so the caller keeps the cache and disk as-is.
+     */
+    private fun MessagesPage.patchedWith(
+        f: (LightServiceMethod.GetMessages.Message) -> LightServiceMethod.GetMessages.Message?,
+    ): MessagesPage? {
+        var changed = false
+        val patched = messages.map { m -> f(m)?.also { changed = true } ?: m }
+        if (!changed) return null
+        return MessagesPage(patched, hasMore, encrypted)
+    }
+
     /** One cached newest page: the page plus when it was computed. */
     private data class MessagePageEntry(
         val page: MessagesPage,
@@ -2914,15 +2929,9 @@ object MatrixRepository {
         if (chain.isEmpty()) return null
         val readEventIds = readReceiptsByEvent(c, RoomId(roomId), chain)
         if (readEventIds.isEmpty()) return null
-        var changed = false
-        val patched = cached.page.messages.map { m ->
-            if (!m.read && m.id in readEventIds) {
-                changed = true
-                m.copy(read = true)
-            } else m
+        return cached.page.patchedWith { m ->
+            if (!m.read && m.id in readEventIds) m.copy(read = true) else null
         }
-        if (!changed) return null
-        return MessagesPage(patched, cached.page.hasMore, cached.page.encrypted)
     }
 
     /**
@@ -2966,12 +2975,9 @@ object MatrixRepository {
     ): MessagesPage? {
         val sendStatuses = sendStatusesByEventIdCached(c, RoomId(roomId))
         if (sendStatuses.isEmpty()) return null
-        var changed = false
-        val patched = cached.page.messages.map { m ->
-            sendStatuses[m.id]?.takeIf { it != m.sendStatus }?.let { changed = true; m.copy(sendStatus = it) } ?: m
+        return cached.page.patchedWith { m ->
+            sendStatuses[m.id]?.takeIf { it != m.sendStatus }?.let { m.copy(sendStatus = it) }
         }
-        if (!changed) return null
-        return MessagesPage(patched, cached.page.hasMore, cached.page.encrypted)
     }
 
     /**
@@ -3022,17 +3028,10 @@ object MatrixRepository {
         }
         val tags = reactionTagsForEvents(c, matrixRoomId, chain + resolved)
         if (tags.isEmpty()) return null
-        var changed = false
-        val patched = cached.page.messages.map { m ->
-            val fresh = tags[m.id] ?: return@map m
-            val collapsed = collapseReactionTags(fresh)
-            if (collapsed != m.reactions) {
-                changed = true
-                m.copy(reactions = collapsed)
-            } else m
+        return cached.page.patchedWith { m ->
+            val collapsed = tags[m.id]?.let(::collapseReactionTags) ?: return@patchedWith null
+            if (collapsed != m.reactions) m.copy(reactions = collapsed) else null
         }
-        if (!changed) return null
-        return MessagesPage(patched, cached.page.hasMore, cached.page.encrypted)
     }
 
     /**

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -225,7 +225,7 @@ object MatrixRepository {
     private const val KEY_SYNC_ENABLED = "sync_enabled"
     /** When the one-shot megolm restore scan last ran (daily gate, 2026-08-15). */
     private const val KEY_RESTORE_LAST_RUN_MS = "restore_last_run_ms"
-    /** True when a full restore crawl completed. Persisted (2026-09-01) so the
+    /** True when a full restore crawl completed. Persisted so the
      *  Account screen's "All messages restored" line survives process restarts —
      *  the crawl runs at most once per 24h, so the in-memory flag alone could
      *  never show after a reboot/install/force-stop. Cleared at login. */
@@ -233,7 +233,7 @@ object MatrixRepository {
     /** Per-room event id the notification watcher last alerted (prefix + roomId.full),
      *  persisted so a watcher re-attach — every process start / app launch — does not
      *  re-alert the same newest event a previous run already dinged (ghost burst
-     *  fix, LP3 2026-09-02). Cleared with the prefs at logout. */
+     *  fix). Cleared with the prefs at logout. */
     private const val KEY_LAST_NOTIFIED_PREFIX = "last_notified_"
     private const val DB_NAME = "matrix_client"
     private const val MEDIA_DIR = "matrix_media"
@@ -273,7 +273,7 @@ object MatrixRepository {
     @Volatile
     var pendingNotifyRoomId: String? = null
 
-    // --- Voice-note playback (Phase 14) -------------------------------------
+    // --- Voice-note playback -------------------------------------
     // The companion plays m.audio messages (the tool runtime forbids audio
     // playback APIs): PlayVoiceNote downloads the audio (decrypting when the
     // room is encrypted) and plays it with a plain MediaPlayer. The tool
@@ -286,16 +286,16 @@ object MatrixRepository {
 
     /**
      * Event id of a PAUSED voice note (null when nothing is paused). Pausing
-     * keeps the player + file + position alive (audioPositionMs() reports
+     * keeps the player + file + position alive (audioPositionMs reports
      * null — the row shows the note's length), so re-tapping the same note
-     * RESUMES from the pause point instead of restarting (feedback 2026-08-27).
+     * RESUMES from the pause point instead of restarting.
      */
     @Volatile
     private var pausedAudioEventId: String? = null
 
     /** Room id of the note currently playing/paused — needed by the
-     *  completion handler to auto-advance to the next note in the same room
-     *  (feedback 2026-08-27). */
+     *  completion handler to auto-advance to the next note in the same room.
+     */
     @Volatile
     private var playingAudioRoomId: String? = null
 
@@ -311,7 +311,7 @@ object MatrixRepository {
      * classified as media/speech and holds transient focus, so the hardware
      * volume buttons control it and another app's playback pauses ours —
      * without explicit attributes some builds route voice notes to a stream
-     * the rocker doesn't touch (feedback 2026-08-14: inaudible notes).
+     * the rocker doesn't touch.
      */
     @Volatile
     private var audioFocusRequest: android.media.AudioFocusRequest? = null
@@ -319,8 +319,8 @@ object MatrixRepository {
     fun audioPlayingEventId(): String? = playingAudioEventId
 
     /** True while a voice note is playing OR paused — the volume rocker then
-     *  controls the media stream in-app instead of relaying to LightOS
-     *  (feedback 2026-08-30). */
+     *  controls the media stream in-app instead of relaying to LightOS.
+     */
     fun isVoiceNoteActive(): Boolean = playingAudioEventId != null || pausedAudioEventId != null
 
     /** Whether a thread is currently on screen (the tool's SetActiveRoom) — the
@@ -346,8 +346,7 @@ object MatrixRepository {
      * Voice-note sends awaiting their sync echo (room key → txn → send info).
      * Multi-slot: two rapid sends in one room must BOTH keep their optimistic
      * rows — a single per-room slot let the second send overwrite the first,
-     * whose row then vanished until its echo (feedback 2026-08-17: "only one
-     * shows").
+     * whose row then vanished until its echo.
      */
     private val pendingAudioEcho = java.util.concurrent.ConcurrentHashMap<
         String, java.util.concurrent.ConcurrentHashMap<String, PendingAudioSend>>()
@@ -365,7 +364,7 @@ object MatrixRepository {
         /** Real event id once the homeserver acks the send (/send 200 — see
          *  [sendVoiceNote]). Cached because Trixnity removes the outbox row as
          *  soon as the sync echo processes, so a served pending row could
-         *  otherwise fall back to the "local-…" id → SENDING (2026-09-02). */
+         *  otherwise fall back to the "local-…" id → SENDING. */
         val eventId: String? = null,
     ) : PendingSend
 
@@ -374,8 +373,7 @@ object MatrixRepository {
      * same optimistic-row pattern as [pendingAudioEcho]. The echo (which can
      * take a full sync tick on a big account) replaces the row; until then
      * every getMessages shows the sent message — including a re-opened thread,
-     * which is why the echo lives server-side and not in the tool's view model
-     * (feedback 2026-08-14: a sent message vanished from a re-opened thread).
+     * which is why the echo lives server-side and not in the tool's view model.
      */
     private val pendingTextEcho = java.util.concurrent.ConcurrentHashMap<
         String, java.util.concurrent.ConcurrentHashMap<String, PendingTextSend>>()
@@ -387,8 +385,7 @@ object MatrixRepository {
     ) : PendingSend
 
     /** Photo sends awaiting their sync echo, the same optimistic-row pattern as
-     *  [pendingTextEcho] (feedback 2026-08-30: a sent photo stayed invisible
-     *  until its sync echo landed). The pending row shows the file name +
+     *  [pendingTextEcho]. The pending row shows the file name +
      *  SENDING; there's no local thumbnail, so the tool's media fetch for its
      *  "local-…" id returns null until the echo resolves. */
     private val pendingImageEcho = java.util.concurrent.ConcurrentHashMap<
@@ -461,7 +458,7 @@ object MatrixRepository {
 
     /** Progress of the background key-backup restore crawl (see
      *  [restoreMegolmSessions]) — mirrored for the Account screen's
-     *  "Recovering… x of y rooms" line (2026-08-29). */
+     *  "Recovering… x of y rooms" line. */
     data class RestoreProgress(
         val scanning: Boolean = false,
         val scanned: Int = 0,
@@ -482,7 +479,7 @@ object MatrixRepository {
      *  SLOW = periodic [de.connect2x.trixnity.client.MatrixClient.syncOnce] once
      *  the screen's been off for a while — the long-poll's per-response
      *  parse/decrypt/store processing is the main standby cost on an
-     *  always-active bridged account (battery, 2026-08-14). */
+     *  always-active bridged account. */
     enum class SyncMode { ACTIVE, SLOW }
 
     @Volatile
@@ -493,8 +490,7 @@ object MatrixRepository {
     val isSlowSyncing: Boolean get() = syncMode == SyncMode.SLOW
 
     /** Screen truth for the sync-cadence decision. ChatSyncService reads this
-     *  so it never starts a long-poll while the screen is dark (battery
-     *  2026-08-19 audit: a service restart at night long-polled all night). */
+     *  so it never starts a long-poll while the screen is dark. */
     val isScreenOn: Boolean get() = isScreenInteractive()
 
     private var slowSyncJob: Job? = null
@@ -514,10 +510,10 @@ object MatrixRepository {
     /** Elapsed-realtime of the last push-wake syncOnce. Read-receipt/unread-
      *  count push bursts collapse against this (see [onPushDelivered]): every
      *  group member's reads POST one push, and each syncOnce costs ~30-50 s of
-     *  CPU on this account (battery 2026-08-17 audit). */
+     *  CPU on this account. */
     private var lastPushWakeSyncAtMs = 0L
 
-    // --- Verification-first sync (LP3 2026-09-06) ----------------------------
+    // --- Verification-first sync ----------------------------
 
     /**
      * True between a fresh login and the device-verification outcome: while
@@ -545,8 +541,8 @@ object MatrixRepository {
     private val verificationSyncSwapped = java.util.concurrent.atomic.AtomicBoolean(false)
 
     /** The default network dropped — the next [networkCallback] onAvailable
-     *  resets the sync loop (Beeper's `networkChanged`/`resetNetworkConnections`,
-     *  2026-09-01). */
+     *  resets the sync loop (Beeper's `networkChanged`/`resetNetworkConnections`).
+     */
     @Volatile
     private var networkWasLost = false
 
@@ -566,7 +562,7 @@ object MatrixRepository {
      *  too high, loosen if battery still burns. */
     private const val SLOW_SYNC_INTERVAL_MS = 300_000L
 
-    /** Push-gated lazy cadence (2026-08-31): while the SSE push channel is
+    /** Push-gated lazy cadence: while the SSE push channel is
      *  provably connected, rounds stretch to 15 min — the push is the
      *  zero-latency wake for real messages, so rounds are only the redundancy
      *  net. A dead channel flips [PushChannel.isConnected] false within its
@@ -578,9 +574,7 @@ object MatrixRepository {
      *  receive latency, loosen if battery still burns. */
     private const val SLOW_SYNC_LAZY_INTERVAL_MS = 900_000L
 
-    /** Foreground-service promotion cadence (2026-08-29: the old 3→60 s
-     *  geometric backoff stretched a blocked promotion to ~176 s after login —
-     *  a fixed interval converges within one tick of the system allowing it). */
+    /** Foreground-service promotion cadence. */
     private const val FGS_PROMOTE_INTERVAL_MS = 5_000L
 
     /** Min gap between read-receipt-push wakeups (see [onPushDelivered]). One
@@ -589,7 +583,7 @@ object MatrixRepository {
      *  cadence, which was proven acceptable for badge freshness. */
     private const val COUNTS_WAKE_MIN_INTERVAL_MS = 300_000L
 
-    /** Real-message push-wake debounce (2026-08-31): a burst of messages is N
+    /** Real-message push-wake debounce: a burst of messages is N
      *  wakes but needs one syncOnce — the trailing-edge debounce drains the
      *  window's pending wakes into a single sync, at ~1s latency. */
     private const val PUSH_WAKE_DEBOUNCE_MS = 1_000L
@@ -692,12 +686,12 @@ object MatrixRepository {
 
 
     /** Min gap between network-triggered sync restarts (flappy-radio guard,
-     *  2026-09-01 — see [networkCallback]). */
+     *  — see [networkCallback]). */
     private const val NETWORK_RESET_MIN_INTERVAL_MS = 60_000L
 
     /**
-     * Per-room timeline window for the ACTIVE long-poll filter (PLAN §8.1,
-     * 2026-08-28): bounds each room's per-/sync payload — the 30-50 s CPU per
+     * Per-room timeline window for the ACTIVE long-poll filter (PLAN §8.1):
+     * bounds each room's per-/sync payload — the 30-50 s CPU per
      * sync on the 1284-room account was mostly pages of timeline events nobody
      * read. 50 is high enough to never truncate a busy bridged room's burst:
      * Trixnity marks `limited` syncs but never backfills, so a truncated burst
@@ -706,11 +700,11 @@ object MatrixRepository {
     private const val SYNC_TIMELINE_LIMIT = 50L
 
     /**
-     * Background-only timeline window (SYNC-PERF-SPEC §Phase 1, 2026-09-05):
+     * Background-only timeline window (SYNC-PERF-SPEC §Phase 1):
      * the syncOnce filter (slow rounds / push wakes / send-wakes) serves steady
      * incremental deltas, not gap-fill, so a slimmer window parses, decrypts
      * and stores less per round. 20, not 10: a burst deeper than the window
-     * truncates (the 2026-09-01 incident), and the wake's [isEventStored]
+     * truncates (the incident), and the wake's [isEventStored]
      * verification then misses → retries → a false sync-pending notification.
      */
     private const val SYNC_TIMELINE_LIMIT_BACKGROUND = 20L
@@ -727,12 +721,12 @@ object MatrixRepository {
                     startActiveRoomRefresh()
                     // A message likely landed while the screen was dark — end
                     // the resolver's screen-off sleep so the list is fresh the
-                    // moment the user opens it (feedback 2026-08-17).
+                    // moment the user opens it.
                     wakeRoomList()
                 }
                 Intent.ACTION_SCREEN_OFF -> {
                     applySyncModeForScreenState()
-                    // Battery (2026-08-15 audit): the active-room refresh was
+                    // Battery: the active-room refresh was
                     // running 24/7 with no visibility coupling — every 2s a full
                     // page rebuild (SQL chain walk + key-backup restore + API
                     // re-reads). Nobody is looking while the screen is off.
@@ -743,8 +737,7 @@ object MatrixRepository {
     }
 
     /**
-     * Network-loss recovery (2026-09-01, mirrors Beeper's
-     * `networkChanged`/`resetNetworkConnections`): a transport drop can leave
+     * Network-loss recovery: a transport drop can leave
      * Trixnity's sync loop dead until its internal retry or the watchdog
      * fires — reset it as soon as the network is back. Registered on the app
      * context in [init], process-lifetime like [screenReceiver].
@@ -790,7 +783,7 @@ object MatrixRepository {
         // no sync loop and no foreground service — the battery escape hatch.
         syncEnabled = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .getBoolean(KEY_SYNC_ENABLED, true)
-        // Seed the restore-completed flag from prefs (2026-09-01): the crawl is
+        // Seed the restore-completed flag from prefs: the crawl is
         // throttled to once per 24h, so after a restart the in-memory
         // [RestoreProgress] would claim "not completed" until the next real
         // crawl — the Account screen's "All messages restored" could never show.
@@ -808,7 +801,7 @@ object MatrixRepository {
             },
             Context.RECEIVER_NOT_EXPORTED,
         )
-        // Network-loss recovery (2026-09-01): reset the sync loop when the
+        // Network-loss recovery: reset the sync loop when the
         // transport returns — Trixnity can sit dead until its internal retry.
         // The initial onAvailable for the current default network is a no-op
         // (networkWasLost starts false).
@@ -822,20 +815,20 @@ object MatrixRepository {
         scope.launch {
             // Restore the session regardless of the sync toggle. GetAccountState
             // reads the live client, so a paused companion that skips the restore
-            // makes the tool report "Not signed in" while the session is fine
-            // (2026-08-14, user-verified on the LP3). Only the sync loop (and
+            // makes the tool report "Not signed in" while the session is fine.
+            // Only the sync loop (and
             // its FGS) is gated on the toggle; the restored client's observers
             // stay dormant without sync (room flows never emit).
             if (ensureClient() != null) {
                 if (syncEnabled) {
-                    // Screen-state-aware start (battery 2026-08-19 audit): a
+                    // Screen-state-aware start: a
                     // session restore that lands while the screen is dark must
                     // NOT long-poll — the boot-time sample above races the
                     // restore, and a SCREEN_OFF broadcast that fired before the
                     // receiver registered is gone. The shared entry point
                     // applies the cadence the screen actually calls for.
                     applySyncModeForScreenState()
-                    // Push wake-up channel (2026-08-16): register the Matrix
+                    // Push wake-up channel: register the Matrix
                     // HTTP pusher + hold the SSE subscription so idle sync has
                     // zero latency — see PushChannel.
                     PushChannel.start(app, client!!)
@@ -890,10 +883,7 @@ object MatrixRepository {
     }
 
     /**
-     * Single entry point for the screen-state → sync-cadence decision (battery
-     * 2026-08-19 audit: the slow-sync gate could silently never fire — a
-     * process restart raced the grace, `enterSlowSync` bailed on a null
-     * client, and the restore's long-poll never re-checked the screen).
+     * Single entry point for the screen-state → sync-cadence decision.
      * Called from [init] after the client is ready, the SCREEN_ON/OFF
      * receiver, and [ChatSyncService] before it starts a long-poll, so a sync
      * loop never runs while the screen is dark. Screen on → active long-poll;
@@ -929,7 +919,7 @@ object MatrixRepository {
     private suspend fun enterSlowSync() {
         if (!syncEnabled || syncMode == SyncMode.SLOW) return
         // The session restore may still be in flight when the grace fires (a
-        // process restart while dark — battery 2026-08-19 audit). Wait for it
+        // process restart while dark — audit). Wait for it
         // (bounded, screen re-checked) instead of bailing: a bail left syncMode
         // ACTIVE and the restore's long-poll ran all night with no re-check.
         var c = client
@@ -952,13 +942,12 @@ object MatrixRepository {
             if (isScreenInteractive()) return // screen came back on — enterActiveSync owns sync
             android.util.Log.w(TAG, "slow-sync grace: waited for client — engaging slow sync")
         }
-        // Screen truth re-check (2026-08-22): the grace's check above can race
+        // Screen truth re-check: the grace's check above can race
         // a SCREEN_ON broadcast (they fire in the same ms on a button press).
         // With a live client (the c == null branch above is skipped) engaging
         // slow mode then STOPS the long-poll while the screen is on — the
         // "sync mode: active" + "sync mode: slow" back-to-back log + a dead
-        // loop until the next SCREEN_ON (LP3 2026-08-22: stuck offline banner
-        // + no message delivery while slow-sync rounds ran underneath).
+        // loop until the next SCREEN_ON.
         if (isScreenInteractive()) return // screen came back on — enterActiveSync owns sync
         syncMode = SyncMode.SLOW // gate first: the watchdog must not restart the long-poll
         runCatching { c.stopSync() }
@@ -979,8 +968,8 @@ object MatrixRepository {
 
     /** One syncOnce round with a wall-clock duration log — the per-sync cost is
      *  the battery metric that decides whether sync can be leaner (Beeper's
-     *  client wakes in ~1s; ours measured here — battery 2026-08-17 audit). The
-     *  round's outcome re-asserts the connection state (2026-08-22): a
+     *  client wakes in ~1s; ours measured here — audit). The
+     *  round's outcome re-asserts the connection state: a
      *  successful round proves connectivity, so it clears a stale "offline"
      *  left by the syncState observer (which can freeze on a long-poll TIMEOUT
      *  while the rounds keep succeeding — the LP3's stuck "Can't reach server"
@@ -1000,8 +989,7 @@ object MatrixRepository {
         // returns — release the sync-ingest gate here. In slow mode no further
         // /sync request follows for minutes, so without this stamp the gate
         // would read "in flight" until the next round and every heavy consumer
-        // would burn its full 8s yield for nothing (emulator 2026-09-05: deep
-        // catch-up round's room-row publish delayed 23s ≈ 3 × 8s yields).
+        // would burn its full 8s yield for nothing.
         syncRoundEndedAt = android.os.SystemClock.elapsedRealtime()
         android.util.Log.d(TAG, "syncOnce took ${android.os.SystemClock.elapsedRealtime() - t0}ms ($reason)")
         return result
@@ -1013,13 +1001,13 @@ object MatrixRepository {
             var lastInterval = 0L
             while (isActive) {
                 if (client !== c) return@launch // logged out / re-logged in under us
-                // Delay before the first round (audit 2026-08-23): a wake
+                // Delay before the first round: a wake
                 // (push/send) cancels the rounds, runs its own syncOnce, then
                 // recreates this job — an immediate first round duplicated the
                 // wake's syncOnce (two /sync per wake, ~2x the per-push cost).
                 // The wake's own round already delivers; the cadence below is
                 // the redundancy net.
-                // Push-gated cadence (2026-08-31, PLAN §8.2): while the push
+                // Push-gated cadence: while the push
                 // channel is connected the rounds run lazy — pushes wake us
                 // for real messages, so a 15-min net is enough; when it's
                 // down we fall back to the 5-min cadence (a dead push must
@@ -1066,17 +1054,16 @@ object MatrixRepository {
     }
 
     /**
-     * Push-wake (2026-08-16, see PushChannel): an SSE push notification
+     * Push-wake: an SSE push notification
      * arrived, so a message is waiting. While idle (slow sync, screen off)
      * run ONE syncOnce round — the notification watcher then posts the local
      * notification and the room flows update. While active the long-poll
      * already delivers it, so the push is redundant and skipped. The slow-sync
      * rounds are the fallback delivery (a silent SSE drop must not mean missed
      * messages) — the same 5-min cadence with or without a live channel
-     * (PLAN §8.2, 2026-08-28: was a 30-min push-gated net; a silently-dead
+     * (PLAN §8.2: was a 30-min push-gated net; a silently-dead
      * push meant a 30-min receive delay, and rounds are cheap with the sync
      * filter).
-     *
      * [countsOnly] = the push carried no room/event id (Beeper's read-receipt /
      * unread-count payloads). Those must not each run a full ~30-50 s syncOnce
      * — a group chat with N members generates one per read action. Bursts
@@ -1121,8 +1108,7 @@ object MatrixRepository {
      *  readTimelineChainFromDb walks; single indexed point queries). Message
      *  events land in TimelineEvent; state events (invites, member/topic
      *  changes) land in RoomState's JSON `event` column instead — both are
-     *  pushable, so both are checked (2026-09-02: an invite push false-
-     *  negatived on TimelineEvent alone, burning the wake's retries). */
+     *  pushable, so both are checked. */
     private suspend fun isEventStored(c: MatrixClient, roomId: String, eventId: String): Boolean {
         val db = runCatching {
             c.di.get<TrixnityRoomDatabase>(TrixnityRoomDatabase::class)
@@ -1164,8 +1150,7 @@ object MatrixRepository {
         slowSyncJob = null
         var caughtUp = false
         // NOTE: `return@repeat` would NOT break here — repeat's inline lambda
-        // returning just continues the next index (2026-09-02: an invite push
-        // ran all 3 syncs back-to-back with no delays for exactly this reason).
+        // returning just continues the next index.
         // A plain for loop with `break` stops the retries once caught up.
         for (attempt in 0 until PUSH_WAKE_ATTEMPTS) {
             timedSyncOnce(c, if (attempt == 0) "push" else "push-retry")
@@ -1200,9 +1185,8 @@ object MatrixRepository {
      * without a handler. Route it to logcat (tag "Trixnity") so crypto/sync
      * internals are debuggable — e.g. why a /keys/claim doesn't result in an olm
      * session ("could not encrypt room key with olm").
-     *
      * Full FINE tracing is gated behind the runtime `debugLog` flag (default
-     * off — efficiency audit 2026-08-14: FINE→logcat was always on and burned
+     * off — efficiency: FINE→logcat was always on and burned
      * standby CPU/logd volume all night); WARN+ always stays visible.
      */
     private fun enableTrixnityLogging() {
@@ -1252,15 +1236,13 @@ object MatrixRepository {
      * foreground — then keep promoting to the foreground service so sync
      * survives the tool closing. ChatSyncService treats an armed in-process
      * loop as keep-alive-only instead of arming a second loop.
-     *
-     * Arm-once since 2026-09-02: under Trixnity v5, [MatrixClient.startSync]
+     * Arm-once since: under Trixnity v5, [MatrixClient.startSync]
      * does NOT run the sync inline — it arms the client's internal sync loop
      * (the /sync rounds and their error retries happen inside the client) and
      * returns. The old restart-with-backoff loop was built on v4 semantics
      * (startSync suspended until the loop died), so on v5 it logged "loop
      * ended" after every arm and re-armed on a 1→30 s clock, aborting the
-     * in-flight round each time (LP3 2026-09-02: W-line every 30 s while the
-     * rounds ran fine inside Trixnity). A wedged loop is recovered by
+     * in-flight round each time. A wedged loop is recovered by
      * [ChatSyncService]'s syncState watchdog once the promotion lands.
      */
     private fun startSyncLoop(context: Context) {
@@ -1387,7 +1369,7 @@ object MatrixRepository {
      * prior [beeperRequestCode] call (its request id is consumed here).
      */
     /**
-     * Login wrappers projecting to [Result]`<Unit>` (NO-SEAM, 2026-09-07):
+     * Login wrappers projecting to [Result]`<Unit>` (NO-SEAM):
      * the tool module can't see Trixnity's MatrixClient (:server hides its
      * deps), so the direct caller maps the response from
      * [lastLoginUserId]/[lastLoginDeviceId]/[lastLoginNeedsVerification].
@@ -1580,7 +1562,7 @@ object MatrixRepository {
     }.getOrDefault(false)
 
     /**
-     * One-time /sync filter migration (LP3 2026-08-28): Trixnity uploads the
+     * One-time /sync filter migration: Trixnity uploads the
      * sync filter once at client setup and caches its id in the Account row;
      * the LP3's cached filter predates `com.beeper.inbox.done` joining
      * the whitelist ([applyDefaultFilter]), so /sync strips it — and because
@@ -1588,14 +1570,12 @@ object MatrixRepository {
      * sync never re-delivers them (Jeff/Tiki never reflected on the LP3).
      * Clearing filterId/backgroundFilterId forces the client's setup to
      * upload a fresh filter.
-     *
-     * v4 (2026-08-28) also cleared syncBatchToken — a full initial sync under
+     * v4 also cleared syncBatchToken — a full initial sync under
      * the fresh filter, needed to re-deliver state that had already passed.
-     * v5 (2026-08-31) keeps the token: the ephemeral notTypes slimming (see
+     * v5 keeps the token: the ephemeral notTypes slimming (see
      * [clientConfiguration]) only affects future windows — ephemeral events
      * are never re-delivered — so a full re-sync would just burn CPU.
-     *
-     * v4/v5 bug (found on-device 2026-08-31): the SQL targeted
+     * v4/v5 bug: the SQL targeted
      * filterId/backgroundFilterId columns that don't exist in the
      * de.connect2x fork — it stores BOTH filter ids as JSON in a single
      * `filter` TEXT column. The UPDATE threw SQLITE_ERROR and runCatching
@@ -1603,14 +1583,13 @@ object MatrixRepository {
      * filter stayed live. v6 clears the `filter` column itself, forcing the
      * client's setup to re-upload both filters. The token stays untouched
      * (ephemeral is never re-delivered, no full re-sync needed).
-     *
      * Must run BEFORE the client is built ([ensureClient]): the client's
      * setup flow uploads a missing filter itself, while startSync
      * checkNotNulls the stored filterId — clearing it on a live client races
      * the upload and throws. AccountStore.updateAccount can't be used here:
      * it passes keyExists=false, which skips the repository write on a cold
-     * cache (the updater sees null and nothing persists — verified
-     * 2026-08-29), so the Account row is cleared via SQL directly. Prefs-gated
+     * cache (the updater sees null and nothing persists), so the Account row is
+     * cleared via SQL directly. Prefs-gated
      * once per account, keyed by [SYNC_FILTER_MAPPINGS_VERSION].
      */
     private suspend fun migrateSyncFilterIfNeeded(ctx: Context) {
@@ -1640,7 +1619,6 @@ object MatrixRepository {
      * syncOnce rounds read the stored id per round). Called from the
      * verification Done branch, its timeout branch, and [finishLogin] when no
      * verification is needed. Idempotent — one swap per login, one retry.
-     *
      * Trixnity 5.8 uploads filters exactly once, in the client's init
      * coroutine (MatrixClient.kt: the `filter == null || eventTypesHash
      * changed` gate); startSync/syncOnce only read the STORED ids — so the
@@ -1652,8 +1630,7 @@ object MatrixRepository {
      * ids through the client's AccountStore (raw SQL would desync its
      * in-memory cache). The upload+store happens AFTER the client's `started`
      * flag flips (the init coroutine's last act, after it stores its own ids),
-     * so the swap always wins over the init store even when they race
-     * (emulator 2026-09-06: a swap before `started` left the slim ids stored).
+     * so the swap always wins over the init store even when they race.
      */
     private suspend fun swapToFullSync() {
         if (!verificationSyncSwapped.compareAndSet(false, true)) return
@@ -1676,8 +1653,7 @@ object MatrixRepository {
         config.syncOnceFilter = fullSyncOnceFilters
         // The init upload reads the config BEFORE its network calls and stores
         // the ids after — a swap racing it could otherwise read filter==null,
-        // skip, and let the init store the SLIM ids right after (measured on
-        // the emulator 2026-09-06). `started` flips only AFTER the init store,
+        // skip, and let the init store the SLIM ids right after. `started` flips only AFTER the init store,
         // so waiting for it makes the stored ids final; we then overwrite them
         // with the full pair. Bounded: an init that never completes (dead
         // network) degrades to uploading with an empty eventTypesHash, which
@@ -1686,10 +1662,7 @@ object MatrixRepository {
         // Stop the slim loop BEFORE nulling the batch token: the old loop's
         // in-flight round writes its token on completion, and a token landing
         // after our null turns the restarted loop into incremental rounds —
-        // the state-bearing initial sync never runs (LP3 2026-09-06: rooms
-        // "Chat" forever AND megolm decrypt refuses on the missing
-        // m.room.encryption state, so history stays [Encrypted] despite a
-        // successful backup-key restore).
+        // the state-bearing initial sync never runs.
         runCatching { c.stopSync() }
         inProcessSyncRunning = false
         val accountStore = c.di.get<AccountStore>()
@@ -1703,10 +1676,10 @@ object MatrixRepository {
                 // phase ADVANCED the batch token past all room state/timeline
                 // (limit 1, state notTypes="*"), and an incremental restart
                 // never re-delivers what the token passed — rooms render
-                // nameless ("Chat…") and history stays "Encrypted" forever
-                // (LP3 2026-09-06). Nulling the token makes the restarted loop
+                // nameless ("Chat…") and history stays "Encrypted" forever.
+                // Nulling the token makes the restarted loop
                 // do a true full initial sync under the full filter — same
-                // reasoning as sync-filter migration v4 (2026-08-28).
+                // reasoning as sync-filter migration v4.
                 it?.copy(
                     filter = Account.Filter(syncFilterId, syncOnceFilterId, storedHash ?: ""),
                     syncBatchToken = null,
@@ -1786,8 +1759,8 @@ object MatrixRepository {
             val key = recoveryKey.filter { it.isLetterOrDigit() }
             if (key.length < 48) error("recovery key needs 48 characters — got ${key.length}")
 
-            // Beeper compatibility (2026-08-12): stock Trixnity's
-            // AesHmacSha2RecoveryKey.verify() first runs checkRecoveryKey, which
+            // Beeper compatibility: stock Trixnity's
+            // AesHmacSha2RecoveryKey.verify first runs checkRecoveryKey, which
             // checks the key against the storage-key config MAC derived with
             // name="". Beeper's clients created this account's storage keys with
             // the secret-name derivation, so the config MAC never matches — the
@@ -1874,9 +1847,9 @@ object MatrixRepository {
     @Volatile
     private var theirSasStartAtMs: Long = 0L
 
-    /** E2EE status memoized for [E2EE_STATE_TTL_MS] — the network getDevices()
+    /** E2EE status memoized for [E2EE_STATE_TTL_MS] — the network getDevices
      *  on every poll (1-5 s) + every thread open was the slow, constant
-     *  "Checking if account is verified" work (2026-08-23). (elapsedRealtime
+     *  "Checking if account is verified" work. (elapsedRealtime
      *  fetchedAt, verified, other-device count.) */
     @Volatile
     private var e2eeStateCache: Triple<Long, Boolean, Int>? = null
@@ -1899,8 +1872,8 @@ object MatrixRepository {
         // Same policy as [isDeviceVerified]: a timed-out trust read must NOT
         // read as "unverified" — on the LP3 the first read after opening the
         // screen can exceed the budget on a cold trust store, and the Account
-        // row flipped "not verified" → "verified" on the next 5s poll
-        // (2026-08-17, user report). Only a genuine non-CrossSigned trust
+        // row flipped "not verified" → "verified" on the next 5s poll.
+        // Only a genuine non-CrossSigned trust
         // result counts as unverified.
         val verified = isDeviceVerified(c)
         if (verified && !restoreAttempted) {
@@ -2033,7 +2006,7 @@ object MatrixRepository {
                 // The SAS is engaging — stay on the accept panel instead of
                 // dipping back to "waiting" (the other device's SAS start
                 // follows their accept within ms; the dip read as the flow
-                // reverting — LP3 2026-08-19).
+                // reverting — ).
                 VerificationUi.Accept
             }
             is ActiveVerificationState.Done -> {
@@ -2042,14 +2015,13 @@ object MatrixRepository {
                 // The backup-key secret lands via /sync a moment after Done, but
                 // the login-time restore ran before it existed and set the 24h
                 // cooldown. Clear it and retry on a short ladder so the crawl
-                // actually runs once the key is local (LP3 2026-08-29: Done →
-                // key arrived ~2s later, restore skipped by the stale cooldown).
+                // actually runs once the key is local.
                 scope.launch {
                     val prefs = appContext?.getSharedPreferences(PREFS, Context.MODE_PRIVATE) ?: return@launch
                     // The backup secret's arrival is out of our control: another
                     // device answers the secret request whenever it does — 25 s
                     // in the working run, never (5+ min) in the two failing
-                    // logins (LP3 2026-09-06/07). The old 3-try/90 s ladder
+                    // logins. The old 3-try/90 s ladder
                     // gave up before late answers could land. Each attempt
                     // re-requests the missing secrets internally (see
                     // [restoreMegolmSessions]); a success stamps the cooldown
@@ -2067,7 +2039,7 @@ object MatrixRepository {
             else -> {
                 if (state is ActiveVerificationState.Cancel) {
                     verificationTimeoutJob?.cancel()
-                    // Trixnity quirks (LP3 2026-08-19 + 2026-09-06): a spurious
+                    // Trixnity quirks: a spurious
                     // m.unexpected_message cancel fires either pre-flow (~4 s
                     // in, right before the partner's accept lands) or moments
                     // after their SAS start when two devices answer the fan-out
@@ -2129,7 +2101,7 @@ object MatrixRepository {
     }
 
     /**
-     * Process-death recovery (LP3 2026-09-06): a restart loses the cached SSSS
+     * Process-death recovery: a restart loses the cached SSSS
      * secrets (backup key, cross-signing keys) that Trixnity normally receives
      * exactly once, right after device verification — its own auto-request is
      * a one-shot at client start and never re-fires. Ask our verified own
@@ -2142,9 +2114,7 @@ object MatrixRepository {
     private suspend fun reRequestMissingSecrets(c: MatrixClient): Boolean = runCatching {
         val keyStore = c.di.get<KeyStore>(KeyStore::class)
         val tm = c.di.get<StoreTransactionManager>(StoreTransactionManager::class)
-        // An unanswered request must not block the retry ladder (2026-09-07:
-        // Trixnity only drops pending requests after 1 day, so without this the
-        // 10s/30s/60s… ladder re-sent nothing after the first attempt). Purge
+        // An unanswered request must not block the retry ladder. Purge
         // pending requests and re-send — a late answer still matches by request
         // id at accept time, so purging is safe.
         keyStore.getAllSecretKeyRequests().forEach { req ->
@@ -2163,7 +2133,7 @@ object MatrixRepository {
         // The local device-key store only knows devices a previous flow happened
         // to fetch — after repeated logout/logins that's mostly our own dead
         // past sessions, while the live Beeper clients (which hold the secrets)
-        // were never asked (2026-09-07, the history-stays-encrypted bug).
+        // were never asked.
         // mautrix/Beeper requests from ALL own devices ("*" semantics). Refresh
         // own keys from the server first: OutdatedKeysHandler fetches /keys/query
         // and computes trust for every current device when the user is marked
@@ -2211,8 +2181,7 @@ object MatrixRepository {
      * After the device is verified, load every undecrypted event's megolm session
      * from the server-side key backup so the room store can decrypt it. Called on
      * verification success; loading a session decrypts what the session covers.
-     *
-     * Battery/UX (2026-08-15): gated to at most once per day and bounded tighter
+     * Battery/UX: gated to at most once per day and bounded tighter
      * per room. Before, it ran on EVERY process start (reboot/install/force-stop)
      * and could crawl for 20+ min at several cores, starving the tool's requests
      * ("Loading messages…" / "…" account). The on-demand page path
@@ -2239,7 +2208,7 @@ object MatrixRepository {
         val now = System.currentTimeMillis()
         if (now - lastRun < RESTORE_INTERVAL_MS) {
             // The cooldown must not silence the re-request recovery: a restart
-            // that dropped the cached backup secret (LP3 2026-09-06) would
+            // that dropped the cached backup secret would
             // otherwise stay un-decryptable for a day. Missing secret → run.
             val hasBackupSecret = runCatching {
                 c.di.get<KeyStore>(KeyStore::class).getSecrets().containsKey(SecretType.M_MEGOLM_BACKUP_V1)
@@ -2253,13 +2222,12 @@ object MatrixRepository {
         // Trixnity's version flow emits its current value immediately — null
         // until the service has actually fetched /room_keys/version. A process
         // restart before that fetch reads as "no backup configured" and stuck
-        // the account un-decryptable for the crawl's 24h interval (LP3
-        // 2026-09-06, post-verification restart). Wait for a real emission;
+        // the account un-decryptable for the crawl's 24h interval. Wait for a real emission;
         // null after the budget means genuinely absent/unreachable.
         var backupVersion = withTimeoutOrNull(KEY_BACKUP_VERSION_BUDGET_MS) {
             runCatching { keyBackup.version.filterNotNull().firstOrNull() }.getOrNull()
         }
-        // Process-death recovery (LP3 2026-09-06): version stays null when the
+        // Process-death recovery: version stays null when the
         // cached backup secret didn't survive a restart (Trixnity receives it
         // exactly once, right after verification, and never re-requests). If
         // the server still has a backup, re-request the missing secrets from
@@ -2274,8 +2242,7 @@ object MatrixRepository {
         android.util.Log.d(TAG, "restore: backup version = $backupVersion")
         if (backupVersion == null) {
             // No server-side backup — the per-room loadMegolmSession would
-            // time out (2 s) on every room for nothing (LP3 2026-08-29 fresh
-            // login: 296 × 2 s of logcat noise every day). Bail; the on-demand
+            // time out (2 s) on every room for nothing. Bail; the on-demand
             // page path still restores the moment a backup appears. Clear the
             // cooldown: a configured account whose service hadn't warmed must
             // get a retry (the cost of a false bail is one version fetch).
@@ -2295,8 +2262,8 @@ object MatrixRepository {
                 if (scanned % 200 == 0) {
                     android.util.Log.d(TAG, "restore: $scanned/${rooms.size} rooms scanned, $roomsTouched with encrypted content")
                 }
-                // The futile-restore cooldown no longer skips the room here
-                // (2026-09-07): parked rooms are exactly the ones with stuck
+                // The futile-restore cooldown no longer skips the room here:
+                // parked rooms are exactly the ones with stuck
                 // rows, and restoreRoomSessions' local-first re-decrypt is
                 // free (no backup round-trip) — the cooldown gates only the
                 // backup part inside it, so parking stays effective.
@@ -2322,13 +2289,12 @@ object MatrixRepository {
         }
         android.util.Log.d(TAG, "restore: done — $roomsTouched rooms with encrypted content")
         // Written on COMPLETION: a crawl killed mid-run (update install,
-        // process death) must be able to re-run — stamping at start stranded
-        // a 21:20 crawl killed by the 21:26 update behind the 24h cooldown
-        // (LP3 2026-09-06). The scan is idempotent; re-running costs the
+        // process death) must be able to re-run.
+        // The scan is idempotent; re-running costs the
         // skipped-room re-reads only.
         prefs.edit().putLong(KEY_RESTORE_LAST_RUN_MS, System.currentTimeMillis()).apply()
         _restoreProgress.value = RestoreProgress(scanned = scanned, roomsTotal = rooms.size, completed = true)
-        // Persist (2026-09-01): the in-memory flag dies with the process and
+        // Persist: the in-memory flag dies with the process and
         // the 24h gate keeps the next crawl a no-op, so without this the
         // Account screen's "All messages restored" could only show in the
         // process that ran the crawl. Cleared at login / logout.
@@ -2374,7 +2340,7 @@ object MatrixRepository {
             runCatching { old?.logout() } // API logout + clears Trixnity's store
                 .onFailure {
                     // A skipped/failed API logout leaks the device server-side
-                    // (2026-09-07: 5 stale "Chats (Light Phone)" devices, one per
+                    // (5 stale "Chats (Light Phone)" devices, one per
                     // force-killed/expired session — they poisoned the secret-
                     // request receiver list). Make the leak visible.
                     android.util.Log.w(TAG, "logout: API logout failed — device stays registered: ${it.message}")
@@ -2419,12 +2385,10 @@ object MatrixRepository {
                 observeClient(restored)
                 // Restore path (process restart / update install) mirrors
                 // finishLogin's E2EE wiring: login-only wiring left updated
-                // installs with no verification and no key-backup crawl
-                // (LP3 2026-09-06: the 21:26 update killed the 21:20 crawl
-                // mid-run and nothing on this path ever re-triggered it).
+                // installs with no verification and no key-backup crawl.
                 scope.launch { armRestoreVerification(restored) }
                 // Show the last-known chats immediately while the resolver's
-                // first pass warms the store (Phase 14 disk cache).
+                // first pass warms the store (disk cache).
                 if (_roomList.value.isEmpty()) preloadRoomListFromDisk()
                 restored
             } else {
@@ -2473,7 +2437,7 @@ object MatrixRepository {
     /** Newest activity first — a pure read of the background-refreshed cache. */
     suspend fun getRooms(): List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room> {
         if (client == null) return emptyList()
-        // Phase-0 latency timer (SYNC-PERF-SPEC.md): how long after the revision
+        // latency timer (SYNC-PERF-SPEC.md): how long after the revision
         // bump the tool's fetch arrives — includes the poll-tick wait + binder
         // transit (the server knows both endpoints, so this needs no tool-side flag).
         if (debugLogging() && roomListPublishedAt > 0) {
@@ -2498,8 +2462,7 @@ object MatrixRepository {
         // tail. The full census stays in _roomList (resolver keeps refreshing
         // every room); any room that gets a new message sorts back into the
         // window on the next publish.
-        //
-        // Per-network guarantee (2026-08-30): a global recency window lets a
+        // Per-network guarantee: a global recency window lets a
         // quiet network (Signal) and its older rooms drop out entirely — the
         // Networks panel (derived from the served rooms) lost the label and
         // the main list lost the chats (LP3). Every network's newest room
@@ -2521,8 +2484,7 @@ object MatrixRepository {
      * The full room census for the tool's contacts list + search — every room,
      * not just the newest [MAX_ROOMS_OVER_BINDER] window (the cap exists for
      * the preview-laden [getRooms] reply; contacts/search rows don't show
-     * previews, so the whole account crosses the binder trimmed, chats
-     * 2026-08-30).
+     * previews, so the whole account crosses the binder trimmed, chats).
      */
     suspend fun getAllRooms(): List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room> {
         if (client == null) return emptyList()
@@ -2551,15 +2513,14 @@ object MatrixRepository {
     )
 
     /**
-     * Newest-page cache (feedback pass): re-opening a thread within the TTL is
+     * Newest-page cache: re-opening a thread within the TTL is
      * a pure map read instead of a timeline re-collect + key-backup restore.
      * Recomputed in the background by [refreshMessagePage].
      */
     private val messagePageCache =
         java.util.concurrent.ConcurrentHashMap<String, MessagePageEntry>()
 
-    /** Rooms with a background page refresh currently in flight (battery
-     *  2026-08-15: the 2s ticker used to launch unbounded concurrent rebuilds). */
+    /** Rooms with a background page refresh currently in flight. */
     private val messagePageRefreshInFlight =
         java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
@@ -2574,10 +2535,9 @@ object MatrixRepository {
      * as RedactedEventContent("m.room.encrypted") whatever it was (message,
      * reaction, edit — the original type lived in the Megolm ciphertext the
      * redaction dropped), so the plain eventType check misses it and the
-     * "[Message unsent]" row silently vanishes on the next page build (LP3
-     * feedback 2026-09-03: the unsent row vanished from the hannah room).
+     * "[Message unsent]" row silently vanishes on the next page build.
      * Trusting the bare m.room.encrypted type instead is NOT an option — the
-     * bridge's key-rotation redactions (megolm self-heal, 2026-08-23) and
+     * bridge's key-rotation redactions (megolm self-heal) and
      * un-react redactions would paint fake tombstones — so only redactions we
      * ourselves issued as message redactions get the marker. Plaintext rooms
      * keep matching on eventType alone (the type survives there).
@@ -2606,8 +2566,7 @@ object MatrixRepository {
     }
 
     /** Room → elapsed-realtime timestamp until which the futile key-backup
-     *  restore is suppressed (battery 2026-08-15: pre-verification history
-     *  never gets its sessions back, yet every page build retried it). */
+     *  restore is suppressed. */
     private val decryptRestoreCooldown = java.util.concurrent.ConcurrentHashMap<String, Long>()
 
     /** True while the room's key-backup restore is in the futile cooldown. */
@@ -2625,7 +2584,7 @@ object MatrixRepository {
     /** Parks a room whose key-backup restore found nothing to load: every retry
      *  path (preview, ghost walk, page build, daily crawl) stops re-attempting
      *  until the park expires. In-band sync decryption is unaffected, so a real
-     *  session arriving mid-park still decrypts events. (Battery 2026-08-17
+     *  session arriving mid-park still decrypts events. (Battery
      *  audit — the pre-verification history on this account never gets its
      *  sessions back, yet the retry paths re-ran doomed restores every 60-120 s,
      *  ~3 cores continuously.) */
@@ -2671,7 +2630,7 @@ object MatrixRepository {
         gapEventId: String,
     ): Pair<List<TimelineEvent>, Boolean>? {
         // Cold Wi-Fi round-trips (headers + TLS + a 30-event page) blow the
-        // 8 s cellular budget — the LP3 2026-09-06 window failed fills with
+        // 8 s cellular budget — the window failed fills with
         // the cause invisible, so the budget is network-aware and the cause
         // (exception vs timeout vs token) is logged now to decide the
         // stale-token fallback.
@@ -2680,9 +2639,9 @@ object MatrixRepository {
         val failure: String = withTimeoutOrNull(budget) {
             runCatching {
                 // Trixnity registers this binding qualified
-                // (bind<TimelineEventHandler>(); named<TimelineEventHandlerImpl>())
+                // (bind<TimelineEventHandler>; named<TimelineEventHandlerImpl>)
                 // — an unqualified lookup throws "No definition found" and every
-                // backfill silently failed forever (LP3 2026-09-06, 'Daniel').
+                // backfill silently failed forever.
                 c.di.get<TimelineEventHandler>(
                     org.koin.core.qualifier.named<TimelineEventHandlerImpl>(),
                 )
@@ -2715,7 +2674,7 @@ object MatrixRepository {
             size > MAX_MEDIA_CACHE_ENTRIES
     }
 
-    // --- Disk cache (Phase 14) ----------------------------------------------
+    // --- Disk cache ----------------------------------------------
     // The "instant re-open" goal: the room list and each room's newest message
     // page are persisted as JSON so a cold process (or a thread re-open after
     // the 5 s memory TTL) serves from disk immediately, while the background
@@ -2836,8 +2795,7 @@ object MatrixRepository {
             // A row whose name IS a bridge ghost's localpart ("whatsapp_lid-…")
             // was persisted before the name resolved — treat it as unresolved
             // so the next pass re-resolves it against the store + provision
-            // contacts (LP3 2026-09-05: "Anni" titled by its LID ghost for a
-            // whole disk-cache generation, the name fallback never re-ran).
+            // contacts.
             val nameIsGhostLocalpart = BRIDGE_KEYS.any { room.name.startsWith("${it}_") } &&
                 !room.name.contains(' ')
             roomListCache.putIfAbsent(
@@ -2861,7 +2819,7 @@ object MatrixRepository {
 
     /** Recomputes and re-stores a room's newest page in the background. */
     private fun refreshMessagePage(roomId: String, limit: Int = THREAD_PAGE_SIZE) {
-        // Battery (2026-08-15 audit): never pile up refreshes — a tick that
+        // Battery: never pile up refreshes — a tick that
         // finds one already in flight is a no-op (the 2s ticker used to launch
         // unbounded concurrent rebuilds that saturated the CPU).
         if (!messagePageRefreshInFlight.add(roomId)) return
@@ -2879,16 +2837,14 @@ object MatrixRepository {
                 // page, and after that every limit=20 poll bounced to the
                 // DISK cache (serving the stale page it held) while this guard
                 // skipped the rebuild — the anni-room misorder stayed on the
-                // LP3 screen long after the page build was fixed (2026-08-21).
+                // LP3 screen long after the page build was fixed.
                 val cached = messagePageCache[roomId]
                 if (cached != null && cached.limit >= limit && lastRefreshedEventId[roomId] == lastId) {
                     // Read receipts are ephemeral — they never move the room's
                     // last TIMELINE event, so this quiet-room guard would freeze
                     // the "seen" tag on a room the other party read without
-                    // replying (feedback 2026-08-30). Reaction tags are the same
-                    // class of quiet event (LP3 feedback 2026-09-03: an
-                    // encrypted m.reaction whose content the cached build never
-                    // resolved stayed tag-less until another event landed).
+                    // replying. Reaction tags are the same
+                    // class of quiet event.
                     // Patch the cached page cheaply (one bounded chain walk +
                     // a backoff-gated resolve for the unresolved ones) instead
                     // of a full rebuild; null = nothing changed, so the cache
@@ -2904,7 +2860,7 @@ object MatrixRepository {
                     }
                     return@launch
                 }
-                // Incremental refresh (PLAN §8.3, 2026-08-28): when the cache
+                // Incremental refresh (PLAN §8.3): when the cache
                 // covers the request and we know the last-refreshed chain head,
                 // append only the events that arrived since — the full
                 // [computeMessagesPage] (SQL chain walk + key-backup restores +
@@ -2947,8 +2903,8 @@ object MatrixRepository {
      * Recomputes only a cached newest page's "read" flags. Read receipts arrive
      * via sync ephemeral and never change the room's last timeline event, so
      * [refreshMessagePage]'s quiet-room guard skips the rebuild and the seen
-     * tag would stay frozen on a room the other party read without replying
-     * (feedback 2026-08-30). Same receipt walk as the page build over the
+     * tag would stay frozen on a room the other party read without replying.
+     * Same receipt walk as the page build over the
      * cached chain (delta empty); null when nothing changed, so the caller
      * keeps the cache and disk as-is.
      */
@@ -2976,8 +2932,8 @@ object MatrixRepository {
 
     /**
      * Quiet-room guard patch: recomputes the cached page's parts that don't
-     * move the room's last event id — read receipts (sync ephemeral, feedback
-     * 2026-08-30), reaction tags (see [patchReactionTags]) and send-status tags
+     * move the room's last event id — read receipts (sync ephemeral),
+     * reaction tags (see [patchReactionTags]) and send-status tags
      * (see [patchSendStatuses]). null when none changed, so the caller keeps
      * the cache and disk as-is.
      */
@@ -3005,7 +2961,7 @@ object MatrixRepository {
      * map (15 s TTL) and baked SENDING into the rows, after which the room is
      * quiet — the head never moves again, and the quiet ticks that patch
      * receipts/reactions never re-read statuses, so the tag sat until the room
-     * was reopened or another message landed (LP3 feedback 2026-09-06). The
+     * was reopened or another message landed. The
      * map TTL bounds how long the patch trails the ack.
      */
     private suspend fun patchSendStatuses(
@@ -3031,8 +2987,7 @@ object MatrixRepository {
      * land as Megolm) reaches the store with its content unresolved, the
      * rebuild that ran on its arrival gave up on the decrypt and stamped
      * lastRefreshedEventId, and every later quiet tick then skipped it — the
-     * tag only appeared when another event forced a rebuild (LP3 feedback
-     * 2026-09-03: the hannah room's reactions showed late or never). Events
+     * tag only appeared when another event forced a rebuild. Events
      * still unresolved are re-read through the API — that re-read triggers the
      * decrypt (the mechanism [resolvePendingEcho] relies on) — at most
      * [REACTION_RESOLVE_MAX] per pass with a per-room backoff after a dry pass,
@@ -3118,8 +3073,8 @@ object MatrixRepository {
         // Bails: anything the incremental path can't resolve exactly.
         if (delta.any { it.gap != null }) return null
         if (delta.any { te -> te.content?.getOrNull() == null && te.event.content is EncryptedMessageEventContent }) return null
-        // A redaction REMOVES content the cached page shows (Phase A, 2026-09-03:
-        // an unsent reaction's tag must vanish) — the append-only patch below can
+        // A redaction REMOVES content the cached page shows (an unsent
+        // reaction's tag must vanish) — the append-only patch below can
         // only add reaction tags, so bail to the full rebuild (rare; the rebuild
         // recomputes tags from the window and the redacted one is gone).
         if (delta.any { te ->
@@ -3191,7 +3146,7 @@ object MatrixRepository {
                 // A media edit (gmessages: pending m.notice → m.image) must
                 // REBUILD the row, not body-copy: the row's contentType comes
                 // from the original event, so a body-only patch left a centred
-                // system line wearing the bare file name (2026-09-03). The
+                // system line wearing the bare file name. The
                 // reactions/read/status patches below still apply.
                 c.room.getTimelineEvent(matrixRoomId, EventId(m.id)).firstOrNull()?.let { target ->
                     messageFrom(
@@ -3208,8 +3163,7 @@ object MatrixRepository {
             if (added != null) {
                 // A delta reaction replaces the same sender's cached tag (the
                 // incremental patch sees only the delta — the replaced
-                // reaction's tag still sits in the cached page; LP3 feedback
-                // 2026-09-03: fire→heart showed both until re-entry). Collapse
+                // reaction's tag still sits in the cached page). Collapse
                 // keeps the merged list at most two lines.
                 val merged = collapseReactionTags(mergeReactionTags(out.reactions, added))
                 if (merged != out.reactions) out = out.copy(reactions = merged)
@@ -3218,7 +3172,7 @@ object MatrixRepository {
             // Send status arrives in its own later event (bridge ack), usually
             // a poll round AFTER the message row was appended — re-patch it
             // here like read state, or the "delivered" tag never appears on
-            // rows already in the page (found 2026-09-06).
+            // rows already in the page.
             sendStatuses[m.id]?.takeIf { it != out.sendStatus }?.let { out = out.copy(sendStatus = it) }
             out
         }
@@ -3275,8 +3229,7 @@ object MatrixRepository {
                 // is served from memory — recompute in the background and the
                 // next poll is fresh. The old path re-read + JSON-decoded the
                 // same page from disk on every TTL expiry (the thread polls
-                // every 3 s vs the 5 s TTL — constant disk churn; profile
-                // 2026-08-20: loadMessagePageFromDisk + sanitizeFileName).
+                // every 3 s vs the 5 s TTL — constant disk churn).
                 if (android.os.SystemClock.elapsedRealtime() - cached.refreshedAtMs >= MESSAGE_PAGE_TTL_MS) {
                     refreshMessagePage(roomId, limit)
                 }
@@ -3297,8 +3250,7 @@ object MatrixRepository {
             // page immediately — the decrypt restores + status walks that make
             // a full page slow are what kept the thread on "Loading messages…"
             // — then recompute the full page in the background; the thread's
-            // poll swaps it in seconds later (feedback 2026-08-19: "could the
-            // room load incrementally? the last 5-8 messages").
+            // poll swaps it in seconds later.
             val first = computeMessagesPage(roomId, null, minOf(limit, INCREMENTAL_FIRST_PAGE), fast = true)
             messagePageCache[roomId] = MessagePageEntry(
                 first,
@@ -3318,8 +3270,7 @@ object MatrixRepository {
      * (memory cache or disk). The send's sync echo can still be in the outbox
      * when the page is read — and re-opening a thread served the stale cached
      * page, so a just-sent message appeared missing until the background
-     * refresh landed (feedback 2026-08-15: "the voice note didn't appear, even
-     * after exiting and entering"). The rows dedup by their "local-…" id; the
+     * refresh landed. The rows dedup by their "local-…" id; the
      * refresh's [computeMessagesPage] replaces them with the real echo.
      */
     private suspend fun injectPendingEchoes(roomId: String, page: MessagesPage): MessagesPage {
@@ -3334,7 +3285,7 @@ object MatrixRepository {
         // a failed one with the FAIL_ marker, a queued one as the optimistic
         // "local-…" row — dedup by id keeps a page that already holds the real
         // row from gaining a duplicate. Every in-flight send in the room is
-        // injected (rapid sends must ALL keep their rows — feedback 2026-08-17).
+        // injected (rapid sends must ALL keep their rows — ).
         for (pending in pendingAudioEchoes(roomId)) {
             addIfMissing(
                 pendingEchoRow(
@@ -3361,7 +3312,7 @@ object MatrixRepository {
         else MessagesPage(result, page.hasMore, page.encrypted)
     }
 
-    // --- Bridge re-import ("ghost") detection (Phase 14.5) ------------------
+    // --- Bridge re-import ("ghost") detection ------------------
     // Beeper's WhatsApp bridge occasionally re-imports room history as NEW
     // events (fresh event ids + timestamps, one megolm session) — surfacing
     // old media in threads and bumping rooms to the top of the chat list.
@@ -3370,7 +3321,6 @@ object MatrixRepository {
     // matches an OLDER event in the room is a copy, and real new messages
     // never duplicate older content. (Transaction ids don't discriminate:
     // real incoming messages carry them too.)
-    //
     // A density fallback catches floods whose content can't be read yet
     // (still-encrypted): an event in a >=30-per-minute txn flood — a real
     // conversation almost never reaches that rate.
@@ -3386,7 +3336,7 @@ object MatrixRepository {
      * re-import-copy candidates — and their media url lives in
      * m.new_content, leaving the top-level url/fileName null, which made
      * every same-sender media edit collapse into one signature and dedupe
-     * kept only the newest (gmessages 2026-09-03: older photo edits dropped,
+     * kept only the newest (gmessages: older photo edits dropped,
      * their "Waiting for attachment …" notices never became photos).
      */
     private fun contentSignature(c: MatrixClient, te: TimelineEvent): String? {
@@ -3427,8 +3377,7 @@ object MatrixRepository {
      * Drops re-import copies from [raw] (newest first). Newest-first: the
      * first occurrence of a content signature is kept (the newest event),
      * older duplicates are the copies — a real new message whose body repeats
-     * an older one must win over the older message (2026-08-23; matches
-     * [dedupeChain]'s thread-path semantics). Flood events (density fallback)
+     * an older one must win over the older message. Flood events (density fallback)
      * are dropped regardless of content readability.
      */
     private fun filterGhosts(c: MatrixClient, raw: List<TimelineEvent>): List<TimelineEvent> {
@@ -3448,8 +3397,7 @@ object MatrixRepository {
      * for [FLOOD_CONTEXT_TTL_MS] — the verdict (txn-id density within
      * [GHOST_BURST_WINDOW_MS]) can't change within seconds, and this read is a
      * full 250-event walk with network/decrypt timeouts, so running it per
-     * event made a message burst cost N× the walk (battery 2026-08-17 audit;
-     * Beeper's server does this dedup for its own client — we do it here).
+     * event made a message burst cost N× the walk.
      */
     private data class FloodContext(val fetchedAtMs: Long, val events: List<TimelineEvent>)
     private val floodContextCache = java.util.concurrent.ConcurrentHashMap<String, FloodContext>()
@@ -3503,7 +3451,7 @@ object MatrixRepository {
             events = fallback
             hasMore = fallback.size >= limit + 1
         }
-        // Gap-marker backfill (PLAN §8, 2026-08-21): a `limited=true` sync
+        // Gap-marker backfill (PLAN §8): a `limited=true` sync
         // stores a gap marker whose missing window the store never fills —
         // events created during the missed window are silently absent (seen
         // live on the LP3: a WhatsApp message existed in Beeper's clients but
@@ -3528,7 +3476,7 @@ object MatrixRepository {
         // session wasn't in the local store at sync time). Restore the
         // sessions from the key backup, then re-read those events once through
         // the API — the read decrypts and re-persists them. Skipped in the
-        // fast first-page path (2026-08-19 feedback round): the background
+        // fast first-page path: the background
         // full-page refresh resolves them; the fast page may briefly show
         // "[Encrypted message]" placeholders instead of a long loading state.
         if (!fast) {
@@ -3537,8 +3485,7 @@ object MatrixRepository {
                     // Decrypt never ATTEMPTED (content unresolved) counts too —
                     // the LP3's stuck rows are exactly this class, and the old
                     // failure-only filter kept them away from the key-backup
-                    // restore forever (drive 3, 2026-09-06: key requests fired,
-                    // backup never consulted). Age-gated like the placeholder:
+                    // restore forever. Age-gated like the placeholder:
                     // young pending events decrypt in-band; only stuck ones
                     // justify the backup round-trip.
                     (it.content == null &&
@@ -3547,7 +3494,7 @@ object MatrixRepository {
                             DECRYPT_PENDING_PLACEHOLDER_AFTER_MS)
             }
             if (undecrypted.isNotEmpty()) {
-                // Battery (2026-08-15 audit): events that can't decrypt (e.g.
+                // Battery: events that can't decrypt (e.g.
                 // pre-verification history — the bridge never re-shares those
                 // sessions) made every page build / 2s refresh repeat a doomed
                 // key-backup restore + per-event API re-read. When a restore finds
@@ -3575,7 +3522,7 @@ object MatrixRepository {
                 }
             }
         }
-        // Bridge re-import dedup (battery 2026-08-15 audit): the old
+        // Bridge re-import dedup: the old
         // filterGhosts heuristic (per-page signature + a 30-per-minute txn-id
         // flood rule) was assumption-based and could drop real messages; the
         // account's duplicates are exact re-imports, so keep the first
@@ -3624,8 +3571,7 @@ object MatrixRepository {
         // The recursive CTE streams potentially hundreds of rows per call, and
         // the crawl + thread precompute + ghost walks + tool RPCs all fire it
         // concurrently — at 4 simultaneous walks the SQLite pool (4 connections)
-        // was fully occupied and SENDS waited 30+s for a connection (LP3
-        // 2026-09-05: "compose hangs, then it sends"). Bound the concurrency;
+        // was fully occupied and SENDS waited 30+s for a connection. Bound the concurrency;
         // the walks are CPU/IO-cheap enough that 2 run near-linearly anyway.
         return chainDbSemaphore.withPermit {
             withContext(Dispatchers.IO) {
@@ -3735,7 +3681,7 @@ object MatrixRepository {
      *  error renders as "not delivered" (FAIL_ status, shown by the tool);
      *  only a still-queued send keeps the optimistic "local-…" row. The tool
      *  shows the send time for all three, so the thread reflects a send
-     *  immediately, until proven sent or not delivered (feedback 2026-08-17).
+     *  immediately, until proven sent or not delivered.
      */
     private suspend fun pendingEchoRow(
         c: MatrixClient,
@@ -3769,8 +3715,8 @@ object MatrixRepository {
      * After a process restart the in-memory pending-echo maps are gone, but
      * Trixnity's outbox is persisted — a message still queued (sync down /
      * slow round pending) or acked-but-not-yet-echoed would show NO row in the
-     * thread until the echo lands, reading as "message took minutes to send"
-     * (feedback 2026-08-30). Rebuild the pending maps from the outbox once per
+     * thread until the echo lands, reading as "message took minutes to send".
+     * Rebuild the pending maps from the outbox once per
      * client attach: every non-draft row becomes an optimistic echo, reusing
      * the live-send machinery ([pendingEchoRow], [insertPendingEchoes], the
      * room-list pending bump). Entries self-clean when the echo lands
@@ -3842,8 +3788,8 @@ object MatrixRepository {
         val matrixRoomId = RoomId(roomId)
 
         // Broadcast channels (you + the channel ghost) echo your own posts
-        // back with your display name baked into the body ("FENN: post" —
-        // feedback 2026-08-28). Resolve the name once so [messageFrom] can
+        // back with your display name baked into the body ("FENN: post").
+        // Resolve the name once so [messageFrom] can
         // strip it; null outside broadcast rooms = no stripping.
         val ownName = if (withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getById(matrixRoomId).firstOrNull()?.joinedMemberCount
@@ -3880,21 +3826,19 @@ object MatrixRepository {
         // triggers decryption of the page's events and restores the megolm
         // sessions that are missing (a decrypt that can't land until the
         // sessions are in the store made the first open slow). Skipped inside
-        // the futile-restore cooldown (battery 2026-08-15 audit) and in the
-        // fast first-page path (2026-08-19 feedback round — the background
-        // full-page refresh primes decrypts).
+        // the futile-restore cooldown and in the
+        // fast first-page path.
         if (!fast) {
             val seed = collectTimelineEvents(c, matrixRoomId, pageCursor, limit + 1)
             // Restore only when the page still has undecryptable events — an
-            // all-decrypted room needs no priming, so skip the parse entirely
-            // (battery 2026-08-17: the seed restore ran on every page read).
+            // all-decrypted room needs no priming, so skip the parse entirely.
             // The futile-restore cooldown now guards only the backup round-trip
             // inside [restoreRoomSessions] — the local-first re-decrypt of
-            // already-held sessions must run regardless (2026-09-07).
+            // already-held sessions must run regardless.
             if (seed.any { it.content?.isFailure == true }) {
                 // Park genuinely undecryptable pages too — the same futility signal
                 // as the page-build path, so opening a doomed room doesn't re-seed
-                // a restore on every read (battery 2026-08-17 audit).
+                // a restore on every read.
                 if (restoreRoomSessions(c, matrixRoomId, seed) == 0) {
                     parkFutileRestore(matrixRoomId)
                 }
@@ -3924,7 +3868,7 @@ object MatrixRepository {
                 hasMore = h2
             }
         }
-        // Older-page dead-end guard (2026-08-17): the chain can run through a
+        // Older-page dead-end guard: the chain can run through a
         // block of events that build no rows — the re-import's m.replace edits
         // are dropped by [messageFrom], so an older page landing on the edit
         // wall returned an empty page. The tool's cursor can't advance past
@@ -3932,8 +3876,7 @@ object MatrixRepository {
         // storm → server ANR). Walk deeper (in big steps — walls can be 100+
         // edits, e.g. the Crocs room's 168) until the page holds renderable
         // events or the chain ends, bounded.
-        //
-        // Extended to the NEWEST page (2026-08-23): the bridge's history
+        // Extended to the NEWEST page: the bridge's history
         // re-import (the 09:08 wall after a WhatsApp number change) leaves a
         // run of re-import copies at the top of a room that resolve to EMPTY
         // bodies — [messageFrom] now drops blank rows, so a page sitting
@@ -3957,16 +3900,14 @@ object MatrixRepository {
         // (ungated by design, see [requestMissingRoomKeys]). Runs AFTER the
         // skip-walk so the walk's accumulated events are included — before,
         // only the page's own events reached the trigger and genuinely-missing
-        // sessions in walked-over regions were never requested (LP3 2026-09-01:
-        // the FILM `$P7YgV85…` and G5zV1tm stuck sessions sit in a re-import
-        // region pagination jumps past).
+        // sessions in walked-over regions were never requested.
         requestMissingRoomKeys(c, matrixRoomId, events)
         android.util.Log.d(
             TAG,
             "getMessages: room=$matrixRoomId before=$beforeEventId limit=$limit page=${events.size} hasMore=$hasMore",
         )
 
-        // Edits (m.replace, feedback 2026-08-27): an edit never becomes a row,
+        // Edits (m.replace): an edit never becomes a row,
         // but it REPLACES its target's body and marks it edited. [events] is
         // newest-first and an edit is newer than its target, so the first
         // occurrence of a target is the NEWEST edit — putIfAbsent keeps it.
@@ -3983,7 +3924,7 @@ object MatrixRepository {
         }
         // Auto-download: the newest audio notes of the opened thread start
         // downloading in the background so the first play tap usually hits the
-        // on-disk cache (feedback 2026-08-27). No-ops for already-cached or
+        // on-disk cache. No-ops for already-cached or
         // in-flight notes, so every 3 s poll costs nothing here.
         prefetchVoiceNotes(c, matrixRoomId, events)
 
@@ -3991,7 +3932,7 @@ object MatrixRepository {
         val startIndex = if (keepCursor) 0 else 1 // drop the boundary cursor on older pages
         // Delivery status only matters for the newest page (what the user just
         // sent): the status events sit right after the message in the timeline.
-        // Send statuses ride on EVERY page (2026-08-23): a bridge FAIL on a
+        // Send statuses ride on EVERY page: a bridge FAIL on a
         // message that scrolled past the newest page showed as plain "sent"
         // — the honest "not delivered" marker must survive pagination. The
         // walk itself is cached per room (see [sendStatusesByEventIdCached]),
@@ -4002,11 +3943,10 @@ object MatrixRepository {
         // newest events; an older page's messages are always "read" in practice
         // but re-resolving each receipt per page isn't worth it).
         val readEventIds = if (beforeEventId == null && !fast) readReceiptsByEvent(c, matrixRoomId, events) else emptySet()
-        // Reactions on EVERY page path (LP3 2026-09-03): m.reaction sits after
+        // Reactions on EVERY page path: m.reaction sits after
         // its target, so a walk from the room head covers the in-window
-        // messages of fast cold-open pages and scrolled-back older pages alike
-        // — both served no tags before (the Sophie 9:12 likes, the Hannah
-        // reactions). Plaintext walk, no decrypt wait; [reactionCache] keeps
+        // messages of fast cold-open pages and scrolled-back older pages alike.
+        // Plaintext walk, no decrypt wait; [reactionCache] keeps
         // repeated builds (older-page scrolls) off the raw chain. Ceiling:
         // messages deeper than SEND_STATUS_WINDOW events from the head show
         // no reactions — a deeper per-scroll walk would tax every pagination.
@@ -4022,8 +3962,7 @@ object MatrixRepository {
         // A just-sent message's echo can sit in the timeline before its
         // decryption lands; the optimistic rows below represent it, so skip
         // the undecrypted "[Encrypted]" placeholder — a message the user just
-        // sent from this device must never read "waiting for key" (feedback
-        // 2026-08-17: the newest sent message appeared missing on re-entry).
+        // sent from this device must never read "waiting for key".
         val pendingTxnIds = buildSet {
             pendingAudioEcho[roomId]?.keys?.let { addAll(it) }
             pendingTextEcho[roomId]?.keys?.let { addAll(it) }
@@ -4037,7 +3976,7 @@ object MatrixRepository {
             val te = events[i]
             val txnId = txnIdOf(te)
             if (txnId != null && txnId in pendingTxnIds && te.content?.getOrNull() == null) continue
-            // Tombstone (Phase C, 2026-09-03): a redacted MESSAGE renders as a
+            // Tombstone: a redacted MESSAGE renders as a
             // quiet "Message unsent" row instead of silently vanishing (the
             // message type only — redacted reactions are timeline noise, not
             // rows). The room-list preview machinery ([effectiveLastEvent])
@@ -4047,8 +3986,7 @@ object MatrixRepository {
             // ("m.room.encrypted"), whatever it was — so a redacted message
             // only identifies via our own unsend marker ([unsentMessageIds]);
             // trusting the bare encrypted type would paint tombstones over the
-            // bridge's key-rotation redactions (LP3 feedback 2026-09-03: the
-            // unsent row vanished from the hannah room's thread).
+            // bridge's key-rotation redactions.
             val resolvedContent = te.content?.getOrNull()
             if (resolvedContent is RedactedEventContent &&
                 (
@@ -4073,7 +4011,7 @@ object MatrixRepository {
                 edited = edit != null,
                 ownName = ownName,
             )?.let { row ->
-                // Bridge caps (Phase C, 2026-09-03): stamp canEdit/canUnsend on
+                // Bridge caps: stamp canEdit/canUnsend on
                 // OWN rows only — the fetch fires on the first own row, so a
                 // received-only thread never pays the state GET.
                 if (!row.isMine) {
@@ -4094,13 +4032,12 @@ object MatrixRepository {
             }
         }
         // Optimistic rows for sends whose sync echo hasn't landed (voice notes
-        // + text share the resolve/replace dance, feedback 2026-08-13/14): a
+        // + text share the resolve/replace dance): a
         // just-sent message shows in every newest page (even a re-opened
         // thread) until its sync echo replaces it. Only a DECRYPTED echo
         // retires the row — the echo is re-read via the API (which triggers
         // decryption; a store decode can leave E2EE content unresolved), so a
-        // just-sent note never flickers into "[Encrypted]" (feedback
-        // 2026-08-17).
+        // just-sent note never flickers into "[Encrypted]".
         suspend fun insertPendingEchoes(
             pendings: List<PendingSend>,
             removeFrom: (String) -> Unit,
@@ -4109,7 +4046,7 @@ object MatrixRepository {
             for (pending in pendings) {
                 // The loop skips the echo only while its content is unresolved —
                 // the in-page render below must fire only then, or the real row
-                // is added twice (LazyColumn duplicate-key crash, 2026-08-17).
+                // is added twice (LazyColumn duplicate-key crash).
                 val echo = events.firstOrNull { txnIdOf(it) == pending.txnId }
                 val echoWasSkipped = echo != null && echo.content?.getOrNull() == null
                 val resolved = resolvePendingEcho(c, matrixRoomId, events, pending.txnId)
@@ -4130,7 +4067,7 @@ object MatrixRepository {
                     // lands at the newest end. (The old append put it at the
                     // OLDEST end: the just-sent message surfaced at the TOP of
                     // the thread and dead-ended pagination via the local-row
-                    // guard; feedback 2026-08-17.) Oldest-first iteration keeps
+                    // guard;.) Oldest-first iteration keeps
                     // rapid sends in chronological order.
                     result.add(0, rowFactory(pending))
                 }
@@ -4178,13 +4115,13 @@ object MatrixRepository {
         // timeline's topological chain order. Beeper bridges ingest messages
         // when they arrive but stamp them with the ORIGINAL send time, so the
         // chain can place a 1:43 PM message above a 1:41 PM one (the 1:41 was
-        // ingested late) — the visible "wrong order" in bridged rooms
-        // (2026-08-21, the anni room on the LP3). The sort is stable, so equal
+        // ingested late) — the visible "wrong order" in bridged rooms.
+        // The sort is stable, so equal
         // timestamps keep the chain order — a no-op for native (non-bridged)
         // rooms, whose homeserver stamps events at ingest. Only CONFIRMED rows
         // sort by timestamp: pending "local-…" rows carry device-clock times
         // that can lag the server clock, which would sort a just-sent message
-        // into the middle of the thread (2026-08-23); they are the newest
+        // into the middle of the thread; they are the newest
         // sends by definition, so they append last, in send order.
         val (pending, confirmed) = result.partition { it.id.startsWith(LOCAL_PENDING_ID_PREFIX) }
         // Sort the REVERSED (oldest-first) confirmed rows like the old code
@@ -4193,9 +4130,7 @@ object MatrixRepository {
         val oldestFirst = confirmed.reversed().sortedWith(compareBy { it.timestampMs }) + pending.reversed()
         // An encrypted room whose stored events all stayed undecryptable builds
         // zero rows — say WHY (the tool shows the decryption notice) instead of
-        // letting the empty page read as "No messages yet." (LP3 2026-08-29: a
-        // fresh login holds no megolm sessions and the account has no key
-        // backup, so history can't decrypt until keys arrive). Only the newest
+        // letting the empty page read as "No messages yet.". Only the newest
         // page carries the flag; a genuinely empty room (no events at all)
         // stays a plain empty page.
         val roomEncrypted = withTimeoutOrNull(ROOM_BUDGET_MS) {
@@ -4205,8 +4140,8 @@ object MatrixRepository {
         return MessagesPage(messages = oldestFirst, hasMore = hasMore, encrypted = undecryptable)
     }
 
-    /** Type of Beeper's per-room bridge-capability state event (Phase C,
-     *  2026-09-03): `edit`/`delete` support levels + `edit_max_age` /
+    /** Type of Beeper's per-room bridge-capability state event:
+     * `edit`/`delete` support levels + `edit_max_age` /
      *  `delete_max_age` windows the bridge enforces (e.g. WhatsApp: edit 15
      *  min, unsend 2 days). The page build reads it to offer/hide the tool's
      *  EDIT/UNSEND actions on own rows. */
@@ -4238,7 +4173,7 @@ object MatrixRepository {
     private val roomFeaturesCache = java.util.concurrent.ConcurrentHashMap<String, RoomFeatures>()
 
     /**
-     * The room's bridge caps (Phase C, 2026-09-03). The state event's
+     * The room's bridge caps. The state event's
      * state_key is the bridge-info key (NOT ""), so a targeted
      * getStateEventContent can't hit it — a full-state GET filtered by type,
      * deserializing to [UnknownEventContent] with the raw JSON. Any failure
@@ -4282,17 +4217,17 @@ object MatrixRepository {
 
     /** Type of Beeper's per-room archive marker (account data): rooms the user
      *  archived on Beeper — hidden from the main room list, silent, reachable
-     *  only via search VIEW ALL (chats, 2026-08-28). Beeper's REAL archive
+     *  only via search VIEW ALL (chats). Beeper's REAL archive
      *  state is `com.beeper.inbox.done`, whose content is reset to `{}` on
      *  unarchive (never deleted). The type is `com.beeper.inbox.done` — NOT
      *  `com.beeper.chats.inbox.done` (the round-4 guess; the LP3's real
-     *  `com.beeper.inbox.done` rows verified on-device 2026-08-29: Tiki's
+     *  `com.beeper.inbox.done` rows verified on-device: Tiki's
      *  archive + the `!updates` room, while the `.chats.` rows in the store
      *  were our own writes). `auto_archive` (`com.beeper.chats.auto_archive`)
      *  is NOT a write-only orphan: Beeper's desktop client actively reads it
      *  as room account data `{archive_at_ms, created_at_ms, archive_at_client,
      *  trigger}` and sets/clears the room's auto-archive from it (bundle
-     *  analysis 2026-08-30). The LP3's own auto_archive writes were ignored
+     *  analysis). The LP3's own auto_archive writes were ignored
      *  because of their shape, not the type — chats neither reads nor writes
      *  it. */
     private const val BEEPER_INBOX_DONE_EVENT_TYPE = "com.beeper.inbox.done"
@@ -4301,7 +4236,7 @@ object MatrixRepository {
      *  = archived, `{}` = unarchived — row presence is NOT the flag, the
      *  content is. The canonical Beeper shape carries only `at_order` +
      *  `updated_ts` (the desktop client reads exactly those two; bundle
-     *  analysis 2026-08-30 — Beeper never writes `at_ts`, the `at_ts` seen
+     *  analysis — Beeper never writes `at_ts`, the `at_ts` seen
      *  on-device was the LP3's own earlier writes). `atTs` stays as a
      *  lenient-deserialization field for those legacy rows. Registered in
      *  the event-content mappings (see [archiveMappingsModule]) so the
@@ -4348,8 +4283,7 @@ object MatrixRepository {
                 // message mappings, and an unregistered type is stripped by
                 // spec-compliant servers (Synapse). Beeper's own server
                 // ignores filters, which is why the LP3 receives statuses
-                // while the emulator never did (found 2026-09-06 verifying
-                // the "delivered" tag). The UnknownEventContent serializer
+                // while the emulator never did. The UnknownEventContent serializer
                 // keeps events parsing exactly as before, so
                 // [sendStatusByEventId]'s raw walk is untouched.
                 messageOf(BEEPER_SEND_STATUS_EVENT_TYPE, UnknownEventContentSerializer(BEEPER_SEND_STATUS_EVENT_TYPE))
@@ -4371,19 +4305,18 @@ object MatrixRepository {
 
     /** Room → (fetched-at elapsedRealtime, status map), TTL-cached so every
      *  page build (fast warm, pagination, refresh) reads one map instead of
-     *  re-walking the room's status window per call (2026-08-23). */
+     *  re-walking the room's status window per call. */
     private val sendStatusCache = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, Map<String, String>>>()
     /** Per-room reaction-tag maps behind the same TTL ([SEND_STATUS_CACHE_TTL_MS])
-     *  as [sendStatusCache] — every page path now carries reactions (LP3
-     *  2026-09-03), and each build would otherwise re-walk the raw chain.
+     *  as [sendStatusCache] — every page path now carries reactions, and each build would otherwise re-walk the raw chain.
      *  Invalidated in [sendReaction]/[unsendReaction] so a toggle never reads
      *  its own stale map. */
     private val reactionCache = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, Map<String, List<String>>>>()
 
     /** [sendStatusByEventId] with a per-room TTL cache — statuses must reach
      *  messages on ANY page (the FAIL marker disappearing once a message
-     *  scrolled past the newest page read as "sent but not delivered", LP3
-     *  2026-08-23), and the 250-event walk must not run per page build. */
+     *  scrolled past the newest page read as "sent but not delivered"),
+     *  and the 250-event walk must not run per page build. */
     private suspend fun sendStatusesByEventIdCached(
         c: MatrixClient,
         matrixRoomId: RoomId,
@@ -4413,7 +4346,7 @@ object MatrixRepository {
         // getLastTimelineEvents view: that view can miss events in a room
         // with a chain gap — the Annette room's FAIL statuses never reached
         // the rows or the session heal ("2 messages show sent but weren't
-        // delivered", LP3 2026-08-23; the page build abandoned that API for
+        // delivered", ; the page build abandoned that API for
         // the same reason — "a partial and fluctuating subset"). Statuses are
         // unencrypted, so the fast walk (no gap backfill / session restore)
         // is enough; the FAIL events sit just past the room's newest events.
@@ -4439,8 +4372,7 @@ object MatrixRepository {
             // predates the bridge's current identity — the other device's
             // sessions decrypt fine). Rotate the session ONCE per room per run
             // the moment the FAIL lands: waiting for the next send let the
-            // first breach in a room fail (LP3 feedback 2026-08-23, Annette +
-            // Anni rooms: every LP3 send undecryptable for the bridge).
+            // first breach in a room fail.
             raw["reason"]?.jsonPrimitive?.contentOrNull
                 ?.takeIf { status.startsWith("FAIL") && it.contains("undecryptable") }
                 ?.let { rotateOnBridgeUndecryptable(c, matrixRoomId, it) }
@@ -4467,10 +4399,9 @@ object MatrixRepository {
         // Walk the RAW chain (like [sendStatusByEventId] and the page build),
         // not the handler's getLastTimelineEvents view: that view can miss
         // events after a chain gap — the Sophie room's existing reaction
-        // never reached the served page's reactions map (LP3 2026-09-03; the
-        // page build abandoned that API for the same reason). Reactions are
+        // never reached the served page's reactions map. Reactions are
         // never encrypted, so the fast walk is enough. Null = the head read
-        // timed out (LP3 2026-09-04: syncs regularly take 17–30 s here) — the
+        // timed out — the
         // caller falls back to the last known map instead of serving/caching
         // an EMPTY one, which made every tag vanish for a TTL window.
         val start = withTimeoutOrNull(ROOM_BUDGET_MS) {
@@ -4483,10 +4414,7 @@ object MatrixRepository {
     /**
      * [reactionLabelsByEvent] behind the same per-room TTL as the send
      * statuses. Serves every page path — the fast cold-open page and
-     * scrolled-back older pages included, which both served no tags before
-     * (LP3 2026-09-03: the Sophie 9:12 likes were invisible on the fast page,
-     * and the fast 6-row page is what gets persisted, so a quiet room kept
-     * its tag-less page until a background rebuild landed).
+     * scrolled-back older pages included, which both served no tags before.
      */
     private suspend fun reactionLabelsByEventCached(
         c: MatrixClient,
@@ -4512,9 +4440,9 @@ object MatrixRepository {
      * newest window, or the sync delta). Each entry is a display string —
      * "Name reacted with ❤️" (own reactions read "You reacted with ❤️") —
      * deduped per SENDER (one reaction per person per message, Beeper
-     * semantics — LP3 feedback 2026-09-03: fire then heart showed both), the
+     * semantics — LP3: fire then heart showed both), the
      * person's newest reaction kept, ordered chronologically so the first tag
-     * is the FIRST person to react (the name a summary keeps; 2026-09-02).
+     * is the FIRST person to react (the name a summary keeps;).
      * The tag map comes from a bounded walk off the room head
      * ([reactionLabelsByEventCached], SEND_STATUS_WINDOW events), so messages
      * deeper than that window report none even on older pages.
@@ -4562,9 +4490,7 @@ object MatrixRepository {
      *  lines: two or fewer stay as-is; more collapse into one compact summary
      *  — the FIRST (earliest) reactor by name, everyone else folded into "and
      *  others", the distinct emoji listed once each, space-separated:
-     *  "Sophie and others reacted with ❤️ 😂" (feedback 2026-09-02: the list
-     *  read as one comma-separated item; a plain space keeps each emoji its
-     *  own glyph). One person stacking several emoji isn't a crowd, so it
+     *  "Sophie and others reacted with ❤️ 😂". One person stacking several emoji isn't a crowd, so it
      *  keeps the per-reaction lines. Tags never exceed two after this, so the
      *  tool renders the list unchanged. */
     private fun collapseReactionTags(tags: List<String>): List<String> {
@@ -4583,8 +4509,7 @@ object MatrixRepository {
      * Merges cached + delta reaction tags per reactor: the delta's tag for a
      * reactor replaces their cached one. [reactionTagsForEvents] dedupes per
      * sender within one event window, but the incremental patch only sees the
-     * delta — the replaced reaction's tag still sits in the cached page (LP3
-     * feedback 2026-09-03: fire→heart showed both until re-entry). The tag
+     * delta — the replaced reaction's tag still sits in the cached page. The tag
      * label's shape ("Who reacted with …") carries the reactor name; a
      * collapsed "X and others" cached line only matches on its exact prefix,
      * the same ceiling [ownReactionKeys] on the tool side lives with.
@@ -4612,15 +4537,14 @@ object MatrixRepository {
      */
     /** The room's bridge-bot user id ("" = non-bridged) — the bot whose m.read
      *  receipts are Beeper bridge bookkeeping, not human reads. Resolved lazily
-     *  on a room's first newest-page build and memoized per room: the old
-     *  per-pass resolver was the 280-400% CPU battery disaster (WORKLOG
-     *  2026-08-17). Beeper flags its bot via m.bridge ("bridgebot"); the
+     *  on a room's first newest-page build and memoized per room.
+     *  Beeper flags its bot via m.bridge ("bridgebot"); the
      *  fallbacks cover older bridges (uk.half-shot.bridge) and rooms without
      *  bridge state (functional_members "service_members" — which misses the
      *  Instagram DM, whose @instagramgobot posts receipts too). Callers must be
      *  inside a store transaction (Room-backed repo reads need one). */
     /**
-     * NOTE (2026-08-22): the m.bridge channel's `fi.mau.receiver` looks like
+     * NOTE: the m.bridge channel's `fi.mau.receiver` looks like
      * the contact's number but is the USER'S OWN WhatsApp number — it repeats
      * across every LID DM. A contact-phone source was explored here and
      * reverted; see the comment at contactIdentifierOf/contactIdentifier in
@@ -4754,9 +4678,7 @@ object MatrixRepository {
     private suspend fun isDeviceVerified(c: MatrixClient): Boolean {
         // A null read (timeout / trust store not warm) must NOT read as
         // "unverified": the encrypted-room fast path then fires intermittently
-        // on a verified device, emptying the thread mid-use (LP3 2026-08-17:
-        // verified at 11:30:35, "unverified" 25 s later — the Note-to-self
-        // page collapsed). A genuinely unverified device's read succeeds and
+        // on a verified device, emptying the thread mid-use. A genuinely unverified device's read succeeds and
         // returns a non-CrossSigned trust level.
         val trust = withTimeoutOrNull(KEY_BACKUP_VERIFY_TIMEOUT_MS) {
             c.key.getTrustLevel(c.userId, c.deviceId).firstOrNull()
@@ -4815,7 +4737,7 @@ object MatrixRepository {
         val encryptionService = c.di.get<RoomEventEncryptionService>(
             org.koin.core.qualifier.named<MegolmRoomEventEncryptionService>(),
         )
-        // Local-first pass (2026-09-07): a row whose megolm session is already
+        // Local-first pass: a row whose megolm session is already
         // in the olm store but whose stored content is a cached failure only
         // needs a re-decrypt — getTimelineEvent never retries (drive 5), and
         // the futile-restore cooldown was parking exactly these rooms (Fen and
@@ -4848,8 +4770,7 @@ object MatrixRepository {
                     loaded++
                     // Re-decrypt + re-persist: getTimelineEvent only reads the
                     // store's cached result, so a freshly loaded session never
-                    // reaches the stored rows through it (drive 5, 2026-09-06:
-                    // loaded 1/1, then 49/50 events still stuck).
+                    // reaches the stored rows through it.
                     resolvedLocal += reDecryptSessionEvents(
                         matrixRoomId, sessionId, stuckRowsForSession(c, matrixRoomId, sessionId)
                             .ifEmpty { sessionToEvents[sessionId].orEmpty() },
@@ -4874,7 +4795,7 @@ object MatrixRepository {
      *  stored content is still unresolved (null or failure). The re-decrypt
      *  passes used to cover only the collected page window, so the older rows
      *  of an already-loaded session stayed stuck after a fresh login (the
-     *  room's oldest messages, 2026-09-07). Plain LIKE scan — bounded by the
+     *  room's oldest messages). Plain LIKE scan — bounded by the
      *  room's row count, only runs while unresolved rows exist. */
     private suspend fun stuckRowsForSession(
         c: MatrixClient,
@@ -4956,8 +4877,7 @@ object MatrixRepository {
         val outgoing = runCatching { c.di.get<OutgoingRoomKeyRequestEventHandler>() }.getOrNull() ?: return
         // One request per missing session, logged with the event ids that
         // produced it — the handler logs the request itself; the event ids tie
-        // a request back to the stuck events (2026-09-01 verification lever:
-        // are the FILM/G5zV1tm re-import-region sessions reached now?).
+        // a request back to the stuck events.
         missing.groupBy({ it.first }, { it.second }).forEach { (sessionId, eventIds) ->
             android.util.Log.d(
                 TAG,
@@ -4970,8 +4890,8 @@ object MatrixRepository {
     /** An own send leaves its echo waiting on the server; without a wake,
      *  the outbox drain + echo are gated on the sync cycle — the long-poll
      *  can hold up to 30s, the slow rounds 5/30 min — so the just-sent
-     *  message sat on "SENDING" and the room panel kept the pre-send preview
-     *  (LP3 2026-08-17, user report: minutes). A queued syncOnce ABORTS an
+     *  message sat on "SENDING" and the room panel kept the pre-send preview.
+     * A queued syncOnce ABORTS an
      *  in-flight long-poll immediately (SyncApiClient selects it away), so
      *  run ONE in both modes: the round drains the outbox (the message
      *  reaches the server now) and the follow-up long-poll returns the echo
@@ -4981,7 +4901,7 @@ object MatrixRepository {
      *  Skipped when sync is paused by the user.
      */
     private fun wakeAfterSend(roomId: String) {
-        // No roomListDirty here (2026-09-03): a pre-echo dirty pass always ran
+        // No roomListDirty here: a pre-echo dirty pass always ran
         // on STALE data (the echo hadn't landed), and the echo's per-room sig
         // collectors in [observeNotifications] dirty the list themselves — so
         // this cost a second full pass per send on a big account. The resolver
@@ -4989,8 +4909,7 @@ object MatrixRepository {
         wakeRoomList()
         // The in-flight send's optimistic row is injected into SERVED pages —
         // bump the page revision so the thread's gating poll fetches and shows
-        // it now instead of waiting for the server echo (feedback 2026-08-15:
-        // "the voice note didn't appear").
+        // it now instead of waiting for the server echo.
         bumpMessagePageRevision(roomId)
         // Publish the sent room's pending bump NOW — [publishRoomList] alone
         // waits for the resolver's next full pass, which on a big bridged
@@ -5035,10 +4954,10 @@ object MatrixRepository {
         }
     }
 
-    // --- Megolm session self-heal (2026-08-23) -----------------------------
-    // The 2026-08-12 bridge-key bug window left some rooms with an outbound
+    // --- Megolm session self-heal -----------------------------
+    // The bridge-key bug window left some rooms with an outbound
     // megolm session created while the bridge device was absent from the
-    // key-share set; since per-send rotation was removed (2026-08-22) the
+    // key-share set; since per-send rotation was removed the
     // stale session is reused forever and the bridge reports an encryption
     // issue for every send. One-shot self-heal: when a FAIL send-status for
     // one of our own messages cites encryption/session problems, rotate the
@@ -5046,7 +4965,7 @@ object MatrixRepository {
 
     /**
      * Room → last-rotation elapsedRealtime for the outbound megolm session.
-     * Re-armed (2026-08-23): once-per-run gave a broken room exactly one
+     * Re-armed: once-per-run gave a broken room exactly one
      * rotation — the Hannah room redacted the new key after one message, so
      * the next FAIL burst had no second attempt. Now rotation is allowed again
      * after [MEGOLM_RE_ROTATE_MIN_MS], letting repeated FAIL bursts recover.
@@ -5057,8 +4976,8 @@ object MatrixRepository {
      *  instead of running before every send. */
     private val encryptionFailCheck = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, Boolean>>()
 
-    /** The FAIL reason that implicates the outbound session — observed on the
-     *  LP3 2026-08-23: `com.beeper.undecryptable_event` on every Anni send
+    /** The FAIL reason that implicates the outbound session:
+     * `com.beeper.undecryptable_event` on every Anni send
      *  (device DB). Only this exact marker rotates; other FAIL reasons
      *  (delivery failures etc.) must not churn the session. */
     private val MEGOLM_STALE_KEYWORDS = listOf("undecryptable")
@@ -5093,7 +5012,7 @@ object MatrixRepository {
     /**
      * Kicks off the stale-session self-heal WITHOUT blocking the send. The
      * first scan per room walks ~250 events with decrypt waits — run inline it
-     * froze the composer for seconds (LP3 feedback 2026-08-23). The scan only
+     * froze the composer for seconds. The scan only
      * acts on FAILs the bridge already posted, so an async heal costs at most
      * one more failed send in an already-broken room; the verdict is
      * TTL-cached after the first scan, and [rotateStaleMegolmIfNeeded] is
@@ -5178,17 +5097,16 @@ object MatrixRepository {
         try {
         val c = client ?: error("not logged in")
         val matrixRoomId = RoomId(roomId)
-        // One-shot self-heal for the 2026-08-12 bridge-key bug window (see the
+        // One-shot self-heal for the bridge-key bug window (see the
         // megolm section above) — before enqueueing, never per-send, and never
         // blocking: the first scan per room walks ~250 events and froze the
-        // composer for seconds (LP3 feedback 2026-08-23: "pressed send 3×,
-        // nothing, then it sent").
+        // composer for seconds.
         healStaleMegolmIfNeeded(c, matrixRoomId)
         // No per-send megolm rotation: a fresh session per message made a burst
         // of sends race — a retried/late event encrypted with an older session
         // arrived after the newer session's room key, and Beeper flagged it
-        // "sent using an outdated encryption session" (2026-08-22). The
-        // rotation was a stopgap for the 2026-08-12 bridge-key bug; that root
+        // "sent using an outdated encryption session". The
+        // rotation was a stopgap for the bridge-key bug; that root
         // cause (broken /keys/claim deserialization) is fixed, and Trixnity
         // re-shares the room key to new devices on every send with the existing
         // session, so the bridge keeps getting keys without per-message churn.
@@ -5207,15 +5125,13 @@ object MatrixRepository {
         // Keep the cached/disk newest page — re-opening the thread serves it
         // instantly with the optimistic row injected ([injectPendingEchoes]),
         // and the active-room refresher (or the next poll) recomputes the page
-        // once the sync echo lands (feedback 2026-08-15: re-open showed
-        // "Loading messages…" because the send had dropped the cache).
+        // once the sync echo lands.
         // Fetch the echo + refresh the panel even in slow-sync mode (screen off).
         wakeAfterSend(matrixRoomId.full)
-        // NO-SEAM (2026-09-07): the thread no longer polls — it reacts to page
+        // NO-SEAM: the thread no longer polls — it reacts to page
         // bumps. The send-time bump fires BEFORE the homeserver ack, so the row
         // sat "SENDING" until the sync echo's page rebuild landed — starved for
-        // ~95 s under the post-attach crawl (LP3 2026-09-07 probe: send at
-        // 13:12:09, echo served 13:13:44). Watch the outbox row and bump at the
+        // ~95 s under the post-attach crawl. Watch the outbox row and bump at the
         // ack: the serve-time [pendingEchoRow] then renders the real event id
         // (sent) from the SAME cached page — no rebuild needed.
         scope.launch {
@@ -5239,7 +5155,7 @@ object MatrixRepository {
         // pending override in the room list) renders the send instantly, and
         // the ack/sync echo confirm it in the background. Holding the RPC up
         // to SEND_ACK_WAIT_MS blocked the composer for seconds on a loaded DB
-        // (LP3 2026-09-05: "compose hangs then it sends") — Beeper's outbox
+        // — Beeper's outbox
         // model renders the echo immediately, network ack invisibly later.
         // Event id is null here; the sync echo replaces the optimistic row
         // (matched by txn id) ~1-3 s later.
@@ -5250,8 +5166,7 @@ object MatrixRepository {
         } catch (e: Exception) {
             // A send that dies before enqueueing used to be invisible: the RPC
             // failure maps to null on the tool side and the resend looked like
-            // a no-op (LP3 2026-08-23 — "tap to resend" pressed, nothing sent,
-            // zero events/outbox rows/log lines). Log the full stack so the
+            // a no-op. Log the full stack so the
             // next resend attempt is diagnosable.
             android.util.Log.e(TAG, "SendMessage FAILED room=$roomId body=$body", e)
             throw e
@@ -5300,8 +5215,8 @@ object MatrixRepository {
     }
 
     /**
-     * Sends a reaction: an m.reaction annotation on [eventId] (Phase A,
-     * 2026-09-03). Reactions are NOT in [RoomService]'s MessageBuilder DSL —
+     * Sends a reaction: an m.reaction annotation on [eventId].
+     * Reactions are NOT in [RoomService]'s MessageBuilder DSL —
      * the raw API call is the path (same shapes verified against Trixnity
      * 5.8.0). Throws on failure; the dispatch maps it to a tool-side error.
      */
@@ -5333,7 +5248,7 @@ object MatrixRepository {
         // not the handler's getLastTimelineEvents view: that view can serve a
         // partial subset — a reaction sent from another device (Beeper) wasn't
         // in it, so the unsend found nothing, the RPC failed and the like
-        // "didn't go" (LP3 feedback 2026-09-03). Reactions are plaintext, so
+        // "didn't go". Reactions are plaintext, so
         // the fast walk is enough.
         val start = withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getById(matrixRoomId).firstOrNull()?.lastEventId?.full
@@ -5344,8 +5259,7 @@ object MatrixRepository {
         // Reaction keys are compared VS16-normalized: bridges map native
         // reactions back with inconsistent variation selectors (a WhatsApp ❤
         // may round-trip as U+2764 while we sent U+2764+FE0F), and an exact
-        // match then finds nothing to unsend (LP3 feedback 2026-09-03:
-        // "remove reaction seems to work sometimes").
+        // match then finds nothing to unsend.
         fun normalizeKey(k: String) = k.replace("\uFE0F", "")
         val wantKey = normalizeKey(key)
         val ownIds = window.mapNotNull { te ->
@@ -5370,17 +5284,17 @@ object MatrixRepository {
     }
 
     /**
-     * Edits an own text message (Phase C, 2026-09-03): an m.replace edit —
+     * Edits an own text message: an m.replace edit —
      * sent through the SAME encrypted outbox DSL as [sendMessage], via the
      * canonical [replace] + [text] builders. The raw plaintext API this used
      * before is rejected by Beeper's homeserver in bridged rooms ("cloud
-     * bridges aren't allowed to send unencrypted messages", LP3 2026-09-04).
+     * bridges aren't allowed to send unencrypted messages").
      * [text] routes through [roomMessageBuilder], the ONLY DSL path that
      * actually attaches the relation: a bare `content(Text(...))` +
-     * `relatesTo = ...` silently DROPS the relation (the `content` lambda
+     * `relatesTo =...` silently DROPS the relation (the `content` lambda
      * ignores the builder's ContentBuilderInfo), producing a relation-less
      * "* <text>" message — the bridge then posts it to Instagram as a NEW
-     * message and the original never edits (LP3 2026-09-04, FEN★RGY room).
+     * message and the original never edits.
      * [text] composes the spec's "* " fallback body plus
      * RelatesTo.Replace(eventId, m.new_content) itself; the Megolm encryptor
      * then hoists rel_type/event_id outside the ciphertext so the bridge can
@@ -5397,15 +5311,15 @@ object MatrixRepository {
         }
         // No ack hold (matching sendMessage): the edit is already enqueued —
         // the 500 ms wait timed out unconfirmed under crawl load and the throw
-        // showed the user "failed" for an edit that landed seconds later
-        // (LP3 2026-09-05). Failures surface as the edit never appearing (the
+        // showed the user "failed" for an edit that landed seconds later.
+        // Failures surface as the edit never appearing (the
         // outbox keeps retrying); the echo applies it on the next poll.
         wakeAfterSend(matrixRoomId.full)
         refreshMessagePage(roomId)
     }
 
     /**
-     * Unsends an own message for everyone (Phase C, 2026-09-03): a plain
+     * Unsends an own message for everyone: a plain
      * Matrix redaction — the identical call [unsendReaction] uses, pointed at
      * the message event instead of a reaction. The delta page patch bails to
      * the full rebuild on redactions, so the tombstone lands on the next
@@ -5422,7 +5336,7 @@ object MatrixRepository {
         refreshMessagePage(roomId)
     }
 
-    // --- Photos (Phase 13) --------------------------------------------------
+    // --- Photos --------------------------------------------------
 
     /**
      * Records the room a photo attach should land in and returns the
@@ -5458,9 +5372,9 @@ object MatrixRepository {
     ): Boolean {
         val c = client ?: return false
         val matrixRoomId = RoomId(roomId)
-        // One-shot self-heal for the 2026-08-12 bridge-key bug window (see the
+        // One-shot self-heal for the bridge-key bug window (see the
         // megolm section above) — before enqueueing, never blocking (first
-        // scan per room is a ~250-event walk; async, LP3 feedback 2026-08-23).
+        // scan per room is a ~250-event walk; async, LP3 ).
         healStaleMegolmIfNeeded(c, matrixRoomId)
         val txnId = runCatching {
             c.room.sendMessage(matrixRoomId) {
@@ -5477,7 +5391,7 @@ object MatrixRepository {
         }.getOrNull() ?: return false
         android.util.Log.d(TAG, "SendPhoto: room=$roomId txn=$txnId bytes=${payload.jpeg.size}")
         // Optimistic row: show the photo (file name + SENDING) immediately,
-        // before the sync echo lands (feedback 2026-08-30). Same pattern as
+        // before the sync echo lands. Same pattern as
         // [sendMessage]; the echo (matched by txn id) replaces it.
         val roomPending = pendingImageEcho.computeIfAbsent(matrixRoomId.full) { java.util.concurrent.ConcurrentHashMap() }
         roomPending[txnId] = PendingImageSend(txnId, System.currentTimeMillis(), payload.fileName)
@@ -5486,7 +5400,7 @@ object MatrixRepository {
         return true
     }
 
-    // --- Media HTTP self-heal (2026-09-02) ----------------------------------
+    // --- Media HTTP self-heal ----------------------------------
     // LP3: the newest voice notes in a room stopped playing — every tap timed
     // out at MEDIA_BUDGET_MS while /sync (a long-lived request on the SAME
     // shared engine) kept delivering and host/device curl fetched the same
@@ -5598,7 +5512,7 @@ object MatrixRepository {
                     // enterActiveSync's guard trusts ChatSyncService.isRunning
                     // and would bail, leaving no long-poll and no push wakes
                     // (onPushDelivered skips in ACTIVE mode) → a stuck
-                    // "Can't reach server" banner (LP3 2026-09-04). Re-kick
+                    // "Can't reach server" banner. Re-kick
                     // the service: onStartCommand sees syncedClient !==
                     // restored and re-arms loop + watchdog on the new client.
                     runCatching {
@@ -5612,7 +5526,7 @@ object MatrixRepository {
         }
     }
 
-    // --- Voice notes (Phase 14) ---------------------------------------------
+    // --- Voice notes ---------------------------------------------
 
     /**
      * Toggles playback of an m.audio message: stops any current playback and
@@ -5625,7 +5539,7 @@ object MatrixRepository {
     suspend fun playVoiceNote(roomId: String, eventId: String): Pair<Boolean, String?> {
         var c = client ?: return false to "not logged in"
         // Tap the playing row again → PAUSE (keeps the position; the next tap
-        // on the same row resumes from there — feedback 2026-08-27).
+        // on the same row resumes from there).
         if (playingAudioEventId == eventId) {
             runCatching { audioPlayer?.pause() }
             playingAudioEventId = null
@@ -5645,8 +5559,7 @@ object MatrixRepository {
         stopAudioPlayback()
         // A still-pending send: the echoed event isn't in the store yet, but
         // the server kept a copy of the recorded file when the note was sent
-        // ([sendVoiceNote]) — play that instead of resolving by event id
-        // (2026-08-23: "can't play a voice note while it's sending").
+        // ([sendVoiceNote]) — play that instead of resolving by event id.
         if (eventId.startsWith(LOCAL_PENDING_ID_PREFIX)) {
             val txnId = eventId.removePrefix(LOCAL_PENDING_ID_PREFIX)
             val local = pendingAudioEcho[roomId]?.get(txnId)?.localFile
@@ -5667,8 +5580,7 @@ object MatrixRepository {
             // Missing copy → fall through to the store path's error handling.
         }
         // A previously-downloaded note plays from the cache — no network, no
-        // "failed to download" on a note that played before (feedback
-        // 2026-08-27: notes playable in the morning failed at night).
+        // "failed to download" on a note that played before.
         val ctx = appContext ?: return false to "no context"
         voiceCacheFile(eventId)?.let { cached ->
             if (cached.exists()) {
@@ -5684,7 +5596,7 @@ object MatrixRepository {
             }
         }
         // A media-stack self-heal is in flight (consecutive download timeouts
-        // while the network is up — 2026-09-02): wait for it so THIS tap uses
+        // while the network is up —): wait for it so THIS tap uses
         // the fresh engine instead of timing out again.
         if (mediaStackSick) {
             val deadline = android.os.SystemClock.elapsedRealtime() + MEDIA_HEAL_WAIT_MS
@@ -5706,14 +5618,13 @@ object MatrixRepository {
                 // An older note's megolm session is often not in the local
                 // store (sessions load lazily per room, mostly via getMessages)
                 // — the content stays encrypted and the note silently "doesn't
-                // play" (feedback 2026-08-14). Pull the session from the key
+                // play". Pull the session from the key
                 // backup, then re-read so decryption can land. Retried on every
                 // iteration (unless parked): a session the backup index hadn't
-                // caught up with on the first try may be there a moment later
-                // (feedback 2026-08-19 — playback "does not always work").
+                // caught up with on the first try may be there a moment later.
                 // EXPLICIT play bypasses the futile-restore park: a
                 // freshly-arrived note whose session isn't cached yet would
-                // otherwise be unrecoverable for 4h (2026-08-23). Parking
+                // otherwise be unrecoverable for 4h. Parking
                 // still fires on failure, so repeated taps on a genuinely
                 // undecryptable note keep backing off (other paths honor it).
                 if (event?.content?.isFailure == true) {
@@ -5729,12 +5640,12 @@ object MatrixRepository {
         if (content == null && te?.content?.isFailure == true) {
             // An UNDECRYPTABLE note is not a non-audio row — the session
             // restore above ran; say what actually happened so a re-tap after
-            // the session lands can play it (2026-08-23).
+            // the session lands can play it.
             android.util.Log.d(TAG, "playVoiceNote: undecryptable, restoring sessions (id=$eventId)")
             return false to "Couldn't play — couldn't decrypt audio"
         }
         if (content !is RoomMessageEventContent.FileBased.Audio) {
-            // Diagnosis hook for the LP3 (feedback 2026-08-21): which content
+            // Diagnosis hook for the LP3: which content
             // type is actually on the timeline when the row reads as a voice
             // note — a bridge sending a different type would land here.
             android.util.Log.w(
@@ -5748,7 +5659,7 @@ object MatrixRepository {
         if (file == null && url == null) return false to "no audio file"
         val mediaService = c.di.get<MediaService>(MediaService::class)
         // One retry: a single flaky fetch failing once shouldn't fail playback
-        // outright — the first attempt can hit a slow window (2026-08-23).
+        // outright — the first attempt can hit a slow window.
         // Each attempt is logged separately so a silent tap maps to one cause.
         var download: Result<de.connect2x.trixnity.client.media.PlatformMedia>? = null
         for (attempt in 1..2) {
@@ -5768,15 +5679,14 @@ object MatrixRepository {
                     "playVoiceNote: download timed out for $eventId after ${MEDIA_BUDGET_MS}ms " +
                         "(attempt $attempt/2, encrypted=${file != null}, url=${url ?: "null"})",
                 )
-                // A timeout is the wedge signature (2026-09-02): count it and
+                // A timeout is the wedge signature: count it and
                 // self-heal once consecutive stalls + a healthy network say the
                 // shared HTTP engine is stuck (see [noteMediaFetchTimeout]).
                 noteMediaFetchTimeout()
                 continue
             }
             if (result.isFailure) {
-                // Diagnosis hook for the LP3 (feedback 2026-08-22 "download
-                // failed"): this stage was silent — the common failure (the
+                // Diagnosis hook for the LP3: this stage was silent — the common failure (the
                 // media fetch) must log what actually went wrong (network
                 // error, missing sha256 on the EncryptedFile →
                 // MediaValidationException, …).
@@ -5798,10 +5708,9 @@ object MatrixRepository {
             ?: return false to "audio download failed"
         // The temp file must carry the ACTUAL format: MediaPlayer's file-source
         // path uses the extension as an extractor hint, and Beeper/WhatsApp
-        // audio files (ogg/opus, mp3, aac…) mislabeled ".m4a" fail to prepare
-        // (2026-08-13: an audio-file voice note played everywhere but the LP3).
+        // audio files (ogg/opus, mp3, aac…) mislabeled ".m4a" fail to prepare.
         // Incoming notes often lack a usable mimetype (our own sends always set
-        // "audio/ogg; codecs=opus", so only THEY played — feedback 2026-08-20),
+        // "audio/ogg; codecs=opus", so only THEY played — ),
         // so sniff the container from the magic bytes and fall back to the
         // mimetype label.
         val mime = content.info?.mimeType?.lowercase().orEmpty()
@@ -5809,10 +5718,8 @@ object MatrixRepository {
         // WhatsApp/bridge quirk: the identification page is written with
         // header-type 0x02 (continuation) instead of 0x01 (BOS) — WhatsApp's
         // own decoder ignores the flag, but Android's OggExtractor requires
-        // BOS to identify the codec, so prepare() fails on the LP3's stricter
-        // media stack (verified 2026-08-21: the emulator's lenient extractor
-        // plays the raw file, the LP3 rejects it; the BOS-repaired file plays
-        // on both). Repair before writing so MediaPlayer never sees the
+        // BOS to identify the codec, so prepare fails on the LP3's stricter
+        // media stack. Repair before writing so MediaPlayer never sees the
         // broken stream.
         val repaired = repairOgg(bytes)
         if (repaired !== bytes) {
@@ -5823,8 +5730,7 @@ object MatrixRepository {
         }
         val playBytes = repaired
         // Cache the downloaded note on disk so re-plays are instant and survive
-        // a bad network (feedback 2026-08-27: auto-download + "played this
-        // morning, failed to download now").
+        // a bad network.
         voiceCacheDir()?.let { dir ->
             val cacheFile = java.io.File(dir, "voice_$eventId.$ext")
             runCatching { cacheFile.writeBytes(playBytes) }
@@ -5854,9 +5760,8 @@ object MatrixRepository {
      * notes: media/speech classification (the hardware volume rocker controls
      * it), transient audio focus, and the FILE-DESCRIPTOR data source — the
      * media server is a different uid and can't traverse the app's private
-     * cache dir, so a path source hits "Permission denied" on the LP3
-     * (verified 2026-08-22; the recording preview plays fine because it hands
-     * over an fd). The file is deleted on stop/failure (see
+     * cache dir, so a path source hits "Permission denied" on the LP3.
+     * The file is deleted on stop/failure (see
      * [stopAudioPlayback]). @return (playing, error).
      */
     private fun playLocalAudioFile(
@@ -5875,8 +5780,7 @@ object MatrixRepository {
         // Explicit media/speech classification + transient focus: playback
         // follows the media volume (the hardware rocker controls it) and stops
         // on focus loss — the default attributes let some builds route voice
-        // notes to a stream the volume buttons don't touch (feedback
-        // 2026-08-14: "can't hear voice notes", "volume toggle does nothing").
+        // notes to a stream the volume buttons don't touch.
         val mediaAttributes = android.media.AudioAttributes.Builder()
             .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
             .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SPEECH)
@@ -5885,9 +5789,9 @@ object MatrixRepository {
         player.setOnCompletionListener {
             // Natural end: release the player but KEEP the audio focus, so the
             // app we transiently paused (a podcast, music) stays paused — a
-            // finishing note must not resume it (feedback 2026-08-27). Then
+            // finishing note must not resume it. Then
             // auto-play the next voice note in the room when there is one
-            // immediately after (same feedback round).
+            // immediately after.
             val finishedId = playingAudioEventId
             val finishedRoom = playingAudioRoomId
             releaseFinishedPlayback()
@@ -5914,8 +5818,8 @@ object MatrixRepository {
         runCatching {
             // Pass the FILE DESCRIPTOR, not the path: the media server is a
             // different uid and can't traverse the app's private cache dir —
-            // a path source hits "Permission denied" on the LP3 (verified
-            // 2026-08-22: FileSource 'Failed to open file … (Permission
+            // a path source hits "Permission denied" on the LP3 (verified:
+            // FileSource 'Failed to open file … (Permission
             // denied)' — the app-private /data/user/0/<pkg> dir is
             // drwx------, so setReadable on the file never helped; the
             // recording preview plays fine because it hands over an fd).
@@ -5927,7 +5831,7 @@ object MatrixRepository {
             player.prepare()
             player.start()
         }.onFailure { e ->
-            // Diagnosis hook for the LP3 (feedback 2026-08-21): the failing
+            // Diagnosis hook for the LP3: the failing
             // stage is MediaPlayer prepare/start — log what was actually
             // handed to it (container, mime label, size, first bytes) so the
             // next device test identifies the container MediaPlayer rejects.
@@ -5941,7 +5845,7 @@ object MatrixRepository {
         playingAudioRoomId = roomId
         playingAudioEventId = eventId
         // Record the measured length — the idle row shows it for bridged notes
-        // whose m.audio event lacks info.duration (Signal — feedback 2026-08-27).
+        // whose m.audio event lacks info.duration (Signal).
         player.duration.takeIf { it > 0 }?.let { voiceDurationMsByEvent[eventId] = it.toLong() }
         android.util.Log.d(TAG, "playVoiceNote: $successDetail")
         return true to null
@@ -5950,7 +5854,7 @@ object MatrixRepository {
     /**
      * Natural-completion cleanup: release the player + file + state, but KEEP
      * the audio focus held — the transient-focus pause must not bounce the
-     * other app (podcast/music) back on when a note ends (feedback 2026-08-27).
+     * other app (podcast/music) back on when a note ends.
      * The focus is released by the next [stopAudioPlayback] (a new note, an
      * explicit stop, or another app taking focus — the focus-loss listener
      * calls [stopAudioPlayback]).
@@ -5971,8 +5875,7 @@ object MatrixRepository {
      * bytes first (bridged audio is often mislabeled or carries no mimetype),
      * the mimetype label as the fallback. MediaPlayer's file-source path uses
      * the extension as its extractor hint, so the right one matters — a real
-     * ogg named ".m4a" fails prepare (2026-08-13; feedback 2026-08-20: only
-     * the LP3's own notes played, because only they carried the ogg mimetype).
+     * ogg named ".m4a" fails prepare.
      */
     private fun sniffAudioExtension(bytes: ByteArray, mime: String): String {
         fun has(s: String, at: Int) = bytes.size >= at + s.length &&
@@ -5982,13 +5885,12 @@ object MatrixRepository {
             has("fLaC", 0) -> "flac"
             has("ID3", 0) -> "mp3"
             // Matroska/WebM (EBML 1A 45 DF A3) — some bridges serve voice
-            // notes as webm/opus (2026-08-21: previously fell to the ".m4a"
-            // default and failed prepare).
+            // notes as webm/opus.
             bytes.size >= 4 && bytes[0].toInt() == 0x1A && bytes[1].toInt() == 0x45 &&
                 bytes[2].toInt() == 0xDF && bytes[3].toInt() == 0xA3 -> "webm"
             // ADTS AAC (sync 0xFFF, layer bits 00) — must be checked BEFORE
             // the MPEG sync test below, which would mislabel it ".mp3" and
-            // fail prepare (2026-08-21).
+            // fail prepare.
             bytes.size >= 2 && (bytes[0].toInt() and 0xFF) == 0xFF &&
                 (bytes[1].toInt() and 0xF6) == 0xF0 -> "aac"
             // MPEG audio frame sync (0xFFE/0xFFF): byte 1's top three bits
@@ -6009,7 +5911,7 @@ object MatrixRepository {
             // Unknown container AND unknown mime: leave the extension off —
             // MediaExtractor then sniffs the actual content instead of being
             // misled by a guessed hint (the old ".m4a" default was exactly
-            // the mislabel that broke playback on the LP3, 2026-08-13/21).
+            // the mislabel that broke playback on the ).
             else -> ""
         }
     }
@@ -6027,9 +5929,7 @@ object MatrixRepository {
      * to fix (or the data isn't Ogg).
      *
      * header_type bits (RFC 3533): 0x01 = continuation, 0x02 = BOS,
-     * 0x04 = EOS. (2026-08-22: an earlier version had these INVERTED — it
-     * "repaired" valid files (BOS=0x02) into continuation pages (0x01), which
-     * is exactly why the user's own notes stopped playing on the LP3.)
+     * 0x04 = EOS.
      */
     private fun repairOgg(bytes: ByteArray): ByteArray {
         if (bytes.size < 27 || bytes[0] != 'O'.code.toByte() || bytes[1] != 'g'.code.toByte() ||
@@ -6080,7 +5980,7 @@ object MatrixRepository {
         }
     }
 
-    // --- Voice-note download cache + auto-advance (feedback 2026-08-27) -----
+    // --- Voice-note download cache + auto-advance -----
     // Notes are kept on disk after their first download so re-plays are
     // instant and survive a bad network ("played this morning, failed to
     // download now"); the newest notes of an opened thread prefetch while its
@@ -6169,7 +6069,7 @@ object MatrixRepository {
     private val voicePrefetchInFlight = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
     /** Measured lengths (ms) of voice notes whose m.audio event carries no
-     *  info.duration (bridged notes — Signal sends none; feedback 2026-08-27).
+     *  info.duration (bridged notes — Signal sends none; ).
      *  Filled by the prefetch/play paths; [messageFrom] falls back to it so the
      *  idle row shows the length instead of the "Voice note" body text. */
     private val voiceDurationMsByEvent = java.util.concurrent.ConcurrentHashMap<String, Long>()
@@ -6177,9 +6077,8 @@ object MatrixRepository {
     /**
      * Starts background downloads of the newest uncached audio notes in
      * [events] (newest-first), so tapping play on a fresh note usually hits
-     * the cache (feedback 2026-08-27: auto-download; play "looked like it was
-     * playing" then silently failed on the fetch). Called from the page
-     * builds; the exists()/in-flight guards make repeated calls no-ops.
+     * the cache. Called from the page
+     * builds; the exists/in-flight guards make repeated calls no-ops.
      */
     private fun prefetchVoiceNotes(c: MatrixClient, matrixRoomId: RoomId, events: List<TimelineEvent>) {
         val ctx = appContext ?: return
@@ -6196,7 +6095,7 @@ object MatrixRepository {
                     val file = cached?.takeIf { it.exists() }
                         ?: downloadVoiceNoteToCache(c, matrixRoomId, eventId, content)
                     // Length probe for bridged notes without info.duration
-                    // (Signal — feedback 2026-08-27): one prepare per note per
+                    // (Signal — ): one prepare per note per
                     // process; the map hit skips it on later page builds.
                     if (file != null && !voiceDurationMsByEvent.containsKey(eventId)) {
                         probeVoiceDurationMs(file)?.let { voiceDurationMsByEvent[eventId] = it }
@@ -6230,8 +6129,7 @@ object MatrixRepository {
 
     /**
      * Auto-advance: after a note ends, play the NEXT audio note in the room
-     * when one follows immediately (feedback 2026-08-27: "play one, the next
-     * should play if there's a voice note immediately after"). "Immediately"
+     * when one follows immediately. "Immediately"
      * = the first audio event newer than the finished one, within
      * [VOICE_AUTO_ADVANCE_WINDOW_MS] of it — a note hours later stays
      * unplayed.
@@ -6243,8 +6141,7 @@ object MatrixRepository {
         // chain walk the message pages use. The previous getLastTimelineEvents
         // read serves the handler's partial in-memory view (see the
         // computeMessagesPage note), which silently dropped the following note
-        // — no auto-play for two notes sent one after the other (feedback
-        // 2026-08-27).
+        // — no auto-play for two notes sent one after the other.
         val lastEventId = withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getById(matrixRoomId).firstOrNull()?.lastEventId?.full
         } ?: return
@@ -6286,21 +6183,19 @@ object MatrixRepository {
      * [RoomMessageEventContent.Unknown] (whose raw JSON is sent verbatim) so
      * it can carry the `org.matrix.msc3245.voice` marker: the WhatsApp bridge
      * renders an m.audio as a WhatsApp *voice note* only when that key is
-     * present, otherwise WhatsApp shows a plain audio file (feedback
-     * 2026-08-14). Trixnity's typed audio DSL has no extension slot, so the
+     * present, otherwise WhatsApp shows a plain audio file. Trixnity's typed audio DSL has no extension slot, so the
      * upload is done here (same encrypted/plain split the DSL performs).
      * `audio/ogg; codecs=opus` is the MSC3245 canonical voice-message
      * mimetype — every Matrix client and the mautrix bridges treat it as a
-     * voice message, and it is ~2-3× smaller than the old AAC/m4a notes
-     * (2026-08-15 switch).
+     * voice message, and it is ~2-3× smaller than the old AAC/m4a notes.
      * @return true when the send was enqueued.
      */
     suspend fun sendVoiceNote(roomId: String, file: java.io.File): Boolean {
         val c = client ?: return false
         val matrixRoomId = RoomId(roomId)
-        // One-shot self-heal for the 2026-08-12 bridge-key bug window (see the
+        // One-shot self-heal for the bridge-key bug window (see the
         // megolm section above) — before enqueueing, never blocking (first
-        // scan per room is a ~250-event walk; async, LP3 feedback 2026-08-23).
+        // scan per room is a ~250-event walk; async, LP3 ).
         healStaleMegolmIfNeeded(c, matrixRoomId)
         val bytes = file.readBytes()
         val durationMs = runCatching {
@@ -6322,13 +6217,13 @@ object MatrixRepository {
             val encryptedFile = mediaService.prepareUploadEncryptedMedia(flowOf(bytes))
             // prepareUploadEncryptedMedia returns an EncryptedFile whose url is
             // the LOCAL "upload://" cache key — the real mxc:// URL exists only
-            // after uploadMedia() uploads the bytes. Trixnity's typed outbox
-            // uploader does that upload + URI rewrite for the image()/audio()
+            // after uploadMedia uploads the bytes. Trixnity's typed outbox
+            // uploader does that upload + URI rewrite for the image/audio
             // DSL content, but this event is hand-built (the msc3245 voice
             // marker has no DSL slot), so the upload must happen here or the
             // note ships with an unreachable upload:// url and the media never
             // reaches the server — other clients see the note but can't play
-            // it (feedback 2026-08-17: Beeper "!" on the play button).
+            // it.
             val mxcUrl = mediaService.uploadMedia(encryptedFile.url).getOrNull()
                 ?: return false
             val sentFile = encryptedFile.copy(url = mxcUrl)
@@ -6373,7 +6268,7 @@ object MatrixRepository {
             c.room.sendMessage(matrixRoomId) {
                 // Empty body: other clients render the body as the caption,
                 // and Beeper/WhatsApp showed "Voice note" as a text message
-                // (feedback 2026-08-13) — voice notes carry no caption.
+                // — voice notes carry no caption.
                 content(content)
             }
         }.getOrNull() ?: return false
@@ -6383,12 +6278,11 @@ object MatrixRepository {
         // until the sync echo lands (the refresher then replaces it with the
         // real event). The send previously dropped the cache, so a re-open
         // recomputed from scratch (slow — "Loading messages…") and could show
-        // the note as missing (feedback 2026-08-15).
+        // the note as missing.
         val roomPending = pendingAudioEcho.computeIfAbsent(matrixRoomId.full) { java.util.concurrent.ConcurrentHashMap() }
         // Keep a copy of the recorded file for the pending row: the activity
         // deletes the original as soon as this RPC returns, and the row must
-        // stay playable until the sync echo replaces it (2026-08-23 — "can't
-        // play a voice note while it's sending"). Best-effort: a failed copy
+        // stay playable until the sync echo replaces it. Best-effort: a failed copy
         // just leaves the pending row unplayable, the send is unaffected.
         val localFile = runCatching {
             java.io.File(appContext?.cacheDir ?: return@runCatching null, "voice_pending_$txnId.ogg")
@@ -6401,7 +6295,7 @@ object MatrixRepository {
         // send's row is served from the pending map, whose id fell back to
         // "local-…" (→ SENDING) once Trixnity removed the outbox row at echo
         // processing — and the active room's page isn't recomputed on the echo,
-        // so the row stuck until a re-entry (2026-09-02). Cache the acked id on
+        // so the row stuck until a re-entry. Cache the acked id on
         // the pending + bump the page: the next poll serves the row with its
         // real id (~1-2 s after send) instead of SENDING. Holds the RPC up to
         // [SEND_ACK_WAIT_MS] like [sendMessage] does (the recording activity
@@ -6432,7 +6326,7 @@ object MatrixRepository {
         val c = client ?: return null
         // A still-in-flight send ("local-…" pending row) has no real event yet
         // — nothing to fetch; the row keeps its file-name fallback until the
-        // sync echo lands (2026-08-30, same guard as [playVoiceNote]).
+        // sync echo lands.
         if (eventId.startsWith(LOCAL_PENDING_ID_PREFIX)) return null
         val cacheKey = "$roomId/$eventId"
         // The cache is local — serve it regardless of the connection state.
@@ -6456,7 +6350,7 @@ object MatrixRepository {
         }
         val content = when (val raw = te?.content?.getOrNull()) {
             // Beeper's RCS bridge sends direct photos as m.file with an image/*
-            // mimetype instead of m.image (feedback 2026-09-01) — accept both,
+            // mimetype instead of m.image — accept both,
             // or RCS image attachments stay on their text fallback forever.
             is RoomMessageEventContent.FileBased.Image -> raw
             is RoomMessageEventContent.FileBased.File ->
@@ -6505,7 +6399,7 @@ object MatrixRepository {
 
     /**
      * Saves an image message's original bytes to the device's Pictures/Chats
-     * album (photo viewer save button, 2026-09-03). The original is re-fetched
+     * album (photo viewer save button). The original is re-fetched
      * (Trixnity's media cache hits after a view) rather than saving the
      * viewer's downscaled display JPEG. App-contributed media needs no storage
      * permission on API 29+.
@@ -6619,7 +6513,7 @@ object MatrixRepository {
         // that arrived between the page fetch and this call (or while the
         // thread sat open before the poll rendered it): the receiver never saw
         // it, yet their receipt covered it and the sender's "seen" tag landed
-        // on it (2026-09-03: "sent 3, they read 2, seen on the 3rd"). A
+        // on it. A
         // behind-the-head marker leaves the room honestly unread — the
         // thread's quiet poll re-marks at the real newest once the page (and
         // the user's screen) catch up. Only a marker that IS the room's head
@@ -6628,10 +6522,7 @@ object MatrixRepository {
             c.room.getById(matrixRoomId).firstOrNull()
         }
         // Cold-start race: getById can return the room before Trixnity has
-        // loaded its timeline view — lastRelevantEventId null (LP3 drive 4,
-        // 2026-09-06: Rewrites marked read head=null 2 ms after open; the
-        // quiet poll's rendered id never changes, so the receipt stayed
-        // behind the head forever and the badge never cleared). Give the
+        // loaded its timeline view — lastRelevantEventId null. Give the
         // head a short bounded window to resolve before deciding.
         var headResolveWaits = 0
         while (room?.lastRelevantEventId == null &&
@@ -6647,7 +6538,7 @@ object MatrixRepository {
         var atHead = eventId == headId?.full
         var markerId = eventId
         // Head that never resolves at all: this room's Trixnity timeline view
-        // doesn't load (Rewrites, LP3 2026-09-06 — null even 18 s into a fresh
+        // doesn't load (Rewrites, — null even 18 s into a fresh
         // process, across restarts, while every other room resolves instantly).
         // The receipt still goes out at the rendered row; without the clear the
         // badge could never clear by design. Clear optimistically — the
@@ -6665,8 +6556,7 @@ object MatrixRepository {
         // head forever: the tool marks read at the newest rendered row and
         // the quiet poll never advances (the rendered id never changes),
         // while both our atHead check and Trixnity's notification clear need
-        // an exact head match (LP3 2026-09-06: "1 euro film - Rewrites"
-        // unread never cleared). Snap the receipt to the head in that case —
+        // an exact head match. Snap the receipt to the head in that case —
         // nothing rendered sits above the marker, so no message is marked
         // seen that the user could have read.
         if (!atHead && headId != null && headNeverRenders(c, matrixRoomId, headId)) {
@@ -6730,7 +6620,7 @@ object MatrixRepository {
             System.currentTimeMillis() - te.event.originTimestamp <=
             DECRYPT_PENDING_PLACEHOLDER_AFTER_MS
         ) return false
-        // General rule (2026-09-07): a head that produces no rendered row —
+        // General rule: a head that produces no rendered row —
         // bridge delivery-status events, reactions, polls the tool can't
         // render, edits, blank re-import copies — can never receive the
         // receipt marker, so the badge stays up forever (LP3: the 1€ FILM
@@ -6755,7 +6645,7 @@ object MatrixRepository {
     }
 
     /**
-     * Pins or unpins a room (m.favourite tag, synced to Beeper, 2026-08-28):
+     * Pins or unpins a room (m.favourite tag, synced to Beeper):
      * pinned rooms sort to the top of the room list (recency among pins) and
      * their rows drop the latest timestamp. Optimistic — the flags cache
      * updates immediately, the sync echo confirms on the next rebuild.
@@ -6781,7 +6671,7 @@ object MatrixRepository {
 
     /**
      * Mutes or unmutes a room's notifications (tool contact panel,
-     * 2026-08-23; synced via Matrix push rules 2026-08-28 — a global ROOM
+     * synced via Matrix push rules — a global ROOM
      * dont_notify rule per room, matching Beeper's own representation). The
      * room list and unread badge keep updating, only [notifyForEvent] is
      * gated. Optimistic like [setRoomPinned].
@@ -6807,9 +6697,9 @@ object MatrixRepository {
 
     /**
      * Archives or unarchives a room (Beeper's `com.beeper.inbox.done`
-     * room account data, synced, 2026-08-28): archived rooms hide from the
+     * room account data, synced): archived rooms hide from the
      * main list and go silent, reachable only via search VIEW ALL. Mirrors
-     * Beeper's own writes (canonical shape, bundle analysis 2026-08-30):
+     * Beeper's own writes (canonical shape, bundle analysis):
      * archive PUTs `{"at_order":…,"updated_ts":…}`, unarchive PUTs `{}` —
      * Beeper never DELETEs the row (the DELETE route 405s on Beeper's
      * server), so neither do we. Trixnity 4.22.7's typed `setAccountData`
@@ -6863,13 +6753,11 @@ object MatrixRepository {
     /**
      * Server truth for Beeper's inbox.done marker: GET 200 whose content
      * carries any canonical field (`at_order`/`updated_ts` — Beeper's
-     * shape, bundle analysis 2026-08-30; `at_ts` tolerated for the LP3's
+     * shape, bundle analysis; `at_ts` tolerated for the LP3's
      * legacy rows) → archived; 200 with `{}`, or 404 → not archived;
      * other/error → null (unknown — keep the store claim rather than unhide
      * on a blip). Needed because Trixnity's sync store never clears removed
-     * room account data (LP3 2026-08-28: Sophie / Anni / 1€ FILM stayed
-     * "archived" long after Beeper removed the marker — sync delivers
-     * additions only, removals are absences the store ignores).
+     * room account data.
      */
     private suspend fun isRoomArchivedOnServer(c: MatrixClient, roomId: String): Boolean? =
         try {
@@ -6904,7 +6792,7 @@ object MatrixRepository {
     /** The room's effective pinned/muted/archived flags (optimistic writes win;
      *  the store collectors keep the cache fresh within seconds of a
      *  Beeper-side change — the flag loops wait on the flags revision and
-     *  refetch this, 2026-08-28). */
+     *  refetch this). */
     suspend fun getRoomFlags(roomId: String): RoomFlags =
         roomFlagsOverlay[roomId] ?: roomFlagsCache[roomId] ?: RoomFlags()
 
@@ -6925,7 +6813,7 @@ object MatrixRepository {
         wakeRoomList()
     }
 
-    // --- Notifications (Phase 4) --------------------------------------------
+    // --- Notifications --------------------------------------------
 
     /**
      * Records the room the tool is currently showing. New-message
@@ -6938,13 +6826,12 @@ object MatrixRepository {
         // While a thread is open, keep its cached newest page fresh in the
         // background — sync echoes and Beeper send-status events then reach the
         // tool's next poll without it blocking on a compute. Stops on thread
-        // close, navigation, SCREEN_OFF and sync-pause (battery 2026-08-15).
+        // close, navigation, SCREEN_OFF and sync-pause.
         stopActiveRoomRefresh()
         if (roomId != null) startActiveRoomRefresh()
         // The tool just showed the list (null = list/settings/background) —
         // end the resolver's idle sleep so its next pass publishes promptly
-        // instead of waiting out the screen-off 60 s breather (feedback
-        // 2026-08-17: stale panel after a push-woken message).
+        // instead of waiting out the screen-off 60 s breather.
         if (roomId == null) wakeRoomList()
         val ctx = appContext ?: return
         if (roomId != null) ChatNotifier.cancelRoom(ctx, roomId)
@@ -6976,9 +6863,7 @@ object MatrixRepository {
         activeRoomRefreshJob = null
     }
 
-    /** Screen truth for the speculative-work gates (battery 2026-08-15: eager
-     *  page pre-computes and resolver passes are wasted while the screen is
-     *  dark — nobody reads them until the next wake). */
+    /** Screen truth for the speculative-work gates. */
     private fun isScreenInteractive(): Boolean =
         (appContext?.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isInteractive == true
 
@@ -7017,7 +6902,7 @@ object MatrixRepository {
     private fun observeNotifications(c: MatrixClient) {
         android.util.Log.d(TAG, "notification watcher starting for ${c.userId.full}")
         val watcher = scope.launch {
-            // Flag-change watcher (LP3 feedback 2026-08-28): a global push-rule
+            // Flag-change watcher: a global push-rule
             // change (any device toggled mute) re-reads the flags cache so the
             // room list / contact panel reflect it within seconds instead of on
             // the next TTL rebuild. The first emission is the baseline.
@@ -7029,7 +6914,7 @@ object MatrixRepository {
                     android.util.Log.w(TAG, "flag watcher: push-rule collector ended: ${e.message}")
                 }
             }.also { notificationWatcherJobs.add(it) }
-            // Settle flags (first-message ping drop fix, 2026-09-02): a room whose
+            // Settle flags (first-message ping drop fix): a room whose
             // newest message is already unread when its collector starts — or whose
             // first message arrives right after (it registered empty) — may notify
             // instead of being baselined as history. "Settled" means the account is
@@ -7056,7 +6941,7 @@ object MatrixRepository {
                     android.util.Log.w(TAG, "notification watcher: sync-state collector ended: ${e.message}")
                 }
             }.also { notificationWatcherJobs.add(it) }
-            // Server unread counts (2026-09-07): the sync response carries the
+            // Server unread counts: the sync response carries the
             // server-computed per-room unread_notifications.notification_count —
             // the same account-wide unread truth the Beeper clients show. Trixnity
             // only stores it as an unencrypted-room cap (and its own badge state
@@ -7105,7 +6990,7 @@ object MatrixRepository {
                                 // gone, so the notification service's per-room
                                 // notification count drives the list badge. Its
                                 // first emission is a cache read; changes mark
-                                // the resolver dirty (skip-gate, audit 2026-08-14).
+                                // the resolver dirty (skip-gate).
                                 // Tied to this job via coroutineScope so a room
                                 // collector ending (or failing) drops both.
                                 coroutineScope {
@@ -7117,7 +7002,7 @@ object MatrixRepository {
                                             }
                                         }
                                     }
-                                    // First-message ping drop (LP3 feedback 2026-09-02):
+                                    // First-message ping drop:
                                     // a room whose newest message is ALREADY in the
                                     // store when its collector starts — the room was
                                     // created by that first message (bridge/RCS first
@@ -7149,14 +7034,14 @@ object MatrixRepository {
                                             // ground truth for "already seen" — the
                                             // NotificationService count (getCount) never
                                             // tracks messages in this app, so a getCount
-                                            // gate stays 0 and eats the first message
-                                            // (verified 2026-09-02). A receipt behind the
+                                            // gate stays 0 and eats the first message.
+                                            // A receipt behind the
                                             // newest event — or none at all (thread never
                                             // opened) — means genuinely unread: notify
                                             // once — and not again on every launch: an
                                             // event this watcher already alerted in an
                                             // earlier process ([recordNotifiedEvent]) is
-                                            // not re-dinged (ghost bursts, LP3 2026-09-02).
+                                            // not re-dinged (ghost bursts).
                                             val ownRead = ownReadReceiptId(c, roomId)
                                             val alreadyAlerted = lastNotifiedEventId(key) == regLastId
                                             if (!alreadyAlerted && ownRead != regLastId) {
@@ -7171,8 +7056,8 @@ object MatrixRepository {
                                         }
                                     }
                                     roomFlow.filterNotNull().collect { updated ->
-                                        // Resolver skip-gate signal (efficiency audit
-                                        // 2026-08-14): any room-state change (message,
+                                        // Resolver skip-gate signal:
+                                        // any room-state change (message,
                                         // membership) wakes the room-list resolver
                                         // instead of its old unconditional 2 s pass
                                         // loop (unread changes come via the count
@@ -7185,7 +7070,7 @@ object MatrixRepository {
                                         if (roomSigSeen[key] != sig) {
                                             roomSigSeen[key] = sig
                                             markRoomListDirty()
-                                            // Phase 2.1: the row publishes NOW (see
+                                            // The row publishes NOW (see
                                             // [publishRoomRowNow]) — not one pass late.
                                             publishRoomRowNow(c, roomId, updated)
                                         }
@@ -7209,7 +7094,7 @@ object MatrixRepository {
                                         }
                                         if (prev != lastId) {
                                             seen[key] = lastId
-                                            // Recency bump (2026-08-30): a new event means the
+                                            // Recency bump: a new event means the
                                             // room is active — refresh its cache timestamp NOW
                                             // so the next publish reorders it to the top.
                                             // Without this the row's time only changed when the
@@ -7217,7 +7102,7 @@ object MatrixRepository {
                                             // the room; on a big account rooms past the pass
                                             // budget kept stale times and dropped out of the
                                             // main list's 200-room window while still recent
-                                            // ("Jeff" missing, LP3 2026-08-30). The sig block
+                                            // ("Jeff" missing). The sig block
                                             // above already marked the resolver dirty; the wake
                                             // makes a sleeping resolver run the pass now.
                                             updated.lastRelevantEventTimestamp?.toEpochMilliseconds()?.let { ts ->
@@ -7229,7 +7114,7 @@ object MatrixRepository {
                                                 }
                                             }
                                             wakeRoomList()
-                                            // NO-SEAM (2026-09-07): the open thread no longer
+                                            // NO-SEAM: the open thread no longer
                                             // long-polls the page revision — it rides the
                                             // pageChanges signal, so an arrival in the ACTIVE
                                             // room must refresh its page cache NOW (notifyForEvent
@@ -7245,8 +7130,7 @@ object MatrixRepository {
                             }
                         }
                         notificationWatcherJobs.add(job)
-                        // Flag-change collectors for this room (LP3 feedback
-                        // 2026-08-28): the m.favourite tag (pin) and Beeper
+                        // Flag-change collectors for this room: the m.favourite tag (pin) and Beeper
                         // inbox.done account data (archive) change on any
                         // device's toggle — re-read the flags cache so the
                         // change reaches the tool within seconds. The first
@@ -7294,13 +7178,13 @@ object MatrixRepository {
     ) {
         val ctx = appContext ?: return
         // Notifications blocked (POST_NOTIFICATIONS not granted — requested from
-        // the tool via the SDK flow, audit 2026-08-23): skip the whole chain —
+        // the tool via the SDK flow): skip the whole chain —
         // the decrypt wait, flood/ghost walk and page warm built a preview the
         // OS drops. The room list still updates (separate resolver path).
         if (!ctx.getSystemService(NotificationManager::class.java).areNotificationsEnabled()) return
         if (activeRoomId == roomId.full) return
         if (room.membership != Membership.JOIN) return
-        // Muted/archived room (chats 2026-08-23 / 2026-08-28): stop notifying;
+        // Muted/archived room (chats /): stop notifying;
         // the unread badge and the room list stay (muted), or the room is
         // hidden from the list entirely and reachable only via search
         // (archived). Checked before the decrypt wait so a muted room costs
@@ -7312,8 +7196,7 @@ object MatrixRepository {
         }
         // Cold-process miss (the whole-cache build waits on the room-list
         // resolver): mute must not wait — the install-restart notified a
-        // MUTED room in this window (LP3 feedback 2026-09-03, the muted
-        // Crocs squad re-notified right after an APK update). The miss path
+        // MUTED room in this window. The miss path
         // reads the push rules directly — one account-data store read, and
         // it warms nothing (the resolver rebuild supersedes it). Archived
         // still falls through to notify here: resolving it costs a network
@@ -7354,8 +7237,7 @@ object MatrixRepository {
         if (te.event.sender == c.userId) {
             // Own account — no notification whether it was sent from THIS
             // device (outbox echo) or from another Beeper/WhatsApp device:
-            // a message the user sent themselves needs no alert (LP3 feedback
-            // 2026-08-23: sending from another device notified this one).
+            // a message the user sent themselves needs no alert.
             // (Previously only outbox-matched sends were suppressed and
             // same-account other-device sends notified — reversed on request.)
             return
@@ -7373,8 +7255,7 @@ object MatrixRepository {
             // No sender prefix in DMs, and never for our own account (a
             // note-to-self message needs no "FENN:" prefix). Channel/broadcast
             // rooms (≤2 members, e.g. a Telegram channel + its account) are
-            // treated the same way — every message comes from the channel
-            // (feedback 2026-08-28).
+            // treated the same way — every message comes from the channel.
             senderName = if (room.isDirect || (room.joinedMemberCount ?: 0L) <= 2L ||
                 te.event.sender == c.userId
             ) null else senderNameOf(c, roomId, te.event.sender),
@@ -7416,7 +7297,7 @@ object MatrixRepository {
         }
     }
 
-    // --- Room-list cache (Phase 5) ------------------------------------------
+    // --- Room-list cache ------------------------------------------
     // The tool's chat list is served from an in-memory cache refreshed in the
     // background, newest-first. A binder call never triggers the 1284-room
     // resolution burst (whose parallel lookups timed out and previews snapshotted
@@ -7445,7 +7326,7 @@ object MatrixRepository {
 
     private val effectiveLastCache = java.util.concurrent.ConcurrentHashMap<String, EffectiveLast>()
 
-    /** Cached summary-gap head probe (fix 2026-09-03): the raw-chain head read
+    /** Cached summary-gap head probe (fix): the raw-chain head read
      *  in [resolveRoomListEntry] used to run UNCACHED every pass and
      *  [effectiveLastEvent] then re-walked the same head (51 events) — the
      *  1→51 double read across the ~85-155 summary-gap rooms dominated the
@@ -7467,13 +7348,12 @@ object MatrixRepository {
      *  its timestamp). The notification count only drops after the
      *  read-marker echo round-trips through sync (a full tick on a big
      *  account), so the served list shows 0 until the echo confirms or a
-     *  message NEWER than the marked one arrives (feedback 2026-08-15: the
-     *  badge lingered after viewing). */
+     *  message NEWER than the marked one arrives. */
     private val pendingReadClear = java.util.concurrent.ConcurrentHashMap<String, Pair<String, Long>>()
     private val _roomList = MutableStateFlow<List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room>>(emptyList())
 
     /**
-     * The live room census (newest-first) as a flow (NO-SEAM, 2026-09-07):
+     * The live room census (newest-first) as a flow (NO-SEAM):
      * the tool's list/search/contacts collect this instead of polling the
      * binder. Same truth [getRooms]/[getAllRooms] read.
      */
@@ -7481,7 +7361,7 @@ object MatrixRepository {
         _roomList.asStateFlow()
 
     /**
-     * Monotonic revision of the published room list (2026-09-01): bumped on
+     * Monotonic revision of the published room list: bumped on
      * every [publishRoomList] and on [resetRoomList]. The tool polls
      * [roomListRevision] (a Long, cheap) instead of re-fetching the whole
      * 400-room [getRooms] payload every 5 s — the binder transfer happens only
@@ -7506,7 +7386,7 @@ object MatrixRepository {
     )
 
     /**
-     * Monotonic revision of a room's cached newest page (2026-09-01): bumped
+     * Monotonic revision of a room's cached newest page: bumped
      * wherever the page cache's content changes (new/edited events,
      * read-receipt patches, pending-echo state). The thread's 3s poll reads
      * this instead of pulling a full [getMessages] page while nothing moved.
@@ -7525,7 +7405,7 @@ object MatrixRepository {
     }
 
     /**
-     * Per-room newest-page change signal (NO-SEAM, 2026-09-07): emitted beside
+     * Per-room newest-page change signal (NO-SEAM): emitted beside
      * every [bumpMessagePageRevision] so the thread collects it instead of
      * long-polling the revision. A signal, not a page payload: the served page
      * shape (pending echoes, audio state — [getMessages]) stays in exactly one
@@ -7541,7 +7421,7 @@ object MatrixRepository {
     val pageChanges: kotlinx.coroutines.flow.SharedFlow<String> = pageChangeSignal.asSharedFlow()
 
     /**
-     * Monotonic revision of the room-flags cache (Phase C, 2026-09-06):
+     * Monotonic revision of the room-flags cache:
      * bumped where the flags fact commits — optimistic writes
      * ([updateRoomFlagsLocal]) and store-fresh rebuilds ([roomFlagsByRoom]).
      * The thread/contact-panel flag loops wait on it ("flags" scope) instead
@@ -7552,7 +7432,7 @@ object MatrixRepository {
 
     /**
      * The live per-room flags (pinned/muted/archived, optimistic overlay
-     * applied) as a flow (NO-SEAM, 2026-09-07): the thread/contact panels
+     * applied) as a flow (NO-SEAM): the thread/contact panels
      * collect this instead of long-polling the flags revision.
      */
     private val _roomFlags = MutableStateFlow<Map<String, RoomFlags>>(emptyMap())
@@ -7566,7 +7446,7 @@ object MatrixRepository {
 
     /**
      * Monotonic revision of the tool-visible account/connection/verification
-     * status facts (Phase C, 2026-09-06): bumped beside every
+     * status facts: bumped beside every
      * [_connectionState] and [_verification] commit. The Account/Verification/
      * Settings screens wait on it ("status" scope) instead of polling
      * [accountState]/[connectionState]/[verificationState] on a timer.
@@ -7593,8 +7473,8 @@ object MatrixRepository {
 
     /**
      * Holds the caller until a watched revision moves past [lastSeen] or
-     * [timeoutMs] elapses (the server half of [LightServiceMethod.WaitForChange]
-     * — the tool's poll ticks became this). Returns the current revision either
+     * [timeoutMs] elapses (the server half of [LightServiceMethod.WaitForChange]).
+     * Returns the current revision either
      * way; the caller compares and refetches. Fast path first: an already-
      * moved revision (raced signal) returns immediately.
      */
@@ -7618,7 +7498,7 @@ object MatrixRepository {
     @Volatile
     private var roomListJob: Job? = null
 
-    /** Dirty flag for the room-list resolver (efficiency audit 2026-08-14):
+    /** Dirty flag for the room-list resolver (efficiency ):
      *  a full pass runs only when [observeNotifications] saw a room-state change
      *  or a parked resolution retry came due — previously every 2 s, 24/7 (the
      *  overnight CPU/IO drain).
@@ -7627,7 +7507,7 @@ object MatrixRepository {
     private var roomListDirty = true
 
     /**
-     * Phase-0 latency timers (SYNC-PERF-SPEC.md 2026-09-04): elapsed-realtime
+     * latency timers (SYNC-PERF-SPEC.md): elapsed-realtime
      * of the FIRST dirty set since the last publish ("store→publish" start)
      * and of the last publish ("revision→RPC" start for getRooms). Stamping is
      * unconditional and cheap (volatile writes); the logs are debugLog-gated.
@@ -7639,13 +7519,13 @@ object MatrixRepository {
     @Volatile
     private var roomListPublishedAt = 0L
 
-    // --- sync-ingest gate (SYNC-PERF-SPEC §Phase 1, 2026-09-05) --------------
+    // --- sync-ingest gate (SYNC-PERF-SPEC §Phase 1) --------------
 
     /** Bounds for [yieldToSyncIngest]: heavy in-process work waits at most this
      *  long for a running sync ingest before proceeding anyway (a wedged round
      *  must not starve the resolver forever). Generous by design — an 8 s cap
      *  let gated consumers barge in cycles during the 22:59 cold-start catchup
-     *  and starved a 44-event ingest for 175 s (LP3 2026-09-05); only a wedged
+     *  and starved a 44-event ingest for 175 s; only a wedged
      *  round outlives 60 s. */
     private const val SYNC_INGEST_YIELD_MAX_MS = 60_000L
     private const val SYNC_INGEST_YIELD_STEP_MS = 100L
@@ -7695,10 +7575,10 @@ object MatrixRepository {
     private val singleRoomPublishInFlight = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
 
     /**
-     * Phase 2.1 (SYNC-PERF-SPEC 2026-09-04): resolve and publish ONE room's row
+     * Per the SYNC-PERF-SPEC: resolve and publish ONE room's row
      * immediately when its notification-watcher collector sees a change, instead
      * of waiting for the next budgeted resolver pass — the dominant measured
-     * tail (Phase 0 LP3 table: store→publish median 8.6 s, 8/12 > 5 s). Uses the
+     * tail. Uses the
      * same bounded per-room reads the pass does; the full pass still runs
      * ([markRoomListDirty] fired) for reordering + crawl work. Skipped during
      * the initial crawl — the back-to-back startup passes already publish, and
@@ -7759,11 +7639,11 @@ object MatrixRepository {
      *  [flagsOnlyWake]). */
     private var lastRoomsMap: Map<RoomId, Flow<MatrixRoom?>>? = null
 
-    /** Next pass's iteration offset into the room map (2026-08-30): the
+    /** Next pass's iteration offset into the room map: the
      *  resolver used to start every pass at the map's front, so rooms past the
      *  per-pass budget were never collected/seeded — their cache rows kept the
      *  initial timestamp (or none) and dropped out of the main list's 200-room
-     *  window despite being recent ("Jeff" missing, LP3 2026-08-30). Rotating
+     *  window despite being recent ("Jeff" missing). Rotating
      *  the offset spreads the full map across consecutive passes, so every
      *  room is eventually collected + resolved. Single-threaded: only the
      *  resolver coroutine reads/writes it. */
@@ -7771,16 +7651,13 @@ object MatrixRepository {
 
     /** True once the resolver has collected the whole room map (cursor wrapped
      *  back to 0). Until then the idle gate lets consecutive passes run, so the
-     *  full account gets seeded even with no incoming messages (2026-08-30: a
-     *  quiet/flapping-sync account ran only the first front-loaded pass, so
-     *  rooms past its budget stayed out of the main list). */
+     *  full account gets seeded even with no incoming messages. */
     private var initialRoomCrawlDone = false
 
     /** Set when a PIN/MUTE/ARCHIVE write lands locally ([updateRoomFlagsLocal]):
      *  the resolver re-stamps the cached rows with the fresh flags and
      *  publishes immediately instead of waiting for the full pass's room
-     *  collect + preview budget (LP3 feedback 2026-08-28: pin/unpin didn't
-     *  reflect instantly). The full pass still runs — the write set
+     *  collect + preview budget. The full pass still runs — the write set
      *  [roomListDirty] — it just no longer gates the flag change. */
     @Volatile
     private var flagsOnlyWake = false
@@ -7788,9 +7665,7 @@ object MatrixRepository {
     /** Wakes the resolver's idle sleep immediately (screen-on, push-wake, the
      *  tool opening the list). Without it, a message that arrived while the
      *  screen was off left the panel stale for the rest of the screen-off
-     *  sleep (60 s) after the user woke the phone (feedback 2026-08-17: "the
-     *  main room panel doesn't update on push" — the message was in the store,
-     *  the served list wasn't). Conflated: many signals collapse to one wake.
+     *  sleep (60 s) after the user woke the phone. Conflated: many signals collapse to one wake.
      */
     private val roomListWake = Channel<Unit>(Channel.CONFLATED)
 
@@ -7829,7 +7704,7 @@ object MatrixRepository {
      * the suppression lifts when the echo confirms (notification count 0) or
      * a message NEWER than the one marked read arrives (real unread again —
      * compared by timestamp, so a lagging summary can't undo the clear for
-     * events the page simply didn't carry, 2026-08-23).
+     * events the page simply didn't carry).
      */
     private fun servedUnread(
         roomId: String,
@@ -7844,7 +7719,7 @@ object MatrixRepository {
         // comparison, not a marker-id match: the marker may be a snapped
         // unrenderable head (reaction/poll/bridge status), which the room's
         // relevant head equals immediately and disarmed the old check
-        // mid-flap (LP3 2026-09-07: "disappears then reappears").
+        // mid-flap.
         return if (newestTs != null && newestTs > markedTs) {
             pendingReadClear.remove(roomId)
             storeUnread
@@ -7854,7 +7729,7 @@ object MatrixRepository {
     }
 
     /**
-     * Local unread fallback (2026-09-07): Trixnity's notification count is
+     * Local unread fallback: Trixnity's notification count is
      * dead after a fresh login — its state machine defaults rooms to "read"
      * when the last message isn't in the local timeline (our battery-thin
      * sync leaves most rooms with 0-1 timeline rows) and only re-checks when
@@ -7881,7 +7756,7 @@ object MatrixRepository {
                             // "read" their own delivery-status events instantly,
                             // so their receipt is always the newest in an active
                             // room and this fallback read every busy bridged room
-                            // as unread (LP3 2026-09-07: the 1€ FILM badges).
+                            // as unread.
                             // ponytail: localpart-suffix heuristic — a human
                             // literally named "…bot" would be excluded; switch
                             // to a rendered-message join if that bites.
@@ -7931,7 +7806,7 @@ object MatrixRepository {
      * is attached: seeds every room with a placeholder row first (so the list
      * shows instantly), then resolves names + previews newest-first within a
      * per-pass time budget, publishing the snapshot after each pass.
-     * Since 2026-08-14 a pass runs only when [observeNotifications] observed a
+     * Since a pass runs only when [observeNotifications] observed a
      * room-state change (see [roomListDirty] / [hasPendingResolveWork]) instead
      * of every 2 s, 24/7 (the standby CPU/IO drain, efficiency audit).
      */
@@ -7965,8 +7840,8 @@ object MatrixRepository {
             val nameMemo = HashMap<String, String>()
             while (true) {
                 // Skip the pass unless the room map moved or a parked
-                // preview/ghost-walk retry came due (efficiency audit
-                // 2026-08-14 — the resolver ran a full pass every 2 s, 24/7).
+                // preview/ghost-walk retry came due:
+                // the resolver ran a full pass every 2 s, 24/7.
                 // The initial crawl (see [initialRoomCrawlDone]) overrides the
                 // gate: until the cursor has wrapped, passes keep running so
                 // every room is collected at least once per process start.
@@ -7974,7 +7849,7 @@ object MatrixRepository {
                     // Idle sleep, interruptible: [wakeRoomList] (screen-on,
                     // push-wake, list re-opened) ends it early so a message
                     // that landed while the screen was dark is served the
-                    // moment the user looks at the list (feedback 2026-08-17).
+                    // moment the user looks at the list.
                     val sleepMs =
                         if (isScreenInteractive()) ROOM_LIST_REFRESH_DELAY_MS else SLOW_RESOLVER_DELAY_MS
                     withTimeoutOrNull(sleepMs) { roomListWake.receive() }
@@ -8018,8 +7893,7 @@ object MatrixRepository {
                     val loaded = mutableListOf<Pair<RoomId, MatrixRoom>>()
                     // Rotating coverage: start this pass's collect at
                     // [roomIterationCursor] instead of the map's front, so rooms
-                    // past the budget on one pass are visited on the next
-                    // (2026-08-30 — see the cursor's comment).
+                    // past the budget on one pass are visited on the next.
                     val entries = rooms.entries.toList()
                     val rotated = entries.drop(roomIterationCursor) + entries.take(roomIterationCursor)
                     var visited = 0
@@ -8056,7 +7930,7 @@ object MatrixRepository {
                     val (networks, communities) = networkByRoom(c, rooms)
                     // Pinned/archived/muted per room (m.favourite tag, Beeper
                     // inbox.done account data, global push rules) — cached
-                    // like the network map (2026-08-28).
+                    // like the network map.
                     val flags = roomFlagsByRoom(c, rooms)
                     // Bridge contact lists (Beeper provision API): pre-fetch
                     // per bridge so the row resolve below is a pure cache hit —
@@ -8068,9 +7942,8 @@ object MatrixRepository {
                         bridgeContacts(c, bridgeId)
                     }
                     seedRoomList(loaded, verified, networks, communities, flags)
-                    // Phase 14 feedback: every joined room gets a preview attempt
-                    // (the user's list looked inconsistent — rooms beyond the old
-                    // 30-room preview window showed no latest message at all).
+                    // Every joined room gets a preview attempt (rooms beyond the
+                    // preview window showed no latest message at all).
                     // The per-pass budget + the encrypted-room retry backoff keep
                     // it cheap: decrypted reads are milliseconds, still-encrypted
                     // rooms back off for a minute, and each pass stops at the
@@ -8093,17 +7966,16 @@ object MatrixRepository {
                     // pre-compute below: the precompute builds the newest
                     // rooms' pages first, and a slow page (e.g. a room whose
                     // history is still undecryptable) used to delay the
-                    // publish — the panel's bump/reorder waited on it
-                    // (LP3 2026-08-17: a sent self-note didn't bump the room
-                    // until a later pass). The precompute only touches the
+                    // publish — the panel's bump/reorder waited on it.
+                    // The precompute only touches the
                     // message-page cache, never the room rows, so publishing
                     // first is safe.
                     publishRoomList()
-                    // Eager page pre-compute (2026-08-13): the most-recent rooms'
+                    // Eager page pre-compute: the most-recent rooms'
                     // newest pages are computed in the background so opening a
                     // thread is a cache hit instead of a cold walk. A few per
                     // pass; rooms with a fresh page (memory or disk) are skipped.
-                    // Battery (2026-08-15): screen-gated — the slow-sync rounds
+                    // Battery: screen-gated — the slow-sync rounds
                     // kept the list dirty on the live account, so the resolver
                     // was rebuilding the hottest room's page on every pass,
                     // 24/7, screen off or not (the second speculative-work loop
@@ -8123,7 +7995,7 @@ object MatrixRepository {
                             // is redundant. The disk check is a file stat, not a
                             // JSON decode: the old loadMessagePageFromDisk ran a
                             // full decode per room per pass just to learn the
-                            // page exists (profile 2026-08-20).
+                            // page exists.
                             if (messagePageCache.containsKey(key)) continue
                             if (messagePageCacheFile(key)?.exists() == true) continue
                             val page = runCatching {
@@ -8146,12 +8018,12 @@ object MatrixRepository {
                             "\n${e.stackTraceToString().lineSequence().take(6).joinToString("\n")}",
                     )
                 }
-                // Battery (2026-08-15): while the screen is off, coalesce the
+                // Battery: while the screen is off, coalesce the
                 // resolver's dirty-loop — the room list only needs to be fresh
                 // for the next wake, not sub-minute (the slow-sync rounds kept
                 // it dirty on the live account, so the old 2s breather meant
                 // near-continuous passes).
-                // Wakeable (2026-08-17): a send/push/list-open wake ends the
+                // Wakeable: a send/push/list-open wake ends the
                 // breather early, so the next pass — and its publish — runs
                 // immediately and the tool's very next list refresh shows the
                 // bump instead of waiting out the cadence. Coalescing is
@@ -8199,10 +8071,9 @@ object MatrixRepository {
                     // the channel account) aren't marked direct either — but
                     // every message there comes from the channel, so a per-row
                     // sender name is redundant noise. Treating both as direct
-                    // hides it (feedback 2026-08-28). [isDirectRoom] also
+                    // hides it. [isDirectRoom] also
                     // counts Beeper 1:1s whose bridge bot inflates
-                    // joinedMemberCount past 2 (LP3: "Amy"-style chats showed
-                    // under Group, 2026-08-30).
+                    // joinedMemberCount past 2.
                     isDirect = isDirectRoom(room),
                     contactId = contactIdOf(room),
                     network = networks[key],
@@ -8250,7 +8121,7 @@ object MatrixRepository {
         // the list and show the re-imported message as its preview.
         var serverTs = room.lastRelevantEventTimestamp?.toEpochMilliseconds() ?: 0L
         var serverLastId = room.lastRelevantEventId?.full
-        // Summary gap (2026-08-30): rooms whose lastRelevantEvent* the (partial)
+        // Summary gap: rooms whose lastRelevantEvent* the (partial)
         // sync never re-stamped resolve to timestamp 0 — which sorts them below
         // every real room and drops them out of the main list's 200-room window
         // ("Jeff" missing though searchable; 155/296 rooms on the LP3). Fall
@@ -8263,8 +8134,7 @@ object MatrixRepository {
             // still give the row a real time — [effectiveLastEvent] walks back
             // to the renderable message for the display time below. The raw
             // chain read is also gap-immune (it follows previous-event links;
-            // the API view truncates at a gap marker — the Annette-room class,
-            // 2026-08-23).
+            // the API view truncates at a gap marker — the Annette-room class,).
             room.lastEventId?.full?.let { lastId ->
                 // Head probe, cached per room.lastEventId (see [summaryGapHeadCache]).
                 val head = summaryGapHeadCache[key]
@@ -8301,7 +8171,7 @@ object MatrixRepository {
                 }
             }
         }
-        // Early pin (fix 2026-09-03): when the summary-gap head is a real,
+        // Early pin (fix): when the summary-gap head is a real,
         // readable message — the same test [effectiveLastEvent]'s fast pin
         // applies — write its pin directly and skip the 51-event walk. A
         // txn-id-free head can't be a flood ghost (see [isFloodGhost]: only
@@ -8322,9 +8192,7 @@ object MatrixRepository {
         }
         // Own send in flight (echo not yet in the store): the row must bump to
         // the top NOW with the send's preview + time — the panel must not keep
-        // the pre-send state while the user's own message is on its way (LP3
-        // 2026-08-17: the panel kept the old timestamp for ~10-15s after a
-        // send). The pending's values (send time + body) match the echo's
+        // the pre-send state while the user's own message is on its way. The pending's values (send time + body) match the echo's
         // closely, so the swap when the echo lands is invisible; once the
         // pending is gone (echo processed) the normal store row takes over.
         val pending = newestPending(key)
@@ -8335,8 +8203,8 @@ object MatrixRepository {
             null -> ts
         }
         // An unverified device can't decrypt — suppress unread for encrypted
-        // rooms only; unencrypted ones stay readable. Local receipt fallback
-        // (2026-09-07): Trixnity's notification count is empty after a fresh
+        // rooms only; unencrypted ones stay readable. Local receipt fallback:
+        // Trixnity's notification count is empty after a fresh
         // login (its state machine marks timeline-less rooms read) — the
         // own-receipt-vs-others comparison catches those.
         val storeUnread = if (verified || !room.encrypted) {
@@ -8368,7 +8236,7 @@ object MatrixRepository {
         } else {
             resolveRoomName(c, roomId, room, nameMemo)
         }
-        // Flash guard (2026-09-07): on a cold start the first passes run before
+        // Flash guard: on a cold start the first passes run before
         // the sync has delivered member state — resolveRoomName falls through
         // to the "Chat" placeholder, and publishing it overwrote the disk
         // cache's previously resolved names (the user-visible name flash when
@@ -8434,10 +8302,9 @@ object MatrixRepository {
                 // the channel account) aren't marked direct either — but
                 // every message there comes from the channel, so a per-row
                 // sender name is redundant noise. Treating both as direct
-                // hides it (feedback 2026-08-28). [isDirectRoom] also counts
+                // hides it. [isDirectRoom] also counts
                 // Beeper 1:1s whose bridge bot inflates joinedMemberCount
-                // past 2 (LP3: "Amy"-style chats showed under Group,
-                // 2026-08-30).
+                // past 2.
                 isDirect = isDirectRoom(room),
                 contactId = contactIdOf(room),
                 // Resolved here (not in the seed pass — this one has a client
@@ -8480,16 +8347,13 @@ object MatrixRepository {
      * room id) lists its rooms, and the space's explicit name carries the
      * network ("WhatsApp (+61420460590)" → "WhatsApp"). Rooms outside any
      * account space (Beeper-internal, e.g. Note to self) stay ungrouped.
-     *
      * Only ACCOUNT spaces are mapped (see [isAccountSpace]): Beeper also
      * creates spaces for WhatsApp group/community chats, named after the group
      * itself — those must not become selectable accounts.
-     *
      * Also returns the community map (room id → the community sub-space's own
      * name, e.g. "1 euro film"): Beeper nests WhatsApp community groups under
      * their own space, a child of the account space — the sub-space's explicit
-     * name is the community the user sees in Beeper (feedback 2026-09-01).
-     *
+     * name is the community the user sees in Beeper.
      * Reads the FULL room map (not the budget-bound newest subset — the space
      * rooms are older than the room activity) and caches the result, since
      * space membership changes rarely.
@@ -8533,7 +8397,7 @@ object MatrixRepository {
                     // Beeper puts WhatsApp community groups under their own
                     // space ("1 euro film", "crocs 2026 squad"), a child of the
                     // account space — those rooms show no network and vanish
-                    // from the network filter (feedback 2026-08-27). Record
+                    // from the network filter. Record
                     // the sub-space so the second pass labels its rooms.
                     if (childId in spaceIds) {
                         groupSpaceChildren[childId] = label to spaceNameBySpaceId[childId].orEmpty()
@@ -8570,7 +8434,7 @@ object MatrixRepository {
      *  network map. Our own PIN/MUTE/ARCHIVE toggles mutate it optimistically;
      *  external Beeper changes invalidate it via the store collectors in
      *  [observeNotifications], so they land within seconds — not on the next
-     *  TTL rebuild (LP3 feedback 2026-08-28). */
+     *  TTL rebuild. */
     @Volatile private var roomFlagsCache: Map<String, RoomFlags> = emptyMap()
     @Volatile private var roomFlagsBuiltAtMs = 0L
 
@@ -8578,7 +8442,7 @@ object MatrixRepository {
      *  every rebuild so a TTL-expiry rebuild can't clobber them with a stale
      *  store read (the sync echo of our own write hasn't landed yet), and
      *  dropped once a rebuild reads the confirmed server value. This is what
-     *  makes pin/unpin reorder the list instantly (LP3 feedback 2026-08-28). */
+     *  makes pin/unpin reorder the list instantly. */
     @Volatile private var roomFlagsOverlay: Map<String, RoomFlags> = emptyMap()
 
     /** Rooms whose tag / inbox.done / push-rule state changed on the server
@@ -8593,8 +8457,7 @@ object MatrixRepository {
      *  collectors in [observeNotifications]) and wakes the room-list resolver
      *  so the change reaches the tool's next list read. [flagsOnlyWake] routes
      *  it through the fast re-stamp path — a remote toggle lands in the list
-     *  within a second instead of waiting for the full pass (LP3 feedback
-     *  2026-08-29: Beeper-side mute/archive was sporadic/never on the LP3). */
+     *  within a second instead of waiting for the full pass. */
     private fun invalidateRoomFlags(roomId: String) {
         synchronized(flagsLock) {
             roomFlagsInvalidated = roomFlagsInvalidated + roomId
@@ -8652,8 +8515,7 @@ object MatrixRepository {
         // Seed from the last-known flags so a room that times out KEEPS its
         // previous state instead of silently unpinning. The old whole-loop
         // budget cut the 296-room walk partway and cached the partial prefix —
-        // the LP3 served exactly 1 pinned room though the store held 3
-        // (2026-08-29: Sophie pinned, Anni + Note to self dropped).
+        // the LP3 served exactly 1 pinned room though the store held 3.
         val result = roomFlagsCache.toMutableMap()
         for ((roomId, _) in rooms) {
             val key = roomId.full
@@ -8664,7 +8526,7 @@ object MatrixRepository {
                 // the claim on the network (only archived rooms cost a GET;
                 // unknown → keep the store claim). Archived = content carries
                 // any canonical field (at_order/updated_ts — Beeper's shape,
-                // bundle analysis 2026-08-30; at_ts tolerated for the LP3's
+                // bundle analysis; at_ts tolerated for the LP3's
                 // legacy rows): Beeper's unarchive resets the content to {}
                 // rather than deleting the row, so row presence is not the
                 // flag.
@@ -8749,7 +8611,7 @@ object MatrixRepository {
         val bridgeId = bridgeIdOf(hero.full)
         val bridgeName = bridgeId?.let { bridgeContactsCache[it]?.get(hero.full)?.name }
             ?.takeIf { it.isNotBlank() }
-        // Diagnostics for the LID-migration title regression (LP3 2026-09-05):
+        // Diagnostics for the LID-migration title regression:
         // "whatsapp_lid-…" titles mean store name null AND bridge cache miss.
         if (debugLogging() && storeName == null && bridgeName == null &&
             hero.localpart.contains("_lid-")
@@ -8797,18 +8659,18 @@ object MatrixRepository {
      * @whatsappbot are members but never the hero. Groups have several heroes
      * → null, so the contact overlay shows name + network only there. The
      * full Matrix ID; the app derives the localpart (the phone number /
-     * username) for display (feedback 2026-08-21).
+     * username) for display.
      */
     /** Direct (1:1) classification for the served room rows. Beyond Trixnity's
      *  own flag: a room with ≤2 joined members is direct (self-rooms, small
      *  chats), and so is a room with exactly one non-bot hero — Beeper DMs
      *  carry the bridge bot as a member, so joinedMemberCount reads 3 for a
      *  plain 1:1 and those rooms would otherwise land in the contacts panel's
-     *  Group tab (LP3 2026-08-30). Bridge ghosts (@whatsapp_*, @instagramgo_*,
+     *  Group tab. Bridge ghosts (@whatsapp_*, @instagramgo_*,
      *  @telegram_*, *bot) are plumbing, not people: a room whose heroes are
      *  ALL whatsapp_lid-* linked identities is one contact's accounts (e.g.
      *  "+15052308756, Amy" = Amy's old + current LIDs), a 1:1 that Beeper
-     *  names by every linked id — direct, not a group (LP3 2026-08-30). */
+     *  names by every linked id — direct, not a group. */
     private fun isDirectRoom(room: MatrixRoom): Boolean {
         if (room.isDirect || (room.joinedMemberCount ?: 0L) <= 2L) return true
         val heroes = room.name?.heroes?.filterNot { it.localpart.endsWith("bot", ignoreCase = true) }.orEmpty()
@@ -8835,7 +8697,7 @@ object MatrixRepository {
      * Tuohy"); 3) a current displayname that is still a number. The
      * prev_content needs a cast to the concrete unsigned type — the
      * `UnsignedRoomEventData` interface hides it, but
-     * `UnsignedStateEventData` carries it (feedback 2026-08-23).
+     * `UnsignedStateEventData` carries it.
      */
     private suspend fun contactPhoneOf(c: MatrixClient, matrixRoomId: RoomId, contactId: String): String? {
         val localpart = contactId.substringAfter("@").substringBefore(":")
@@ -8940,7 +8802,7 @@ object MatrixRepository {
     /** The session access token, persisted at login ([KEY_ACCESS_TOKEN]).
      *  Trixnity's raw ktor client only attaches the bearer on its typed
      *  request path — raw GETs (here, and [setRoomArchived]'s PUT) ride bare,
-     *  and Beeper's provision API 404s without it (curl-verified 2026-09-01:
+     *  and Beeper's provision API 404s without it (curl-verified:
      *  no-auth → 404 M_UNRECOGNIZED, with bearer → 200). Sessions restored
      *  from before this key existed read it once from Trixnity's own
      *  `Authentication` table (Room, `value` JSON) and cache it in prefs. */
@@ -9044,7 +8906,7 @@ object MatrixRepository {
         // ghost is in it; WhatsApp LID heroes like mo/Hannah were dropping
         // out) or the bridge serves no list at all (instagramgo's
         // deterministic 404) → resolve per contact, which is what Beeper's
-        // own client does for DMs (curl-verified 2026-09-01: telegram →
+        // own client does for DMs (curl-verified: telegram →
         // tel/username, instagramgo → username). A transient list FAILURE
         // (null) returns null — the 60s retry covers it without per-contact
         // hammering.
@@ -9065,7 +8927,7 @@ object MatrixRepository {
      *  (decompiled Beeper BridgeApi.retrieveContactList/resolveIdentifier,
      *  response shape identical to a contact). The id is the ghost mxid's
      *  localpart minus the "{bridgeKey}_" prefix — numeric for instagramgo
-     *  and telegram (curl-verified 2026-09-01: instagramgo → identifiers
+     *  and telegram (curl-verified: instagramgo → identifiers
      *  ["instagram:animus.film"], telegram → ["tel:+49…","telegram:karin3na"]).
      *  Cached per contact like the list; same TTL. */
     private suspend fun resolveBridgeIdentifier(c: MatrixClient, bridgeId: String, contactId: String): String? {
@@ -9106,12 +8968,7 @@ object MatrixRepository {
 
     /**
      * The room's newest event that renders as a message row, for the list's
-     * sort + timestamp + preview (LP3 2026-08-17: the panel showed the
-     * bridge's `com.beeper.message_send_status` delivery ack as the latest
-     * message — 22:08 — while the thread's newest message was 21:59; Beeper's
-     * status acks sit after the message in the timeline, so Trixnity's
-     * summary, which counts any timeline event, bumped the row to the ack
-     * time). The server's room summary points at the newest event — after a
+     * sort + timestamp + preview. The server's room summary points at the newest event — after a
      * bridge re-import flood that is a ghost, which bumped every room to the
      * top of the chat list. When the server's last event is a ghost (or any
      * non-renderable event — ack, reaction, redaction, edit), walk back
@@ -9143,16 +9000,14 @@ object MatrixRepository {
         // hold the PREVIOUS server-last event's resolution — keep showing
         // that message instead of stamping the row with an undecryptable
         // event's time (re-import copies arrive re-encrypted; their content
-        // can't be read, 2026-08-23).
+        // can't be read).
         val prev = effectiveLastCache[key]
         // Fast in-path walk (no session restore — old originals may not
         // decrypt yet): if the server's newest event survives the dedup AND
         // isn't inside a flood, it's a real message (the common case). The
         // renderable filter also drops bridge status acks / reactions /
         // redactions — events the thread never shows — so the row's time +
-        // preview match the newest actual message (2026-08-17: a
-        // message_send_status ack stamped 22:08 topped the row for a 21:59
-        // message).
+        // preview match the newest actual message.
         val fast = withTimeoutOrNull(ROOM_BUDGET_MS) {
             // The DB chain, not the API walk: a gap marker at the room's
             // newest event truncates the API view to just the head event, so
@@ -9166,15 +9021,14 @@ object MatrixRepository {
         // message" — the first entry here is what the row shows. Filtering
         // empties out lets the FIRST real message behind a run of copies/acks
         // resolve immediately (the fast window holds it), instead of waiting
-        // on the async ghost resolve (LP3 2026-08-23: Sophie's room stamped
-        // 18:26 by a status ack; the 09:08 wall rooms persisted).
+        // on the async ghost resolve.
         val fastFiltered = filterGhosts(c, fast)
             .filter { isRenderableRow(it) && previewText(it)?.isNotBlank() == true }
         val serverLast = fast.firstOrNull { it.event.id.full == serverLastId }
         val inFlood = serverLast != null && isFloodGhost(c, serverLast, fast)
         // Pin permanently only when the server-last event is a REAL message:
         // its content must be READABLE (an undecryptable re-import copy must
-        // not top the list — 2026-08-23) AND it must RENDER something (a
+        // not top the list —) AND it must RENDER something (a
         // re-import copy whose body resolves to nothing shows an empty
         // preview — LP3: rooms stamped 09:08 with lastMsg='' after the
         // bridge's history re-import; "the timestamp should reflect the
@@ -9189,9 +9043,7 @@ object MatrixRepository {
         // failure — the megolm key arrived after this pass started): it drops
         // out of fastFiltered below, so without this branch the firstReal pin
         // would cache yesterday's message forever and the row would keep the
-        // old timestamp until the room's next message or a restart (LP3
-        // 2026-09-02: Directing showed yesterday while the thread had today's
-        // message). Stamp the new event now — the room bumps to today on the
+        // old timestamp until the room's next message or a restart. Stamp the new event now — the room bumps to today on the
         // same dirty pass — and retry after the decrypt window; the re-walk
         // then pins it permanently once readable, or routes a failed decrypt
         // to the ghost machinery below.
@@ -9212,12 +9064,11 @@ object MatrixRepository {
         // (megolm session missing until the backup restore, Beeper bridged
         // rooms) fell through to the ghost machinery below and the row sat on
         // the old message for hours-to-weeks while the thread itself showed
-        // the newer message (LP3 2026-09-05: Directing 3 h, Note to self 20 h,
-        // BRATS - Actors 12 days; ~150/296 rooms behind). Edits (m.replace)
+        // the newer message. Edits (m.replace)
         // and flood ghosts are excluded — the row must not bump to edit time
-        // (2026-08-17) or to a re-import flood (2026-08-23). The ghost resolve
+        // or to a re-import flood. The ghost resolve
         // below still runs so the preview heals once content resolves; member
-        // -join/ack heads keep the 2026-08-31 no-fake-time park.
+        // -join/ack heads keep the no-fake-time park.
         if (serverLast != null && isMessageClassHead(serverLast) && !inFlood) {
             effectiveLastCache[key] = EffectiveLast(serverLastId, serverLastId, serverTs)
             return serverLastId to serverTs
@@ -9226,9 +9077,7 @@ object MatrixRepository {
         // bridge status ack / reaction / redaction, or an in-flood ghost. When
         // the fast window already holds a renderable event, resolve it
         // immediately: real messages decrypt fine, so the background walk
-        // would find the same event after a needless session-restore detour
-        // (feedback 2026-08-17: rooms topped by edits showed "last message
-        // Thursday").
+        // would find the same event after a needless session-restore detour.
         val firstReal = fastFiltered.firstOrNull()
         // A still-decrypting newest must not pin the older message forever
         // either (in-flood copies fall through here) — route to the ghost
@@ -9246,7 +9095,7 @@ object MatrixRepository {
             // Parked room (futile restore): a ghost walk can't resolve it
             // either — the originals' sessions are gone, so the dedup can't
             // identify the real event. Retry at the park's end, not in 2
-            // minutes (battery 2026-08-17 audit).
+            // minutes.
             effectiveLastCache[key] = EffectiveLast(
                 serverLastId, prev?.effectiveEventId ?: serverLastId, prev?.effectiveTs ?: serverTs,
                 retryAtMs = decryptRestoreCooldown[key] ?: (now + GHOST_WALK_RETRY_MS),
@@ -9257,9 +9106,7 @@ object MatrixRepository {
         // bridge ack) and which has NEVER resolved a real message (prev ==
         // null) has nothing to stamp: the server's head time is a state
         // re-delivery, not activity, and surfacing it as fresh fakes a
-        // timestamp (LP3 2026-08-31: the WhatsApp bridge re-delivered a
-        // member-join burst at 17:55; three message-less rooms popped to the
-        // top as "17:55" though Beeper shows no messages). Park the row at
+        // timestamp. Park the row at
         // the bottom (ts 0, no preview) until the ghost walk finds real
         // content or a real message arrives — the fast path re-checks on
         // every server-last change, so a genuine arrival still surfaces.
@@ -9301,9 +9148,7 @@ object MatrixRepository {
                     val events = collectTimelineEvents(c, matrixRoomId, serverLastId, EFFECTIVE_LAST_WALK)
                     // Skip the re-collect when the restore found nothing to
                     // load — nothing changed, the first walk's events are the
-                    // final answer (battery 2026-08-17: the second walk doubled
-                    // every ghost resolve, and on the live account the big
-                    // rooms' walks exceeded the 8s budget and never resolved).
+                    // final answer.
                     val loaded = restoreRoomSessions(c, matrixRoomId, events)
                     if (loaded > 0) {
                         collectTimelineEvents(c, matrixRoomId, serverLastId, EFFECTIVE_LAST_WALK)
@@ -9338,11 +9183,11 @@ object MatrixRepository {
                     // Timed out: the walk can't complete within budget (large or
                     // undecryptable rooms). Back off hard instead of retrying
                     // every 2 minutes — the room isn't going to resolve, and the
-                    // fast path re-checks it on every server-last change anyway
-                    // (battery 2026-08-17 audit). Keep the current effective
+                    // fast path re-checks it on every server-last change anyway.
+                    // Keep the current effective
                     // values (the message-less park's null/0, or the last-known-
                     // good message) — re-stamping the raw head here would
-                    // resurrect a fake state-event time (2026-08-31).
+                    // resurrect a fake state-event time.
                     val kept = effectiveLastCache[key]
                     effectiveLastCache[key] = EffectiveLast(
                         serverLastId,
@@ -9364,8 +9209,7 @@ object MatrixRepository {
      * retryAtMs): an "[Encrypted]" preview is unresolved; the room is parked
      * (futile-restore cooldown) and retried only after the park expires. A
      * real session arrival decrypts in-band and re-resolves it via the room's
-     * state change, so short retries just burn CPU on rooms that can't decrypt
-     * (battery 2026-08-17 audit).
+     * state change, so short retries just burn CPU on rooms that can't decrypt.
      */
     private suspend fun resolveRoomPreview(
         c: MatrixClient,
@@ -9391,7 +9235,7 @@ object MatrixRepository {
         val encrypted = text.startsWith("[Encrypted")
         // DMs and broadcast channels (you + the channel ghost) don't need a
         // sender prefix — Beeper never marks Telegram channel rooms as direct,
-        // so the same ≤2-member test as the room list applies (2026-08-28).
+        // so the same ≤2-member test as the room list applies.
         // Channel echoes also bake your own name into the body ("FENN: post"),
         // stripped here so the preview shows the post itself.
         val broadcast = room.isDirect || (room.joinedMemberCount ?: 0L) <= 2L
@@ -9414,7 +9258,7 @@ object MatrixRepository {
     }
 
     /**
-     * Drops stale community-room duplicates (LP3 2026-09-01): when the
+     * Drops stale community-room duplicates: when the
      * WhatsApp number changed, Beeper re-created community groups under new
      * rooms; the old rooms linger outside the community sub-space (no
      * [community] label) with the same name as the live group, their timeline
@@ -9440,9 +9284,8 @@ object MatrixRepository {
     }
 
     /** Publishes the cache as the sorted, SDK-shaped list (and persists it).
-     *  Pinned rooms float to the top (Beeper convention — the m.favourite tag;
-     *  LP3 2026-08-29: a pinned DM sorted to the bottom by recency and read as
-     *  "missing"), then newest-first. */
+     *  Pinned rooms float to the top (Beeper convention — the m.favourite tag),
+     *  then newest-first. */
     private fun publishRoomList() {
         val rooms = hideStaleCommunityDuplicates(roomListCache.values.map { it.room })
             .sortedWith(
@@ -9467,7 +9310,7 @@ object MatrixRepository {
     // --- internals -----------------------------------------------------------
 
     /**
-     * Phase-0 latency timer (SYNC-PERF-SPEC.md): elapsed-realtime of the last
+     * latency timer (SYNC-PERF-SPEC.md): elapsed-realtime of the last
      * /sync HTTP response completion — the start of the "sync processed"
      * ingest measurement at the sync event subscriber. Set unconditionally
      * (one volatile write per sync round); the log that reads it is
@@ -9487,14 +9330,13 @@ object MatrixRepository {
      */
     private fun httpLoggingInterceptor(): okhttp3.Interceptor = okhttp3.Interceptor { chain ->
         // /sync size + duration — one log line per sync, always on. The per-sync
-        // cost is the battery metric for whether the sync is lean enough
-        // (battery 2026-08-17 audit; no body buffering — this must stay cheap).
+        // cost is the battery metric for whether the sync is lean enough.
         val path = chain.request().url.encodedPath
         if (path.contains("/sync")) {
             // A new /sync request proves the previous round's ingest finished
             // (Trixnity processes rounds sequentially) — sync-ingest gate.
             syncRoundEndedAt = android.os.SystemClock.elapsedRealtime()
-            // Ingest-gap attribution (LP3 2026-09-06 verify stall): the time
+            // Ingest-gap attribution: the time
             // between the last response arriving and this next request is the
             // previous round's emit/ingest. Normally ≈ instant; when it blows
             // past one long-poll period the emit path (e.g. Trixnity's inline
@@ -9519,7 +9361,7 @@ object MatrixRepository {
             )
             return@Interceptor response
         }
-        // Off by default (efficiency audit 2026-08-14): the body buffering +
+        // Off by default (efficiency ): the body buffering +
         // UTF-8 conversion ran on every request, 24/7, logging multi-KB megolm
         // ciphertexts. Live-read, so the debugLog toggle applies immediately.
         if (!debugLogging()) return@Interceptor chain.proceed(chain.request())
@@ -9605,15 +9447,14 @@ object MatrixRepository {
         addInterceptor(claimFailuresFixInterceptor)
     }.also { android.util.Log.d(TAG, "HTTP-TRAFFIC: generic engine armed") }
 
-    // Steady-state sync filters. Sync payload slimming (PLAN §8.1,
-    // 2026-08-28): the default filter ships every presence update + a huge
+    // Steady-state sync filters. Sync payload slimming (PLAN §8.1):
+    // the default filter ships every presence update + a huge
     // per-room timeline on the 1284-room account (30-50 s CPU per /sync).
     // Presence is never displayed — set_presence=offline only stops OUR
     // updates, this filter stops receiving theirs — and the timeline limit
-    // bounds each room's per-sync window. Trixnity's applyDefaultFilter()
+    // bounds each room's per-sync window. Trixnity's applyDefaultFilter
     // merges over it, keeping lazy-load members + the event-type whitelists.
-    //
-    // Ephemeral slimming (2026-08-31): applyDefaultFilter REPLACES types with
+    // Ephemeral slimming: applyDefaultFilter REPLACES types with
     // its own whitelist, so narrowing must go through notTypes, which
     // survives the merge. Nothing renders incoming typing (the composer only
     // sends it), and it is the noisiest per-sync element in active rooms —
@@ -9629,14 +9470,13 @@ object MatrixRepository {
         ),
     )
 
-    // SYNC-PERF-SPEC §Phase 1 lever 3, partially reverted (LP3 2026-09-06):
-    // this filter once stripped room state (`state = notTypes="*"`). That is
-    // only safe while the DB already holds state from an earlier initial
-    // sync — but the initial sync can run under THIS filter: the
+    // SYNC-PERF-SPEC §Phase 1 lever 3 (without the room-state strip):
+    // stripping room state (`state = notTypes="*"`) is only safe while the
+    // DB already holds state from an earlier initial sync — but the initial
+    // sync can run under THIS filter: the
     // verification-phase swap nulls the batch token, and a slow-sync round /
-    // push wake can win the queue and consume the one-shot initial sync
-    // (measured: 302 rooms × 20-timeline stored, zero m.room.name/create/
-    // power_levels → every room "Chat" forever, LP3 2026-09-06). State
+    // push wake can win the queue and consume the one-shot initial sync.
+    // State
     // DELTAS in background rounds are rare (name/membership changes) — keep
     // state here so an initial sync is always correct. The ephemeral
     // slimming (m.typing/m.receipt) stays. Invites are unaffected:
@@ -9651,7 +9491,7 @@ object MatrixRepository {
 
     /**
      * Verification-phase variant of both sync filters (verification-first
-     * sync, LP3 2026-09-06): a fresh login that will run device verification
+     * sync): a fresh login that will run device verification
      * must not let the initial sync outrun the SAS emoji round-trips. Under
      * the full background filter the initial sync ingests 6902 events (301
      * rooms × 20 timeline + state) over ~180 s of serialized emit, and the
@@ -9688,7 +9528,7 @@ object MatrixRepository {
         // Verification-first sync: a login that will verify (see
         // [pendingVerificationPhase]) builds with the slim filters on BOTH the
         // long-poll and the background/initial filter — measured 6902-event /
-        // 180 s initial ingest on a fresh install (LP3 2026-09-06), with the
+        // 180 s initial ingest on a fresh install, with the
         // SAS emoji stuck behind it. The swap back to the full set happens in
         // [swapToFullSync] once the verification outcome is known.
         syncFilter = if (pendingVerificationPhase) verificationSyncFilters else fullSyncFilters
@@ -9839,7 +9679,7 @@ object MatrixRepository {
     }
 
     /**
-     * Background key-request trigger (2026-09-01, Beeper cross-check): Beeper's
+     * Background key-request trigger: Beeper's
      * core asks its own devices for missing megolm sessions the moment a sync
      * round leaves an event undecryptable; we only requested on page open (see
      * [requestMissingRoomKeys]). Subscribes to the sync event emitter — the same
@@ -9859,7 +9699,7 @@ object MatrixRepository {
                         ClientEvent.RoomEvent<EncryptedMessageEventContent.MegolmEncryptedMessageEventContent>
                     > { events ->
                         runCatching {
-                            // Phase-0 latency timer (SYNC-PERF-SPEC.md): HTTP response
+                            // latency timer (SYNC-PERF-SPEC.md): HTTP response
                             // → our visibility of the round's decrypted events ≈ the
                             // ingest cost the 17–30 s model attributes to hop 1.
                             if (debugLogging()) {
@@ -9961,9 +9801,8 @@ object MatrixRepository {
 
     /**
      * The "[Message unsent]" tombstone row for a redacted message event (Phase
-     * C, 2026-09-03): id/sender/name/time preserved so the row stays in its
-     * conversation slot, rendered like a normal text row (LP3 feedback
-     * 2026-09-03). Reactions/status/read never apply to a redacted event.
+     * C): id/sender/name/time preserved so the row stays in its
+     * conversation slot, rendered like a normal text row. Reactions/status/read never apply to a redacted event.
      */
     private suspend fun redactedRow(
         c: MatrixClient,
@@ -10003,27 +9842,27 @@ object MatrixRepository {
             // A bridge media edit (m.replace) rewrites a pending m.notice into
             // the real m.image/m.video/m.audio — classify the row from the
             // edit's new content, or it stays a system line wearing the edited
-            // file name (gmessages, 2026-09-03). Text edits keep the original
+            // file name (gmessages). Text edits keep the original
             // classification (their body swap rides on [editedBody]).
             (editedContent as? RoomMessageEventContent.FileBased) ?: orig
         }
         // Edit events (m.replace) never become a row — they REPLACE their
         // target, and the target row is rebuilt with the edited body + the
-        // edited flag by [computeMessagesPage] (feedback 2026-08-27). Beeper's
+        // edited flag by [computeMessagesPage]. Beeper's
         // re-import edits target originals we never sync (whatsapp.com bridge
         // rooms), so un-matched edits still render as nothing here.
         if (isReplaceEdit(te)) return null
         // A WhatsApp forward's "↷ Forwarded" header (stripForwardHeader) is
         // lifted out of the body; the flag makes the tool render it as a small
-        // chip above the content (2026-09-02). Text rows report it here; media
+        // chip above the content. Text rows report it here; media
         // rows carry it on their caption (a forwarded photo's caption IS the
         // bare header).
         var forwarded = false
         val (body, contentType) = when (content) {
             is RoomMessageEventContent.FileBased.Image ->
                 // The body is the row's fallback label, not the file name — a
-                // bare "IMG_0312.JPG" renders like a message (gmessages,
-                // 2026-09-03). Rows with no media uri at all can never fetch
+                // bare "IMG_0312.JPG" renders like a message (gmessages).
+                // Rows with no media uri at all can never fetch
                 // ("[Photo — unavailable]"); the rest get "[Photo]" when their
                 // bytes are missing.
                 (if (content.url.isNullOrBlank() && content.file?.url.isNullOrBlank())
@@ -10033,13 +9872,11 @@ object MatrixRepository {
             is RoomMessageEventContent.FileBased.Video ->
                 // A video (incl. WhatsApp animated GIFs, which arrive as
                 // m.video) renders as the "[Video]" marker — there's no
-                // playback — with its caption under it via [Message.caption]
-                // (feedback 2026-09-01: the caption alone lost the video
-                // context).
+                // playback — with its caption under it via [Message.caption].
                 "[Video]" to "text"
             is RoomMessageEventContent.FileBased.File ->
                 // RCS direct photos arrive as m.file with an image/* mimetype
-                // (feedback 2026-09-01) — render those as image rows so the
+                // — render those as image rows so the
                 // media actually fetches; other m.file stays a "[File]" row.
                 if (content.info?.mimeType?.startsWith("image/", ignoreCase = true) == true)
                     (if (content.url.isNullOrBlank() && content.file?.url.isNullOrBlank())
@@ -10050,15 +9887,15 @@ object MatrixRepository {
                 // messages", timer-set notices… — the mautrix bridge sends them
                 // as notices from the contact's own ghost, so sender can't
                 // distinguish them). The tool renders them as a small centered
-                // system line instead of a normal message (2026-08-22).
+                // system line instead of a normal message.
                 // A BLANK body renders nothing — the bridge's re-import copies
                 // (09:08 wall after a WhatsApp number change) resolve to empty
                 // text, and an empty bubble reads as "no messages" (LP3: the
                 // Lillian room). Drop them so the real conversation shows.
                 // The edited body (the m.new_content of an m.replace) replaces
-                // the original when the target is in the page (2026-08-27).
+                // the original when the target is in the page.
                 // Broadcast channels bake the user's own name into echoed posts
-                // ("FENN: post") — stripped when ownName is set (2026-08-28).
+                // ("FENN: post") — stripped when ownName is set.
                 val (stripped, fwd) = stripForwardHeader(stripReplyQuote(editedBody ?: content.body))
                 forwarded = fwd
                 val text = stripOwnPrefix(stripped, ownName)
@@ -10069,9 +9906,9 @@ object MatrixRepository {
         }
         // The media caption (the m.image / m.video body — most clients put the
         // caption there, separate from the file name). A caption that equals
-        // the file name is not a caption (feedback round 2026-08-19); neither
+        // the file name is not a caption; neither
         // is a bare file name — Signal's m.image body IS "image.jpg" with no
-        // caption (feedback 2026-08-27). A forwarded photo's caption is the
+        // caption. A forwarded photo's caption is the
         // bare "↷ Forwarded" header (or the header + a real caption) —
         // stripped here, and the forwarded flag carries the header to the
         // tool's chip.
@@ -10098,7 +9935,7 @@ object MatrixRepository {
             // more than two reaction tags (feedback 2026-09-02).
             reactions = collapseReactionTags(reactions),
             // The voice-note row shows the length + playing progress. Bridged
-            // notes often carry no info.duration (Signal — feedback 2026-08-27):
+            // notes often carry no info.duration (Signal — ):
             // fall back to the length measured at prefetch/play time.
             durationMs = (content as? RoomMessageEventContent.FileBased.Audio)?.let { audio ->
                 audio.info?.duration ?: voiceDurationMsByEvent[te.event.id.full]
@@ -10116,9 +9953,8 @@ object MatrixRepository {
 
     /** The sender's caption for a media message — the m.image / m.video body
      *  (most clients put the caption there, separate from the file name). A
-     *  caption that equals the file name is not a caption (feedback round
-     *  2026-08-19); neither is a bare file name — Signal's m.image body IS
-     *  "image.jpg" with no caption (feedback 2026-08-27). */
+     *  caption that equals the file name is not a caption; neither is a bare file name — Signal's m.image body IS
+     *  "image.jpg" with no caption. */
     private fun captionOf(file: RoomMessageEventContent.FileBased): String? =
         file.body.takeIf {
             it.isNotBlank() && it != file.fileName && !isBareFilename(it)
@@ -10173,16 +10009,14 @@ object MatrixRepository {
         }
         return when {
             // A genuinely undecryptable message renders as a single calm
-            // placeholder (2026-08-19 feedback round — was "[Encrypted —
-            // waiting for key…]" and "[Encrypted]" depending on the failure
-            // state; same meaning, one label).
+            // placeholder.
             // Two render paths: a real decrypt FAILURE shows it outright; a
             // still-PENDING decrypt (content unresolved, raw content still
             // m.room.encrypted) skips the row only while the event is young —
-            // new messages never flash the placeholder (feedback 2026-08-20).
+            // new messages never flash the placeholder.
             // Past [DECRYPT_PENDING_PLACEHOLDER_AFTER_MS] pending means stuck:
             // skipping the row froze older-page pagination and markRead behind
-            // the head (unread flag stuck — LP3 window 2026-09-06), so the
+            // the head (unread flag stuck — LP3 window), so the
             // placeholder renders and the row exists; a late-arriving key
             // re-renders it as real content.
             te.content?.isFailure == true -> "[Encrypted message]"
@@ -10204,7 +10038,7 @@ object MatrixRepository {
 
     /** Lifts a bridge "forwarded" header off a message body (WhatsApp forwards
      *  arrive as "↷ Forwarded" + a blank line + the content — the bridge's
-     *  text stand-in for WhatsApp's forward chip; 2026-09-02). Returns the
+     *  text stand-in for WhatsApp's forward chip;). Returns the
      *  content ("" when the message is nothing but the header — a forwarded
      *  photo's caption is just the marker) and whether the header was found.
      *  The tool renders the header itself as a small chip via [Message.forwarded],
@@ -10220,7 +10054,7 @@ object MatrixRepository {
 
     /** In broadcast rooms (you + the channel ghost) Beeper echoes your own
      *  channel posts back with your display name baked into the body ("FENN:
-     *  post" — Telegram channels, feedback 2026-08-28). Strip that redundant
+     *  post" — Telegram channels). Strip that redundant
      *  prefix; ownName is null outside broadcast rooms, so it's a no-op there.
      *  Not applied unconditionally: a group member writing "FENN: good point"
      *  must keep their words. */
@@ -10236,7 +10070,7 @@ object MatrixRepository {
     private const val SEND_STATUS_CACHE_TTL_MS = 15_000L
     /** Flood-context read TTL (see [ghostContext]): the density verdict can't
      *  change within seconds, so a message burst reuses the walk instead of
-     *  re-reading 250 events per event (battery 2026-08-17 audit). */
+     *  re-reading 250 events per event. */
     private const val FLOOD_CONTEXT_TTL_MS = 10_000L
     /** Rebuild the network map at most this often (space membership is stable). */
     private const val NETWORK_MAP_TTL_MS = 300_000L
@@ -10255,7 +10089,7 @@ object MatrixRepository {
     private const val BRIDGE_CONTACTS_BUDGET_MS = 5_000L
     /** Per-room budget for the flags walk ([roomFlagsByRoom]): one room's store
      *  reads + the archive network GET fit in this; a room that exceeds it
-     *  keeps its last-known flags instead of being dropped (2026-08-29). */
+     *  keeps its last-known flags instead of being dropped. */
     private const val ROOM_FLAGS_ROOM_BUDGET_MS = 2_000L
     /** Bump to force a fresh /sync filter upload + full initial sync once per
      *  account (see [migrateSyncFilterIfNeeded]) — e.g. when a new room
@@ -10265,10 +10099,7 @@ object MatrixRepository {
     private const val ROOMS_BUDGET_MS = 15_000L
     private const val ROOM_BUDGET_MS = 3_000L
     private const val MESSAGES_BUDGET_MS = 15_000L
-    /** Restore-scan cadence: at most one full crawl per day (battery/UX
-     *  2026-08-15 — it used to run on every process start and starve the app
-     *  for 20+ min on the bridged account; the on-demand page path still
-     *  restores when a room is actually read). */
+    /** Restore-scan cadence: at most one full crawl per day. */
     private const val RESTORE_INTERVAL_MS = 86_400_000L
     /** Per-room budget + window for the restore scan (the shared
      *  [MESSAGES_BUDGET_MS] / 100-event window is fine for reads, wasteful for
@@ -10278,11 +10109,10 @@ object MatrixRepository {
     private const val FETCH_TIMEOUT_SECONDS = 5L
     /** The thread's page size (matches the tool's PAGE_SIZE). */
     private const val THREAD_PAGE_SIZE = 20
-    /** Cold-open first page (2026-08-19 feedback round): a room with no cached
+    /** Cold-open first page: a room with no cached
      *  page opens with this many messages at once — fast, no decrypt/status
      *  work — while the background refresh fills the full page. 6 ≈ one
-     *  screenful on the LP3 thread (feedback 2026-08-23: "fast load on
-     *  initial show …"; tuned 8 → 6). */
+     *  screenful on the LP3 thread. */
     private const val INCREMENTAL_FIRST_PAGE = 6
     /** Max events the incremental refresh (PLAN §8.3) walks to find the
      *  last-refreshed chain head. A burst beyond this — or a lost boundary
@@ -10301,8 +10131,7 @@ object MatrixRepository {
     private const val MESSAGE_PAGE_TTL_MS = 5_000L
     /** Recompute the active room's cached newest page at this cadence. The
      *  tool's own poll (3s) hits the cache, so 30s is invisible — and the
-     *  refresh skips unchanged rooms entirely (battery audit 2026-08-15: was
-     *  2s, running 24/7 with no screen coupling — the drain's engine). */
+     *  refresh skips unchanged rooms entirely. */
     private const val ACTIVE_ROOM_REFRESH_MS = 30_000L
     private const val TYPING_TIMEOUT_MS = 30_000L
     private const val DECRYPT_RETRIES = 3
@@ -10312,7 +10141,7 @@ object MatrixRepository {
      *  path stops re-attempting for this long. Long on purpose — these rooms
      *  (pre-verification bridged history) essentially never get their sessions,
      *  and the short retries (60 s preview / 120 s ghost walk) burned ~3 cores
-     *  continuously (battery 2026-08-17 audit). In-band sync decryption is
+     *  continuously. In-band sync decryption is
      *  unaffected: a session arriving mid-park decrypts the room fresh. */
     private const val DECRYPT_RESTORE_COOLDOWN_MS = 14_400_000L
     private const val DECRYPT_WAIT_MS = 3_000L
@@ -10323,9 +10152,9 @@ object MatrixRepository {
      *  message]" instead of being skipped. Skipped rows freeze older-page
      *  pagination (the fetch returns the window, no row can render, the next
      *  scroll-up re-requests the same window) and park markRead behind the
-     *  head, so the room's unread flag never clears (LP3 window 2026-09-06).
+     *  head, so the room's unread flag never clears.
      *  Younger events keep the skip — live traffic never flashes the
-     *  placeholder (feedback 2026-08-20). */
+     *  placeholder. */
     private const val DECRYPT_PENDING_PLACEHOLDER_AFTER_MS = 60_000L
     /** markRead cold-start race: retries while Trixnity's room view loads its
      *  timeline (lastRelevantEventId null) before deciding the receipt. */
@@ -10343,10 +10172,8 @@ object MatrixRepository {
     /** Bounded wait for the homeserver ack of a send ([awaitOutboxAck]) —
      *  kept for voice sends only: the recording activity's "sending" state
      *  holds until the RPC returns, and caching the acked id keeps the
-     *  pending row from flickering back to SENDING (2026-09-02). Text sends
-     *  no longer wait (LP3 2026-09-05: "compose hangs then it sends" — the
-     *  optimistic row shows instantly anyway; slower acks confirm via the
-     *  sync echo). */
+     *  pending row from flickering back to SENDING. Text sends
+     *  no longer wait. */
     private const val SEND_ACK_WAIT_MS = 500L
     /** Poll cadence on the outbox row while awaiting the ack. */
     private const val SEND_ACK_POLL_INTERVAL_MS = 100L
@@ -10362,7 +10189,7 @@ object MatrixRepository {
     /** [resolveRoomName]'s dead-end fallback — a row showing this is NOT a
      *  resolved name and must be re-resolved on a later pass (heroes land
      *  with the full initial sync, after the slim-phase pass stamped "Chat"
-     *  as resolved forever, LP3 2026-09-06). */
+     *  as resolved forever). */
     private const val ROOM_NAME_FALLBACK = "Chat"
     /** Per-pass time budget; the resolver loops until the list is settled. */
     private const val ROOM_LIST_PASS_BUDGET_MS = 12_000L
@@ -10374,7 +10201,7 @@ object MatrixRepository {
      *  past the cap are still tracked/refreshed; a new message sorts them back
      *  into the served window. (Roadmap: search / a cap-raising page flow.) */
     private const val MAX_ROOMS_OVER_BINDER = 400
-    /** Resolver breather while the screen is off (battery 2026-08-15): the
+    /** Resolver breather while the screen is off: the
      *  live bridged account keeps the list dirty, so the 2s breather meant
      *  near-continuous passes overnight; the list only needs freshness for
      *  the next wake. */
@@ -10384,7 +10211,7 @@ object MatrixRepository {
     /** Per-room state collect in the resolver (the store cache emits instantly). */
     private const val ROOM_LIST_ROOM_BUDGET_MS = 500L
 
-    // Gap-marker backfill (PLAN §8, 2026-08-21): a `limited=true` sync stores a
+    // Gap-marker backfill (PLAN §8): a `limited=true` sync stores a
     // gap marker whose missing window Trixnity never fills — events created
     // during the missed window are silently absent from the store. The fill is
     // triggered by the page walk and bounded below so it can't burn battery.
@@ -10421,7 +10248,7 @@ object MatrixRepository {
     /** How long the daily crawl waits for the key-backup version to actually
      *  arrive before concluding there is no server-side backup (the flow emits
      *  null until the service's first fetch — a cold-start null read as "no
-     *  backup" stuck the account un-decryptable for a day, LP3 2026-09-06). */
+     *  backup" stuck the account un-decryptable for a day). */
     private const val KEY_BACKUP_VERSION_BUDGET_MS = 5_000L
     /** How long to wait for an m.secret.send answer after re-requesting the
      *  missing SSSS secrets (process-death recovery, LP3 2026-09-06). */
@@ -10443,7 +10270,7 @@ object MatrixRepository {
     private const val GHOST_FLOOD_THRESHOLD = 30
     /** Room-list effective-last walk cap (decrypted events). Was 800 — walks
      *  over that depth never completed inside [GHOST_WALK_BUDGET_MS] on the
-     *  LP3 (1284-room account, 2026-09-05), so rooms backed off instead of
+     *  LP3 (1284-room account), so rooms backed off instead of
      *  healing; 100 still spans any ack/reaction/re-import run. */
     private const val EFFECTIVE_LAST_WALK = 100
     /** In-path fast window — big enough to spot a >=[GHOST_FLOOD_THRESHOLD] flood. */
@@ -10451,14 +10278,14 @@ object MatrixRepository {
     /** How long a pending ghost-resolution is parked before the resolver retries. */
     private const val GHOST_WALK_RETRY_MS = 120_000L
     /** Backoff after a ghost walk times out (can't complete within its budget).
-     *  Was 4 h — with the head-time stamp (2026-09-05) the row no longer
+     *  Was 4 h — with the head-time stamp the row no longer
      *  depends on the walk for its timestamp, so 15 min keeps the heal cheap
      *  without a 4 h-stale row as the cost of a failed walk. */
     private const val GHOST_WALK_FAIL_BACKOFF_MS = 900_000L
     /** Bound for the effective-last decrypting walk (one-time per room, cached). */
     private const val GHOST_WALK_BUDGET_MS = 8_000L
 
-    // Media / photos (Phase 13).
+    // Media / photos.
     /**
      * Longest side (px) of the display JPEG served to the tool. Sized so the
      * base64-encoded payload stays comfortably inside the ~1 MB binder
@@ -10477,8 +10304,8 @@ object MatrixRepository {
     private const val MEDIA_CONTENT_RETRIES = 4
     private const val MEDIA_CONTENT_RETRY_DELAY_MS = 1_500L
     /** Consecutive voice-media download timeouts (network up) that mark the
-     *  shared HTTP engine wedged and trigger the in-process self-heal
-     *  (2026-09-02 — see [selfHealHttpStack]). */
+     *  shared HTTP engine wedged and trigger the in-process self-heal.
+     */
     private const val MEDIA_STALL_HEAL_THRESHOLD = 3
     /** Cooldown between HTTP-stack self-heals (a slow link must not churn). */
     private const val MEDIA_STALL_HEAL_MIN_INTERVAL_MS = 300_000L
@@ -10496,15 +10323,14 @@ object MatrixRepository {
      *  ("immediately after" — feedback 2026-08-27). */
     private const val VOICE_AUTO_ADVANCE_WINDOW_MS = 60_000L
     /** The tool's photo-picker activity, flattened for the tool to launch. The
-     *  package is the TOOL's own id — the single-APK merge (2026-08-19) made
+     *  package is the TOOL's own id — the single-APK merge made
      *  the former companion a library inside com.lightphone.chats, so the old
-     *  com.lightphone.chats.server package no longer resolves (feedback
-     *  2026-08-19: "mic and photos do not work"). */
+     *  com.lightphone.chats.server package no longer resolves. */
     private const val PHOTO_PICKER_ACTIVITY = "com.lightphone.chats/.server.PhotoSendActivity"
     /** The tool's voice-note recording activity, flattened for the tool. */
     private const val VOICE_NOTE_ACTIVITY = "com.lightphone.chats/.server.VoiceNoteActivity"
 
-    // Disk cache (Phase 14).
+    // Disk cache.
     // Versioned so a stale pre-ghost-filter cache (pages/lists polluted by the
     // bridge re-import) is never served after an upgrade.
     private const val DISK_CACHE_DIR = "chats_cache_v2"

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -115,6 +115,9 @@ import de.connect2x.trixnity.client.room
 import de.connect2x.trixnity.client.room.GetTimelineEventConfig
 import de.connect2x.trixnity.client.room.GetTimelineEventsConfig
 import de.connect2x.trixnity.client.room.TimelineEventHandler
+import de.connect2x.trixnity.client.room.MegolmRoomEventEncryptionService
+import de.connect2x.trixnity.client.room.RoomEventEncryptionService
+import de.connect2x.trixnity.client.room.TimelineEventHandlerImpl
 import de.connect2x.trixnity.client.room.message.image
 import de.connect2x.trixnity.client.room.message.reply
 import de.connect2x.trixnity.client.room.message.replace
@@ -124,6 +127,7 @@ import de.connect2x.trixnity.client.store.GlobalAccountDataStore
 import de.connect2x.trixnity.client.store.KeyStore
 import de.connect2x.trixnity.client.store.OlmCryptoStore
 import de.connect2x.trixnity.client.store.Room as MatrixRoom
+import de.connect2x.trixnity.client.store.RoomTimelineStore
 import de.connect2x.trixnity.client.store.StoredSecretKeyRequest
 import de.connect2x.trixnity.client.store.StoreTransactionManager
 import de.connect2x.trixnity.client.store.TimelineEvent
@@ -2385,17 +2389,35 @@ object MatrixRepository {
         limit: Int,
         gapEventId: String,
     ): Pair<List<TimelineEvent>, Boolean>? {
-        val ok = withTimeoutOrNull(GAP_BACKFILL_BUDGET_MS) {
+        // Cold Wi-Fi round-trips (headers + TLS + a 30-event page) blow the
+        // 8 s cellular budget — the LP3 2026-09-06 window failed fills with
+        // the cause invisible, so the budget is network-aware and the cause
+        // (exception vs timeout vs token) is logged now to decide the
+        // stale-token fallback.
+        val budget =
+            if (isOnCellularData()) GAP_BACKFILL_BUDGET_MS else GAP_BACKFILL_BUDGET_WIFI_MS
+        val failure: String = withTimeoutOrNull(budget) {
             runCatching {
-                c.di.get<TimelineEventHandler>()
+                // Trixnity registers this binding qualified
+                // (bind<TimelineEventHandler>(); named<TimelineEventHandlerImpl>())
+                // — an unqualified lookup throws "No definition found" and every
+                // backfill silently failed forever (LP3 2026-09-06, 'Daniel').
+                c.di.get<TimelineEventHandler>(
+                    org.koin.core.qualifier.named<TimelineEventHandlerImpl>(),
+                )
                     .unsafeFillTimelineGaps(EventId(gapEventId), matrixRoomId, GAP_BACKFILL_LIMIT)
                     .getOrThrow()
-                true
-            }.getOrDefault(false)
-        } ?: false
-        if (!ok) {
+            }.fold(
+                onSuccess = { return@withTimeoutOrNull "" },
+                onFailure = { it.message ?: it::class.simpleName ?: "error" },
+            )
+        } ?: "timeout after ${budget / 1000}ms"
+        if (failure.isNotEmpty()) {
             parkGapBackfill(matrixRoomId)
-            android.util.Log.d(TAG, "gap backfill failed for $matrixRoomId — retrying in ${GAP_BACKFILL_COOLDOWN_MS / 1000}s")
+            android.util.Log.d(
+                TAG,
+                "gap backfill failed for $matrixRoomId ($failure) — retrying in ${GAP_BACKFILL_COOLDOWN_MS / 1000}s",
+            )
             return null
         }
         // The store now holds the missing window — re-walk the chain.
@@ -2674,8 +2696,9 @@ object MatrixRepository {
     /**
      * Quiet-room guard patch: recomputes the cached page's parts that don't
      * move the room's last event id — read receipts (sync ephemeral, feedback
-     * 2026-08-30) and reaction tags (see [patchReactionTags]). null when
-     * neither changed, so the caller keeps the cache and disk as-is.
+     * 2026-08-30), reaction tags (see [patchReactionTags]) and send-status tags
+     * (see [patchSendStatuses]). null when none changed, so the caller keeps
+     * the cache and disk as-is.
      */
     private suspend fun patchQuietPage(
         c: MatrixClient,
@@ -2689,7 +2712,34 @@ object MatrixRepository {
                 receiptPatched?.let { MessagePageEntry(it, cached.limit, cached.refreshedAtMs) } ?: cached,
             )
         }.getOrNull()
-        return tagPatched ?: receiptPatched
+        val tagEntry = tagPatched?.let { MessagePageEntry(it, cached.limit, cached.refreshedAtMs) } ?: cached
+        val statusPatched = runCatching { patchSendStatuses(c, roomId, tagEntry) }.getOrNull()
+        return statusPatched ?: tagPatched ?: receiptPatched
+    }
+
+    /**
+     * Recomputes a cached newest page's send-status tags ("SENDING" →
+     * "delivered"). The bridge's ack is its own timeline event: the incremental
+     * refresh that consumed it may have read a stale [sendStatusesByEventIdCached]
+     * map (15 s TTL) and baked SENDING into the rows, after which the room is
+     * quiet — the head never moves again, and the quiet ticks that patch
+     * receipts/reactions never re-read statuses, so the tag sat until the room
+     * was reopened or another message landed (LP3 feedback 2026-09-06). The
+     * map TTL bounds how long the patch trails the ack.
+     */
+    private suspend fun patchSendStatuses(
+        c: MatrixClient,
+        roomId: String,
+        cached: MessagePageEntry,
+    ): MessagesPage? {
+        val sendStatuses = sendStatusesByEventIdCached(c, RoomId(roomId))
+        if (sendStatuses.isEmpty()) return null
+        var changed = false
+        val patched = cached.page.messages.map { m ->
+            sendStatuses[m.id]?.takeIf { it != m.sendStatus }?.let { changed = true; m.copy(sendStatus = it) } ?: m
+        }
+        if (!changed) return null
+        return MessagesPage(patched, cached.page.hasMore, cached.page.encrypted)
     }
 
     /**
@@ -3201,7 +3251,20 @@ object MatrixRepository {
         // full-page refresh resolves them; the fast page may briefly show
         // "[Encrypted message]" placeholders instead of a long loading state.
         if (!fast) {
-            val undecrypted = events.filter { it.content?.isFailure == true }
+            val undecrypted = events.filter {
+                it.content?.isFailure == true ||
+                    // Decrypt never ATTEMPTED (content unresolved) counts too —
+                    // the LP3's stuck rows are exactly this class, and the old
+                    // failure-only filter kept them away from the key-backup
+                    // restore forever (drive 3, 2026-09-06: key requests fired,
+                    // backup never consulted). Age-gated like the placeholder:
+                    // young pending events decrypt in-band; only stuck ones
+                    // justify the backup round-trip.
+                    (it.content == null &&
+                        it.event.content is EncryptedMessageEventContent &&
+                        System.currentTimeMillis() - it.event.originTimestamp >
+                            DECRYPT_PENDING_PLACEHOLDER_AFTER_MS)
+            }
             if (undecrypted.isNotEmpty()) {
                 // Battery (2026-08-15 audit): events that can't decrypt (e.g.
                 // pre-verification history — the bridge never re-shares those
@@ -4431,6 +4494,7 @@ object MatrixRepository {
         matrixRoomId: RoomId,
         events: List<TimelineEvent>,
     ): Int {
+        val sessionToEvents = HashMap<String, MutableList<TimelineEvent>>()
         val sessionIds = events.mapNotNull { te ->
             // Only events that failed to decrypt need a key-backup restore:
             // already-resolved events have their megolm session in the local
@@ -4440,7 +4504,10 @@ object MatrixRepository {
             // nothing needed restoring.
             val content = te.content
             if (content?.getOrNull() != null) null
-            else (te.event.content as? EncryptedMessageEventContent.MegolmEncryptedMessageEventContent)?.sessionId
+            else (te.event.content as? EncryptedMessageEventContent.MegolmEncryptedMessageEventContent)
+                ?.sessionId?.also { sid ->
+                    sessionToEvents.getOrPut(sid) { mutableListOf() }.add(te)
+                }
         }.distinct()
         android.util.Log.d(TAG, "restoreRoomSessions: $matrixRoomId — ${events.size} events, ${sessionIds.size} megolm sessions, " +
             "encrypted classes: ${events.map { it.event.content::class.simpleName }.distinct()}")
@@ -4459,12 +4526,42 @@ object MatrixRepository {
             return 0
         }
         var loaded = 0
+        val timelineStore = c.di.get<RoomTimelineStore>()
+        val tm = c.di.get<StoreTransactionManager>()
+        val encryptionService = c.di.get<RoomEventEncryptionService>(
+            org.koin.core.qualifier.named<MegolmRoomEventEncryptionService>(),
+        )
         sessionIds.forEach { sessionId ->
             try {
                 val ok = withTimeoutOrNull(KEY_BACKUP_LOAD_TIMEOUT_MS) {
                     keyBackup.loadMegolmSession(matrixRoomId, sessionId)
                 }
-                if (ok != null) loaded++ else {
+                if (ok != null) {
+                    loaded++
+                    // Re-decrypt + re-persist: getTimelineEvent only reads the
+                    // store's cached result, so a freshly loaded session never
+                    // reaches the stored rows through it (drive 5, 2026-09-06:
+                    // loaded 1/1, then 49/50 events still stuck). Run the megolm
+                    // service directly and write the result back.
+                    var resolved = 0
+                    val sessionEvents = sessionToEvents[sessionId].orEmpty()
+                    sessionEvents.forEach { te ->
+                        val messageEvent = te.event as? ClientEvent.RoomEvent.MessageEvent<*>
+                        if (messageEvent == null) return@forEach
+                        val decrypted = runCatching { encryptionService.decrypt(messageEvent) }
+                            .getOrNull()?.getOrNull() ?: return@forEach
+                        tm.writeTransaction {
+                            timelineStore.update(te.event.id, matrixRoomId) { old ->
+                                old?.copy(content = Result.success(decrypted))
+                            }
+                        }
+                        resolved++
+                    }
+                    android.util.Log.d(
+                        TAG,
+                        "restoreRoomSessions: re-decrypted $resolved/${sessionEvents.size} events for $matrixRoomId / $sessionId",
+                    )
+                } else {
                     android.util.Log.w(TAG, "restoreRoomSessions: loadMegolmSession timed out for $matrixRoomId / $sessionId")
                 }
             } catch (e: Exception) {
@@ -6125,7 +6222,10 @@ object MatrixRepository {
     }
 
     suspend fun markRead(roomId: String, eventId: String) {
-        val c = client ?: return
+        val c = client ?: run {
+            android.util.Log.w(TAG, "markRead: room=$roomId — no client, dropped")
+            return
+        }
         val matrixRoomId = RoomId(roomId)
         // Mark at the event the tool asked for — the newest message it actually
         // rendered. The old behavior bumped the marker to the store's current
@@ -6138,14 +6238,65 @@ object MatrixRepository {
         // thread's quiet poll re-marks at the real newest once the page (and
         // the user's screen) catch up. Only a marker that IS the room's head
         // message keeps the optimistic badge clear below.
-        val room = withTimeoutOrNull(ROOM_BUDGET_MS) {
+        var room = withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getById(matrixRoomId).firstOrNull()
         }
-        val atHead = eventId == room?.lastRelevantEventId?.full
+        // Cold-start race: getById can return the room before Trixnity has
+        // loaded its timeline view — lastRelevantEventId null (LP3 drive 4,
+        // 2026-09-06: Rewrites marked read head=null 2 ms after open; the
+        // quiet poll's rendered id never changes, so the receipt stayed
+        // behind the head forever and the badge never cleared). Give the
+        // head a short bounded window to resolve before deciding.
+        var headResolveWaits = 0
+        while (room?.lastRelevantEventId == null &&
+            headResolveWaits < HEAD_RESOLVE_RETRIES
+        ) {
+            kotlinx.coroutines.delay(HEAD_RESOLVE_RETRY_MS)
+            room = withTimeoutOrNull(ROOM_BUDGET_MS) {
+                c.room.getById(matrixRoomId).firstOrNull()
+            }
+            headResolveWaits++
+        }
+        val headId = room?.lastRelevantEventId
+        var atHead = eventId == headId?.full
+        var markerId = eventId
+        // Head that never resolves at all: this room's Trixnity timeline view
+        // doesn't load (Rewrites, LP3 2026-09-06 — null even 18 s into a fresh
+        // process, across restarts, while every other room resolves instantly).
+        // The receipt still goes out at the rendered row; without the clear the
+        // badge could never clear by design. Clear optimistically — the
+        // suppression lifts as soon as a newer message arrives ([servedUnread]),
+        // so nothing newer is ever silently marked seen.
+        if (headId == null) {
+            android.util.Log.w(
+                TAG,
+                "markRead: room=$matrixRoomId — head unresolved after $headResolveWaits retries; clearing badge optimistically",
+            )
+            atHead = true
+        }
+        // A head that can never render a row (blank re-import copy, edit,
+        // still-young pending decrypt) pins the receipt one row behind the
+        // head forever: the tool marks read at the newest rendered row and
+        // the quiet poll never advances (the rendered id never changes),
+        // while both our atHead check and Trixnity's notification clear need
+        // an exact head match (LP3 2026-09-06: "1 euro film - Rewrites"
+        // unread never cleared). Snap the receipt to the head in that case —
+        // nothing rendered sits above the marker, so no message is marked
+        // seen that the user could have read.
+        if (!atHead && headId != null && headNeverRenders(c, matrixRoomId, headId)) {
+            markerId = headId.full
+            atHead = true
+        }
+        // Ungated on purpose: one line per thread open, and the debugLog flag
+        // keeps being off exactly when this path needs debugging (LP3 2026-09-06).
+        android.util.Log.d(
+            TAG,
+            "markRead: room=$matrixRoomId at=$eventId head=${headId?.full} marker=$markerId atHead=$atHead",
+        )
         c.api.room.setReadMarkers(
             roomId = matrixRoomId,
-            fullyRead = EventId(eventId),
-            read = EventId(eventId),
+            fullyRead = EventId(markerId),
+            read = EventId(markerId),
         )
         // Opening the thread makes the room's notification moot.
         appContext?.let { ChatNotifier.cancelRoom(it, roomId) }
@@ -6156,7 +6307,7 @@ object MatrixRepository {
             // used to leave the badge up long after the thread was opened. The
             // resolver keeps serving 0 until the echo confirms or a newer
             // event arrives ([servedUnread]).
-            pendingReadClear[roomId] = eventId to
+            pendingReadClear[roomId] = markerId to
                 (room?.lastRelevantEventTimestamp?.toEpochMilliseconds() ?: 0L)
             roomListCache[roomId]?.let { entry ->
                 if (entry.room.unreadCount > 0) {
@@ -6166,6 +6317,31 @@ object MatrixRepository {
                 }
             }
             markRoomListDirty()
+        }
+    }
+
+    /** True when the head event can never produce a rendered row (i.e.
+     *  [messageFrom] returns null for it however often it is fetched):
+     *  m.replace edits, blank-body re-import copies, and pending decryptions
+     *  still inside the no-flash skip window. Used by [markRead] to decide
+     *  whether the receipt may snap to the head (see the call site). */
+    private suspend fun headNeverRenders(
+        c: MatrixClient,
+        matrixRoomId: RoomId,
+        headId: EventId,
+    ): Boolean {
+        val te = withTimeoutOrNull(ROOM_BUDGET_MS) {
+            c.room.getTimelineEvent(matrixRoomId, headId).firstOrNull()
+        } ?: return false
+        return when (val content = te.content?.getOrNull()) {
+            is RoomMessageEventContent.TextBased ->
+                stripForwardHeader(stripReplyQuote(content.body)).first.isBlank()
+            null ->
+                isReplaceEdit(te) ||
+                    (te.event.content is EncryptedMessageEventContent &&
+                        System.currentTimeMillis() - te.event.originTimestamp <=
+                        DECRYPT_PENDING_PLACEHOLDER_AFTER_MS)
+            else -> isReplaceEdit(te)
         }
     }
 
@@ -9450,15 +9626,22 @@ object MatrixRepository {
             // A genuinely undecryptable message renders as a single calm
             // placeholder (2026-08-19 feedback round — was "[Encrypted —
             // waiting for key…]" and "[Encrypted]" depending on the failure
-            // state; same meaning, one label). Only a real decrypt FAILURE
-            // shows it: an event whose decrypt is still pending (content
-            // unresolved, raw content still m.room.encrypted) returns null,
-            // so the thread skips the row and it appears once decrypted —
-            // new messages no longer flash "[Encrypted message]" for a poll
-            // (feedback 2026-08-20: "new messages come through as [encrypted
-            // message] and are decrypted shortly after").
+            // state; same meaning, one label).
+            // Two render paths: a real decrypt FAILURE shows it outright; a
+            // still-PENDING decrypt (content unresolved, raw content still
+            // m.room.encrypted) skips the row only while the event is young —
+            // new messages never flash the placeholder (feedback 2026-08-20).
+            // Past [DECRYPT_PENDING_PLACEHOLDER_AFTER_MS] pending means stuck:
+            // skipping the row froze older-page pagination and markRead behind
+            // the head (unread flag stuck — LP3 window 2026-09-06), so the
+            // placeholder renders and the row exists; a late-arriving key
+            // re-renders it as real content.
             te.content?.isFailure == true -> "[Encrypted message]"
-            else -> null
+            else ->
+                if (System.currentTimeMillis() - te.event.originTimestamp >
+                    DECRYPT_PENDING_PLACEHOLDER_AFTER_MS &&
+                    te.event.content is EncryptedMessageEventContent
+                ) "[Encrypted message]" else null
         }
     }
 
@@ -9586,6 +9769,19 @@ object MatrixRepository {
     private const val DECRYPT_WAIT_MS = 3_000L
     /** Peek budget for events after the first one failed to decrypt. */
     private const val QUICK_DECRYPT_WAIT_MS = 100L
+    /** Older than this at render time, a still-PENDING decrypt (content never
+     *  resolved) is stuck, not transient: the row renders as "[Encrypted
+     *  message]" instead of being skipped. Skipped rows freeze older-page
+     *  pagination (the fetch returns the window, no row can render, the next
+     *  scroll-up re-requests the same window) and park markRead behind the
+     *  head, so the room's unread flag never clears (LP3 window 2026-09-06).
+     *  Younger events keep the skip — live traffic never flashes the
+     *  placeholder (feedback 2026-08-20). */
+    private const val DECRYPT_PENDING_PLACEHOLDER_AFTER_MS = 60_000L
+    /** markRead cold-start race: retries while Trixnity's room view loads its
+     *  timeline (lastRelevantEventId null) before deciding the receipt. */
+    private const val HEAD_RESOLVE_RETRIES = 6
+    private const val HEAD_RESOLVE_RETRY_MS = 500L
     /** Quiet-guard reaction patch (see [patchReactionTags]): unresolved events
      *  API-resolved per pass, and the backoff after a pass that resolved none. */
     private const val REACTION_RESOLVE_MAX = 2
@@ -9642,6 +9838,8 @@ object MatrixRepository {
     private const val GAP_BACKFILL_LIMIT = 30L
     /** A fill must complete within this (the sync-aware retry can back off long). */
     private const val GAP_BACKFILL_BUDGET_MS = 8_000L
+    /** Wi-Fi fill budget — cold round-trips regularly exceed the cellular one. */
+    private const val GAP_BACKFILL_BUDGET_WIFI_MS = 20_000L
     /** After a failed/blocked fill, back off this long before retrying. */
     private const val GAP_BACKFILL_COOLDOWN_MS = 300_000L
     /** Delay before stopping the sync service after an expiry detection. */

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
@@ -1385,6 +1386,22 @@ object MatrixRepository {
      * on [BEEPER_HOMESERVER] — WhatsApp via Beeper's own bridges. Requires a
      * prior [beeperRequestCode] call (its request id is consumed here).
      */
+    /**
+     * Login wrappers projecting to [Result]`<Unit>` (NO-SEAM, 2026-09-07):
+     * the tool module can't see Trixnity's MatrixClient (:server hides its
+     * deps), so the direct caller maps the response from
+     * [lastLoginUserId]/[lastLoginDeviceId]/[lastLoginNeedsVerification].
+     */
+    suspend fun loginAsUnit(
+        homeserver: String,
+        user: String,
+        passwordOrToken: String,
+        tokenLogin: Boolean,
+    ): Result<Unit> = login(homeserver, user, passwordOrToken, tokenLogin).map { }
+
+    suspend fun beeperLoginAsUnit(email: String, code: String): Result<Unit> =
+        beeperLogin(email, code).map { }
+
     suspend fun beeperLogin(email: String, code: String): Result<MatrixClient> = runCatching {
         val ctx = appContext ?: error("companion not initialized")
         initMutex.withLock {
@@ -1492,6 +1509,11 @@ object MatrixRepository {
             // trusted) — leave the verification-phase slim sync immediately.
             swapToFullSync()
         }
+        // Identity the tool's login responses project (NO-SEAM: the tool module
+        // can't see Trixnity's MatrixClient — :server hides its deps — so the
+        // direct ChatClient mapping reads these instead of the client object).
+        lastLoginUserId = newClient.userId.full
+        lastLoginDeviceId = newClient.deviceId
         return newClient
     }
 
@@ -1521,6 +1543,16 @@ object MatrixRepository {
      *  `needsVerification` to the SetAccount/SetBeeperAccount responses. */
     @Volatile
     var lastLoginNeedsVerification: Boolean = false
+        private set
+
+    /** The last finished login's identity (see the NO-SEAM note in
+     *  [finishLogin]) — null until a login completes in this process. */
+    @Volatile
+    var lastLoginUserId: String? = null
+        private set
+
+    @Volatile
+    var lastLoginDeviceId: String? = null
         private set
 
     /**
@@ -5179,6 +5211,28 @@ object MatrixRepository {
         // "Loading messages…" because the send had dropped the cache).
         // Fetch the echo + refresh the panel even in slow-sync mode (screen off).
         wakeAfterSend(matrixRoomId.full)
+        // NO-SEAM (2026-09-07): the thread no longer polls — it reacts to page
+        // bumps. The send-time bump fires BEFORE the homeserver ack, so the row
+        // sat "SENDING" until the sync echo's page rebuild landed — starved for
+        // ~95 s under the post-attach crawl (LP3 2026-09-07 probe: send at
+        // 13:12:09, echo served 13:13:44). Watch the outbox row and bump at the
+        // ack: the serve-time [pendingEchoRow] then renders the real event id
+        // (sent) from the SAME cached page — no rebuild needed.
+        scope.launch {
+            var lastAcked = false
+            repeat(120) {
+                delay(250)
+                val om = runCatching {
+                    c.room.getOutbox(matrixRoomId, txnId).first()
+                }.getOrNull() ?: return@launch
+                val acked = om.eventId != null || om.sendError != null
+                if (acked != lastAcked) {
+                    lastAcked = acked
+                    bumpMessagePageRevision(matrixRoomId.full)
+                }
+                if (acked) return@launch
+            }
+        }
         android.util.Log.d(TAG, "SendMessage: room=$roomId txn=$txnId body=$body")
         // No composer hold for the homeserver ack: the thread's pending-row
         // machinery (optimistic injection via bumpMessagePageRevision + the
@@ -6637,10 +6691,11 @@ object MatrixRepository {
             // notification count only drops after the read-marker echo
             // round-trips through sync (a full tick on a big account), which
             // used to leave the badge up long after the thread was opened. The
-            // resolver keeps serving 0 until the echo confirms or a newer
-            // event arrives ([servedUnread]).
-            pendingReadClear[roomId] = markerId to
-                (room?.lastRelevantEventTimestamp?.toEpochMilliseconds() ?: 0L)
+            // resolver keeps serving 0 until GENUINELY newer activity arrives
+            // ([servedUnread]; markedTs = wall clock of this mark — the marker
+            // id may be a snapped unrenderable head the room's relevant head
+            // equals immediately, which disarmed the old id-match check).
+            pendingReadClear[roomId] = markerId to System.currentTimeMillis()
             roomListCache[roomId]?.let { entry ->
                 if (entry.room.unreadCount > 0) {
                     val cleared = entry.copy(room = entry.room.copy(unreadCount = 0))
@@ -6665,16 +6720,28 @@ object MatrixRepository {
         val te = withTimeoutOrNull(ROOM_BUDGET_MS) {
             c.room.getTimelineEvent(matrixRoomId, headId).firstOrNull()
         } ?: return false
-        return when (val content = te.content?.getOrNull()) {
-            is RoomMessageEventContent.TextBased ->
-                stripForwardHeader(stripReplyQuote(content.body)).first.isBlank()
-            null ->
-                isReplaceEdit(te) ||
-                    (te.event.content is EncryptedMessageEventContent &&
-                        System.currentTimeMillis() - te.event.originTimestamp <=
-                        DECRYPT_PENDING_PLACEHOLDER_AFTER_MS)
-            else -> isReplaceEdit(te)
-        }
+        // A JUST-arrived undecrypted message must not be snapped over: its
+        // placeholder clears once it decrypts, and marking it read would hide
+        // a message the user never saw. Older undecryptables fall through to
+        // the render check below.
+        val content = te.content?.getOrNull()
+        if (content == null &&
+            te.event.content is EncryptedMessageEventContent &&
+            System.currentTimeMillis() - te.event.originTimestamp <=
+            DECRYPT_PENDING_PLACEHOLDER_AFTER_MS
+        ) return false
+        // General rule (2026-09-07): a head that produces no rendered row —
+        // bridge delivery-status events, reactions, polls the tool can't
+        // render, edits, blank re-import copies — can never receive the
+        // receipt marker, so the badge stays up forever (LP3: the 1€ FILM
+        // rooms' heads are reactions / an unrenderable poll). Snap the
+        // receipt to the head instead. The sentinel distinguishes "renders
+        // nothing" from a budget timeout (timeout = keep the old marker).
+        val notRendered = Any()
+        val row = runCatching {
+            withTimeoutOrNull(ROOM_BUDGET_MS) { messageFrom(c, matrixRoomId, te) ?: notRendered }
+        }.getOrNull()
+        return row === notRendered
     }
 
     suspend fun setTyping(roomId: String, active: Boolean) {
@@ -7162,6 +7229,13 @@ object MatrixRepository {
                                                 }
                                             }
                                             wakeRoomList()
+                                            // NO-SEAM (2026-09-07): the open thread no longer
+                                            // long-polls the page revision — it rides the
+                                            // pageChanges signal, so an arrival in the ACTIVE
+                                            // room must refresh its page cache NOW (notifyForEvent
+                                            // skips the active room; the active-room tick is only
+                                            // a 30 s backstop). Cheap when nothing changed.
+                                            if (activeRoomId == key) refreshMessagePage(key)
                                             notifyForEvent(c, roomId, lastId, updated)
                                         }
                                     }
@@ -7399,6 +7473,14 @@ object MatrixRepository {
     private val _roomList = MutableStateFlow<List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room>>(emptyList())
 
     /**
+     * The live room census (newest-first) as a flow (NO-SEAM, 2026-09-07):
+     * the tool's list/search/contacts collect this instead of polling the
+     * binder. Same truth [getRooms]/[getAllRooms] read.
+     */
+    val roomList: StateFlow<List<com.thelightphone.sdk.shared.LightServiceMethod.GetRooms.Room>> =
+        _roomList.asStateFlow()
+
+    /**
      * Monotonic revision of the published room list (2026-09-01): bumped on
      * every [publishRoomList] and on [resetRoomList]. The tool polls
      * [roomListRevision] (a Long, cheap) instead of re-fetching the whole
@@ -7439,7 +7521,24 @@ object MatrixRepository {
     private fun bumpMessagePageRevision(roomId: String) {
         messagePageRevision[roomId] = (messagePageRevision[roomId] ?: 0L) + 1
         changeSignal.tryEmit(Unit)
+        pageChangeSignal.tryEmit(roomId)
     }
+
+    /**
+     * Per-room newest-page change signal (NO-SEAM, 2026-09-07): emitted beside
+     * every [bumpMessagePageRevision] so the thread collects it instead of
+     * long-polling the revision. A signal, not a page payload: the served page
+     * shape (pending echoes, audio state — [getMessages]) stays in exactly one
+     * place, and the tool re-reads it on each signal. DROP_OLDEST: a dropped
+     * signal costs one tick, same as the old poll's worst case.
+     */
+    private val pageChangeSignal = MutableSharedFlow<String>(
+        replay = 0, extraBufferCapacity = 64,
+        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+    )
+
+    /** The per-room page-change signal the thread collects. */
+    val pageChanges: kotlinx.coroutines.flow.SharedFlow<String> = pageChangeSignal.asSharedFlow()
 
     /**
      * Monotonic revision of the room-flags cache (Phase C, 2026-09-06):
@@ -7451,8 +7550,17 @@ object MatrixRepository {
     @Volatile
     private var roomFlagsRevision = 0L
 
+    /**
+     * The live per-room flags (pinned/muted/archived, optimistic overlay
+     * applied) as a flow (NO-SEAM, 2026-09-07): the thread/contact panels
+     * collect this instead of long-polling the flags revision.
+     */
+    private val _roomFlags = MutableStateFlow<Map<String, RoomFlags>>(emptyMap())
+    val roomFlags: StateFlow<Map<String, RoomFlags>> = _roomFlags.asStateFlow()
+
     private fun bumpRoomFlagsRevision() {
         roomFlagsRevision++
+        _roomFlags.value = roomFlagsCache + roomFlagsOverlay
         changeSignal.tryEmit(Unit)
     }
 
@@ -7725,16 +7833,19 @@ object MatrixRepository {
      */
     private fun servedUnread(
         roomId: String,
-        markedAt: String?,
         markedTs: Long?,
-        newestId: String?,
         newestTs: Long?,
         storeUnread: Long,
     ): Long {
-        if (markedAt == null) return storeUnread
-        return if (storeUnread == 0L || newestId == markedAt ||
-            (newestTs != null && markedTs != null && newestTs > markedTs)
-        ) {
+        if (markedTs == null) return storeUnread
+        // The read receipt's echo takes a sync round trip; until then the
+        // count sources can still carry the pre-read value. Suppress until
+        // GENUINELY newer activity arrives (its count is real) — an event-ts
+        // comparison, not a marker-id match: the marker may be a snapped
+        // unrenderable head (reaction/poll/bridge status), which the room's
+        // relevant head equals immediately and disarmed the old check
+        // mid-flap (LP3 2026-09-07: "disappears then reappears").
+        return if (newestTs != null && newestTs > markedTs) {
             pendingReadClear.remove(roomId)
             storeUnread
         } else {
@@ -7766,6 +7877,15 @@ object MatrixRepository {
                         "SELECT userId, MAX(je.value) FROM RoomUserReceipts, " +
                             "json_tree(RoomUserReceipts.value) je " +
                             "WHERE RoomUserReceipts.roomId=? AND je.key='ts' AND je.type='integer' " +
+                            // Bridge bot accounts (@whatsappbot, @telegrambot, …)
+                            // "read" their own delivery-status events instantly,
+                            // so their receipt is always the newest in an active
+                            // room and this fallback read every busy bridged room
+                            // as unread (LP3 2026-09-07: the 1€ FILM badges).
+                            // ponytail: localpart-suffix heuristic — a human
+                            // literally named "…bot" would be excluded; switch
+                            // to a rendered-message join if that bites.
+                            "AND RoomUserReceipts.userId NOT LIKE '%bot:%' " +
                             "GROUP BY userId",
                         arrayOf(roomId),
                     ).use { cur ->
@@ -8068,9 +8188,7 @@ object MatrixRepository {
                     // encrypted rooms only; unencrypted ones stay readable.
                     unreadCount = servedUnread(
                         key,
-                        cleared?.first,
                         cleared?.second,
-                        room.lastRelevantEventId?.full,
                         room.lastRelevantEventTimestamp?.toEpochMilliseconds(),
                         if (verified || !room.encrypted) (unreadCounts[key]?.toLong() ?: 0L) else 0,
                     ),
@@ -8231,9 +8349,7 @@ object MatrixRepository {
         val cleared = pendingReadClear[key]
         val unread = servedUnread(
             key,
-            cleared?.first,
             cleared?.second,
-            room.lastRelevantEventId?.full,
             room.lastRelevantEventTimestamp?.toEpochMilliseconds(),
             storeUnread,
         )

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -3225,6 +3225,10 @@ object MatrixRepository {
         limit: Int,
     ): MessagesPage {
         if (beforeEventId == null) {
+            // A room open warms the megolm send path in the background so the
+            // FIRST send in the room doesn't pay the member-load/session cost
+            // inline (see [warmRoomMegolm]).
+            warmRoomMegolm(roomId)
             val cached = messagePageCache[roomId]
             if (cached != null && cached.limit >= limit) {
                 // The memory page is never older than disk (disk writes are
@@ -3346,16 +3350,22 @@ object MatrixRepository {
         val content = te.content?.getOrNull() ?: return null
         if ((content as? RoomMessageEventContent)?.relatesTo is RelatesTo.Replace) return null
         val sender = te.event.sender.full
+        // origin_server_ts is part of the signature: the dedup exists for the
+        // bridge's EXACT re-imports (same ts), but a user legitimately
+        // repeating a message ("ok", "ok") minted the same sender|text|body
+        // signature minutes apart and the older copy vanished from the served
+        // page (found on-emulator 2026-09-08).
+        val ts = te.event.originTimestamp
         return when (content) {
-            is RoomMessageEventContent.TextBased -> "$sender|text|${content.body}"
+            is RoomMessageEventContent.TextBased -> "$sender|text|$ts|${content.body}"
             is RoomMessageEventContent.FileBased.Image ->
-                "$sender|image|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
+                "$sender|image|$ts|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
             is RoomMessageEventContent.FileBased.Audio ->
-                "$sender|audio|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
+                "$sender|audio|$ts|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
             is RoomMessageEventContent.FileBased.Video ->
-                "$sender|video|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
+                "$sender|video|$ts|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
             is RoomMessageEventContent.FileBased.File ->
-                "$sender|file|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
+                "$sender|file|$ts|${content.url ?: content.file?.url}|${content.fileName ?: ""}"
             else -> null
         }
     }
@@ -3661,7 +3671,9 @@ object MatrixRepository {
     /** Row for a send whose sync echo hasn't rendered yet. The message is
      *  treated as SENT the moment the server acks it: once the outbox records
      *  the real event id (the /send 200 — ~1s after the send, long before the
-     *  sync echo), the row carries that id + the send time; a recorded outbox
+     *  sync echo), the row carries that id + the send time and the
+     *  SENT_PENDING_ECHO status (rendered "sent" by the tool, Beeper's
+     *  SENT_PENDING_SERVER_ECHO); a recorded outbox
      *  error renders as "not delivered" (FAIL_ status, shown by the tool);
      *  only a still-queued send keeps the optimistic "local-…" row. The tool
      *  shows the send time for all three, so the thread reflects a send
@@ -3689,7 +3701,14 @@ object MatrixRepository {
             body = body,
             timestampMs = timestampMs,
             isMine = true,
-            sendStatus = if (outbox?.sendError != null) "FAIL_LOCAL_SEND" else null,
+            sendStatus = when {
+                outbox?.sendError != null -> "FAIL_LOCAL_SEND"
+                // Beeper's SENT_PENDING_SERVER_ECHO parity: the homeserver ack
+                // (outbox event id) flips the row to "sent" while the sync echo
+                // is still in flight; the echo then replaces this row wholesale.
+                outbox?.eventId != null -> "SENT_PENDING_ECHO"
+                else -> null
+            },
             contentType = contentType,
             durationMs = durationMs,
         )
@@ -5013,6 +5032,35 @@ object MatrixRepository {
     }
 
     /**
+     * Pre-warms the megolm send path when a room is opened (Beeper's
+     * prepareSendMessage): the first encrypted send in a room otherwise pays
+     * the /members fetch + outbound-session creation + /keys/claim inline in
+     * the outbox drain, and the just-tapped send waits seconds behind it.
+     * Encrypting a throwaway payload runs exactly that path (member load,
+     * session creation, key share) once per process per room, in the
+     * background — the ciphertext is discarded. Plaintext rooms no-op fast
+     * (encrypt returns null for them).
+     */
+    private val megolmWarmedRooms = java.util.concurrent.ConcurrentHashMap<String, Boolean>()
+
+    private fun warmRoomMegolm(roomId: String) {
+        val c = client ?: return
+        if (megolmWarmedRooms.putIfAbsent(roomId, true) != null) return
+        val matrixRoomId = RoomId(roomId)
+        scope.launch {
+            runCatching {
+                c.di.getAll<RoomEventEncryptionService>().forEach { service ->
+                    runCatching {
+                        service.encrypt(RoomMessageEventContent.TextBased.Text(body = ""), matrixRoomId)
+                    }
+                }
+            }.onFailure { e ->
+                android.util.Log.w(TAG, "megolm pre-warm failed for $roomId: ${e.message}")
+            }
+        }
+    }
+
+    /**
      * Rotation triggered directly by a bridge FAIL in the status walk
      * ([sendStatusByEventId], which runs on every newest-page build): once per
      * room per process run, fire-and-forget. The next send creates a fresh
@@ -5117,7 +5165,10 @@ object MatrixRepository {
         // and the active-room refresher (or the next poll) recomputes the page
         // once the sync echo lands.
         // Fetch the echo + refresh the panel even in slow-sync mode (screen off).
-        wakeAfterSend(matrixRoomId.full)
+        // Fire-and-forget like Beeper's send worker: the composer RPC covers
+        // only the outbox insert — the room-list bump, the wake round and the
+        // ack watch all run in the background.
+        scope.launch { wakeAfterSend(matrixRoomId.full) }
         // NO-SEAM: the thread no longer polls — it reacts to page
         // bumps. The send-time bump fires BEFORE the homeserver ack, so the row
         // sat "SENDING" until the sync echo's page rebuild landed — starved for
@@ -5126,6 +5177,7 @@ object MatrixRepository {
         // (sent) from the SAME cached page — no rebuild needed.
         scope.launch {
             var lastAcked = false
+            var lastKickAt = android.os.SystemClock.elapsedRealtime()
             repeat(120) {
                 delay(250)
                 val om = runCatching {
@@ -5137,6 +5189,20 @@ object MatrixRepository {
                     bumpMessagePageRevision(matrixRoomId.full)
                 }
                 if (acked) return@launch
+                // Sync-stall kicker: a send that threw (offline blip) parks in
+                // the outbox drain's retry sleep — 100ms*2^n capped at 5 min
+                // while sync is errored/stopped, and the sleep only ends on a
+                // sync-state change. A successful round sets state RUNNING
+                // (SyncApiClient), which interrupts that sleep immediately, so
+                // re-fire the send-wake round every 5 s while the ack is
+                // missing. Battery saver + dark screen skips the send-wake
+                // (see [wakeAfterSend]) — stay consistent there.
+                val now = android.os.SystemClock.elapsedRealtime()
+                if (now - lastKickAt >= SEND_KICK_INTERVAL_MS && (syncEnabled || isScreenInteractive())) {
+                    lastKickAt = now
+                    timedSyncOnce(c, "send-retry")
+                        .onFailure { android.util.Log.w(TAG, "send-retry sync failed: ${it.message}") }
+                }
             }
         }
         android.util.Log.d(TAG, "SendMessage: room=$roomId txn=$txnId body=$body")
@@ -10150,6 +10216,9 @@ object MatrixRepository {
     private const val SEND_ACK_WAIT_MS = 500L
     /** Poll cadence on the outbox row while awaiting the ack. */
     private const val SEND_ACK_POLL_INTERVAL_MS = 100L
+
+    /** Gap between send-stall kicker rounds while a send waits for its ack. */
+    private const val SEND_KICK_INTERVAL_MS = 5_000L
     /** Whole-outbox read for the restart pending reconstruction (one query;
      *  empty outbox → instant). */
     private const val OUTBOX_RECONSTRUCT_BUDGET_MS = 5_000L

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -759,12 +759,12 @@ object MatrixRepository {
             scope.launch {
                 runCatching { c.stopSync() }
                 android.util.Log.d(TAG, "network back after loss — resetting sync loop")
-                if (isScreenInteractive() && syncEnabled) {
+                if (isScreenInteractive()) {
                     // Re-arm through the shared entry point (the stopSync above
                     // un-armed the slot, so [startSyncLoop] must re-arm it). A
-                    // dark screen must NOT start a long-poll and a paused sync
-                    // must stay paused: that branch goes through the shared
-                    // screen → cadence entry point (both gates live in it).
+                    // dark screen must NOT start a long-poll: that branch goes
+                    // through the shared screen → cadence entry point (the
+                    // battery-saver and slow-sync gates live in it).
                     inProcessSyncRunning = false
                     startSyncLoop(appContext ?: return@launch)
                 } else {
@@ -816,36 +816,29 @@ object MatrixRepository {
             // Restore the session regardless of the sync toggle. GetAccountState
             // reads the live client, so a paused companion that skips the restore
             // makes the tool report "Not signed in" while the session is fine.
-            // Only the sync loop (and
-            // its FGS) is gated on the toggle; the restored client's observers
-            // stay dormant without sync (room flows never emit).
             if (ensureClient() != null) {
-                if (syncEnabled) {
-                    // Screen-state-aware start: a
-                    // session restore that lands while the screen is dark must
-                    // NOT long-poll — the boot-time sample above races the
-                    // restore, and a SCREEN_OFF broadcast that fired before the
-                    // receiver registered is gone. The shared entry point
-                    // applies the cadence the screen actually calls for.
-                    applySyncModeForScreenState()
-                    // Push wake-up channel: register the Matrix
-                    // HTTP pusher + hold the SSE subscription so idle sync has
-                    // zero latency — see PushChannel.
-                    PushChannel.start(app, client!!)
-                } else {
-                    setConnectionState(ChatConnectionState.Offline("sync paused"))
-                    android.util.Log.d(TAG, "sync disabled by preference — session restored, no sync loop")
-                }
+                // Screen-state-aware start: a
+                // session restore that lands while the screen is dark must
+                // NOT long-poll — the boot-time sample above races the
+                // restore, and a SCREEN_OFF broadcast that fired before the
+                // receiver registered is gone. The shared entry point
+                // applies the cadence the screen actually calls for (battery
+                // saver: nothing while dark, full sync while on).
+                applySyncModeForScreenState()
+                // Push wake-up channel: register the Matrix
+                // HTTP pusher + hold the SSE subscription so idle sync has
+                // zero latency — see PushChannel. It is background keep-alive,
+                // so battery saver never starts it.
+                if (syncEnabled) PushChannel.start(app, client!!)
             }
         }
     }
 
     /**
-     * Pauses/resumes the Matrix sync loop + foreground service (Settings → Sync).
-     * Pausing stops all background sync work; the notification watcher and
-     * room-list resolver go dormant on their own (without sync the room flows
-     * never emit). Re-enabling restores the session if needed and restarts the
-     * loop. Persisted, so it survives reboots.
+     * Toggles Battery Saver (Settings): when on, all sync machinery stops
+     * while the screen is dark — messages arrive only while the screen is
+     * on. Re-enabling restores the session if needed and restarts the loop.
+     * Persisted, so it survives reboots.
      */
     suspend fun setSyncEnabled(enabled: Boolean) {
         val ctx = appContext ?: return
@@ -853,24 +846,23 @@ object MatrixRepository {
             .edit().putBoolean(KEY_SYNC_ENABLED, enabled).apply()
         syncEnabled = enabled
         val c = client
-        // Tear down the background sync machinery in both branches (pausing
-        // stops it all; re-enabling restarts it below).
+        // Cancel the dark-screen schedules in both branches (battery saver
+        // stops them; re-enabling restarts them below).
         slowSyncJob?.cancel()
         slowSyncJob = null
         screenOffJob?.cancel()
         screenOffJob = null
         syncMode = SyncMode.ACTIVE
         if (!enabled) {
-            runCatching { c?.stopSync() }
-            inProcessSyncJob?.cancel()
-            inProcessSyncJob = null
-            inProcessSyncRunning = false
-            activeRoomRefreshJob?.cancel()
-            activeRoomRefreshJob = null
-            PushChannel.stop()
-            ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
-            setConnectionState(ChatConnectionState.Offline("sync paused"))
-            android.util.Log.d(TAG, "sync paused by user")
+            if (isScreenInteractive()) {
+                // Foreground sync keeps running while the screen is on — the
+                // dark-screen teardown happens on the next SCREEN_OFF.
+                PushChannel.stop()
+            } else {
+                stopBackgroundSync()
+                setConnectionState(ChatConnectionState.Offline("battery saver"))
+            }
+            android.util.Log.d(TAG, "battery saver on")
         } else {
             if (c == null) {
                 if (ensureClient() != null) startSyncLoop(ctx)
@@ -883,18 +875,38 @@ object MatrixRepository {
     }
 
     /**
+     * Stops every piece of sync machinery (battery saver with a dark screen):
+     * the long-poll, slow-sync rounds, the push channel and the FGS. The
+     * notification watcher and room-list resolver go dormant on their own
+     * (without sync the room flows never emit).
+     */
+    private suspend fun stopBackgroundSync() {
+        val ctx = appContext ?: return
+        runCatching { client?.stopSync() }
+        inProcessSyncJob?.cancel()
+        inProcessSyncJob = null
+        inProcessSyncRunning = false
+        activeRoomRefreshJob?.cancel()
+        activeRoomRefreshJob = null
+        PushChannel.stop()
+        ctx.stopService(android.content.Intent(ctx, ChatSyncService::class.java))
+    }
+
+    /**
      * Single entry point for the screen-state → sync-cadence decision.
      * Called from [init] after the client is ready, the SCREEN_ON/OFF
      * receiver, and [ChatSyncService] before it starts a long-poll, so a sync
      * loop never runs while the screen is dark. Screen on → active long-poll;
-     * dark → slow sync after the grace.
+     * dark → slow sync after the grace, or nothing at all under battery saver.
      */
     fun applySyncModeForScreenState() {
-        if (!syncEnabled) return
         if (isScreenInteractive()) {
             scope.launch { enterActiveSync() }
-        } else {
+        } else if (syncEnabled) {
             scheduleSlowSync()
+        } else {
+            // Battery saver: nothing runs while the screen is dark.
+            scope.launch { stopBackgroundSync() }
         }
     }
 
@@ -902,7 +914,7 @@ object MatrixRepository {
      * Drops to the slow cadence once the screen has been dark for the grace
      * period: stop the long-poll and run periodic [MatrixClient.syncOnce]
      * rounds instead. The FGS stays (it keeps the process alive for the slow
-     * loop); the manual Settings → Sync toggle is the fully-off control.
+     * loop); battery saver (the toggle off) runs nothing at all while dark.
      */
     private fun scheduleSlowSync() {
         screenOffJob?.cancel()
@@ -1045,7 +1057,6 @@ object MatrixRepository {
         // would leave a fresh screen-on start with no sync at all.
         if (syncMode == SyncMode.ACTIVE && (inProcessSyncRunning || ChatSyncService.isRunning)) return
         syncMode = SyncMode.ACTIVE
-        if (!syncEnabled) return
         val ctx = appContext ?: return
         if (client != null) {
             startSyncLoop(ctx)
@@ -1260,6 +1271,9 @@ object MatrixRepository {
         // interval converges within one tick of the system allowing it).
         scope.launch {
             while (isActive && client === c && !ChatSyncService.isRunning) {
+                // Battery saver tore sync down with the screen dark — don't
+                // resurrect the FGS behind the teardown's back.
+                if (!syncEnabled && !isScreenInteractive()) return@launch
                 if (ChatSyncService.tryStart(context)) break
                 delay(FGS_PROMOTE_INTERVAL_MS)
             }
@@ -1483,7 +1497,8 @@ object MatrixRepository {
         screenOffJob = null
         syncMode = SyncMode.ACTIVE
         startSyncLoop(ctx)
-        PushChannel.start(ctx, newClient)
+        // Background keep-alive — battery saver never starts it.
+        if (syncEnabled) PushChannel.start(ctx, newClient)
         // Verification is part of login (Beeper's model) — but only when there
         // is something to verify against: the account has cross-signing keys
         // uploaded and this fresh session isn't trusted yet. The request goes
@@ -1696,7 +1711,7 @@ object MatrixRepository {
         // Restart the loop through the shared cadence entry points (same shape
         // as the network-recovery reset): a dark screen must not start a
         // long-poll — it goes through the screen → cadence decision instead.
-        if (isScreenInteractive() && syncEnabled) {
+        if (isScreenInteractive()) {
             startSyncLoop(appContext ?: error("companion not initialized"))
         } else {
             applySyncModeForScreenState()
@@ -2981,7 +2996,7 @@ object MatrixRepository {
     }
 
     /**
-     * Recomputes a cached newest page's reaction tags ("Name reacted with ❤️")
+     * Recomputes a cached newest page's reaction tags ("Name reacted ❤️")
      * over the cached chain window — the same newest-page-only scope the full
      * rebuild tags from, so the patch stays consistent with what the page
      * holds. The reason this exists: an encrypted m.reaction (bridge reactions
@@ -4412,7 +4427,7 @@ object MatrixRepository {
     /**
      * Reaction tags per target message id from a list of timeline events (the
      * newest window, or the sync delta). Each entry is a display string —
-     * "Name reacted with ❤️" (own reactions read "You reacted with ❤️") —
+     * "Name reacted ❤️" (own reactions read "You reacted ❤️") —
      * deduped per SENDER (one reaction per person per message, Beeper
      * semantics — LP3: fire then heart showed both), the
      * person's newest reaction kept, ordered chronologically so the first tag
@@ -4452,7 +4467,7 @@ object MatrixRepository {
             result.getOrPut(targetId) { mutableListOf() }.add(entry)
         }
         return result.mapValues { (_, entries) ->
-            entries.sortedBy { it.timestampMs }.map { "${it.who} reacted with ${it.key}" }
+            entries.sortedBy { it.timestampMs }.map { "${it.who} reacted ${it.key}" }
         }
     }
 
@@ -4460,23 +4475,23 @@ object MatrixRepository {
      *  (the person's latest reaction survives dedupe). */
     private class ReactionEntry(var timestampMs: Long, val who: String, var key: String)
 
-    /** Keeps a message's reaction tags ("Name reacted with ❤️") to at most two
+    /** Keeps a message's reaction tags ("Name reacted ❤️") to at most two
      *  lines: two or fewer stay as-is; more collapse into one compact summary
      *  — the FIRST (earliest) reactor by name, everyone else folded into "and
      *  others", the distinct emoji listed once each, space-separated:
-     *  "Sophie and others reacted with ❤️ 😂". One person stacking several emoji isn't a crowd, so it
+     *  "Sophie and others reacted ❤️ 😂". One person stacking several emoji isn't a crowd, so it
      *  keeps the per-reaction lines. Tags never exceed two after this, so the
      *  tool renders the list unchanged. */
     private fun collapseReactionTags(tags: List<String>): List<String> {
         if (tags.size <= 2) return tags
         val reactions = tags.map { tag ->
-            val at = tag.indexOf(" reacted with ")
+            val at = tag.indexOf(" reacted ")
             if (at <= 0) return tags // not our label shape — leave untouched
-            tag.substring(0, at) to tag.substring(at + " reacted with ".length)
+            tag.substring(0, at) to tag.substring(at + " reacted ".length)
         }
         if (reactions.map { it.first }.distinct().size < 2) return tags
         val emojis = reactions.map { it.second }.distinct()
-        return listOf("${reactions.first().first} and others reacted with ${emojis.joinToString(" ")}")
+        return listOf("${reactions.first().first} and others reacted ${emojis.joinToString(" ")}")
     }
 
     /**
@@ -4484,18 +4499,18 @@ object MatrixRepository {
      * reactor replaces their cached one. [reactionTagsForEvents] dedupes per
      * sender within one event window, but the incremental patch only sees the
      * delta — the replaced reaction's tag still sits in the cached page. The tag
-     * label's shape ("Who reacted with …") carries the reactor name; a
+     * label's shape ("Who reacted …") carries the reactor name; a
      * collapsed "X and others" cached line only matches on its exact prefix,
      * the same ceiling [ownReactionKeys] on the tool side lives with.
      */
     private fun mergeReactionTags(cached: List<String>, added: List<String>): List<String> {
         if (added.isEmpty()) return cached
         val replaced = added.mapNotNull { tag ->
-            val at = tag.indexOf(" reacted with ")
+            val at = tag.indexOf(" reacted ")
             if (at <= 0) null else tag.substring(0, at)
         }.toSet()
         return cached.filterNot { tag ->
-            val at = tag.indexOf(" reacted with ")
+            val at = tag.indexOf(" reacted ")
             at > 0 && tag.substring(0, at) in replaced
         } + added
     }
@@ -4911,7 +4926,9 @@ object MatrixRepository {
             publishRoomList()
         }
         val c = client ?: return
-        if (!syncEnabled) return
+        // Battery saver skips only the dark-screen wake — a send with the
+        // screen on is foreground work and gets its catch-up sync.
+        if (!syncEnabled && !isScreenInteractive()) return
         slowSyncJob?.cancel()
         slowSyncJob = null
         scope.launch {
@@ -9620,11 +9637,13 @@ object MatrixRepository {
                             // periodic syncOnce rounds — that's still "syncing",
                             // not an outage.
                             isSlowSyncing -> ChatConnectionState.Syncing
-                            // The sync toggle is the source of truth while paused —
-                            // the restored client reports STOPPED until resumed, and
-                            // that must read as "paused", not "stopped" (or, worse,
-                            // the race with init's explicit assignment).
-                            !syncEnabled -> ChatConnectionState.Offline("sync paused")
+                            // Battery saver is the source of truth while it
+                            // has sync stopped — the restored client reports
+                            // STOPPED until the screen comes back on, and
+                            // that must read as "battery saver", not
+                            // "stopped" (or, worse, the race with init's
+                            // explicit assignment).
+                            !syncEnabled -> ChatConnectionState.Offline("battery saver")
                             c.loginState.value == MatrixClient.LoginState.LOGGED_IN -> ChatConnectionState.Offline("sync stopped")
                             sessionExpired -> ChatConnectionState.Offline("session expired — sign in again")
                             else -> ChatConnectionState.LoggedOut
@@ -10320,7 +10339,7 @@ object MatrixRepository {
     // Disk cache.
     // Versioned so a stale pre-ghost-filter cache (pages/lists polluted by the
     // bridge re-import) is never served after an upgrade.
-    private const val DISK_CACHE_DIR = "chats_cache_v2"
+    private const val DISK_CACHE_DIR = "chats_cache_v3"
     private const val DISK_ROOM_LIST_FILE = "room_list.json"
     /** How many rooms keep an on-disk message page (the re-open surface). */
     private const val DISK_CACHE_MAX_PAGES = 100

--- a/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/MatrixRepository.kt
@@ -7085,26 +7085,6 @@ object MatrixRepository {
                                         }
                                         if (prev != lastId) {
                                             seen[key] = lastId
-                                            // Recency bump: a new event means the
-                                            // room is active — refresh its cache timestamp NOW
-                                            // so the next publish reorders it to the top.
-                                            // Without this the row's time only changed when the
-                                            // budget-bound resolver pass happened to re-resolve
-                                            // the room; on a big account rooms past the pass
-                                            // budget kept stale times and dropped out of the
-                                            // main list's 200-room window while still recent
-                                            // ("Jeff" missing). The sig block
-                                            // above already marked the resolver dirty; the wake
-                                            // makes a sleeping resolver run the pass now.
-                                            updated.lastRelevantEventTimestamp?.toEpochMilliseconds()?.let { ts ->
-                                                val entry = roomListCache[key]
-                                                if (entry != null && ts > entry.room.lastTimestampMs) {
-                                                    roomListCache[key] = entry.copy(
-                                                        room = entry.room.copy(lastTimestampMs = ts),
-                                                    )
-                                                }
-                                            }
-                                            wakeRoomList()
                                             // NO-SEAM: the open thread no longer
                                             // long-polls the page revision — it rides the
                                             // pageChanges signal, so an arrival in the ACTIVE
@@ -7737,19 +7717,31 @@ object MatrixRepository {
                     ).use { cur -> if (cur.moveToFirst() && !cur.isNull(0)) cur.getLong(0) else -1L }
                     if (own < 0) return@runCatching null
                     db.openHelper.writableDatabase.query(
-                        "SELECT COUNT(*) FROM (SELECT 1 FROM TimelineEvent " +
+                        // Bridge re-import floods re-deliver a whole read batch as
+                        // "new" undecryptable events sharing one origin ts (LP3:
+                        // à bientôt — 35 copies stamped 08-23 07:08:24 across 3
+                        // senders). Count same-ts groups of ≤6 only: a genuine
+                        // burst never lands >6 messages in the same millisecond.
+                        // ponytail: real history re-imports of NEW messages would
+                        // under-count; Beeper dedups equivalents at ingestion.
+                        "SELECT MIN(99, SUM(n)) FROM (" +
+                            "SELECT n FROM (" +
+                            "SELECT json_extract(value,'$.event.origin_server_ts') AS ets, " +
+                            "COUNT(*) AS n " +
+                            "FROM TimelineEvent " +
                             "WHERE TimelineEvent.roomId=? " +
-                            "AND json_extract(TimelineEvent.value,'$.event.type') " +
+                            "AND json_extract(value,'$.event.type') " +
                             "  IN ('m.room.message','m.room.encrypted') " +
-                            "AND json_extract(TimelineEvent.value,'$.event.sender') != ? " +
+                            "AND json_extract(value,'$.event.sender') != ? " +
                             // CAST: query() binds selection args as TEXT, and an
                             // INTEGER column never compares greater than a TEXT
                             // value in SQLite — the un-cast version silently
                             // counted 0 for every room (LP3: Jasmine/Rose
                             // genuinely-unread badges vanished).
-                            "AND json_extract(TimelineEvent.value,'$.event.origin_server_ts') " +
+                            "AND json_extract(value,'$.event.origin_server_ts') " +
                             "  > CAST(? AS INTEGER) " +
-                            "LIMIT 99)",
+                            "GROUP BY ets" +
+                            ") WHERE n <= 6)",
                         arrayOf(roomId, c.userId.full, own.toString()),
                     ).use { cur -> if (cur.moveToFirst()) cur.getLong(0) else 0L }
                 }.getOrNull()
@@ -9068,6 +9060,25 @@ object MatrixRepository {
             effectiveLastCache[key] = EffectiveLast(serverLastId, firstReal.event.id.full, realTs)
             return firstReal.event.id.full to realTs
         }
+        // A room whose newest event is pure state (member join, reaction,
+        // bridge ack) and which has NEVER resolved a real message (prev ==
+        // null) has nothing to stamp: the server's head time is a state
+        // re-delivery, not activity, and surfacing it as fresh fakes a
+        // timestamp. Park the row at the bottom (ts 0, no preview) until the
+        // ghost walk finds real content or a real message arrives — the fast
+        // path re-checks on every server-last change, so a genuine arrival
+        // still surfaces. (LP3: this check MUST sit before the
+        // decrypt-restore branch below — with the cooldown inactive that
+        // branch serves the raw head (member id + ts) and re-stamps parked
+        // rows: Josh Schiff / WhatsApp (+49…) bounced between park and the
+        // top of the list on every cooldown expiry.)
+        if (prev == null && serverLast?.let { !isRenderableRow(it) } == true) {
+            enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
+            effectiveLastCache[key] = EffectiveLast(
+                serverLastId, null, 0L, retryAtMs = now + GHOST_WALK_RETRY_MS,
+            )
+            return null to 0L
+        }
         // Suspicious (dropped by the dedup, or inside a flood): resolve in the
         // background with a session restore (the copies' originals are old
         // messages whose keys load from the backup — slow, so not on the
@@ -9083,21 +9094,6 @@ object MatrixRepository {
                     ?: (now + GHOST_WALK_RETRY_MS),
             )
             return (prev?.effectiveEventId ?: serverLastId) to (prev?.effectiveTs ?: serverTs)
-        }
-        // A room whose newest event is pure state (member join, reaction,
-        // bridge ack) and which has NEVER resolved a real message (prev ==
-        // null) has nothing to stamp: the server's head time is a state
-        // re-delivery, not activity, and surfacing it as fresh fakes a
-        // timestamp. Park the row at
-        // the bottom (ts 0, no preview) until the ghost walk finds real
-        // content or a real message arrives — the fast path re-checks on
-        // every server-last change, so a genuine arrival still surfaces.
-        if (prev == null && serverLast?.let { !isRenderableRow(it) } == true) {
-            enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
-            effectiveLastCache[key] = EffectiveLast(
-                serverLastId, null, 0L, retryAtMs = now + GHOST_WALK_RETRY_MS,
-            )
-            return null to 0L
         }
         enqueueGhostResolve(c, matrixRoomId, serverLastId, serverTs)
         effectiveLastCache[key] = EffectiveLast(

--- a/server/src/main/kotlin/com/lightphone/chats/server/PhotoSendActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/PhotoSendActivity.kt
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
@@ -197,7 +196,7 @@ class PhotoSendActivity : ComponentActivity() {
         } catch (_: Exception) {
             // No DocumentsUI handler — try the Android photo picker below.
         }
-        if (!launched && Build.VERSION.SDK_INT >= 33) {
+        if (!launched) {
             try {
                 pickPhoto.launch(Intent(MediaStore.ACTION_PICK_IMAGES))
                 launched = true

--- a/server/src/main/kotlin/com/lightphone/chats/server/PushChannel.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/PushChannel.kt
@@ -24,8 +24,7 @@ import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * Push-based wake-up for the companion (2026-08-16, chats/push/README.md).
- *
+ * Push-based wake-up for the companion.
  * The sync loop is the delivery mechanism for notifications, but only as
  * often as it polls. Matrix HTTP pushers fix the latency: the homeserver
  * gets a pusher whose `data.url` is an endpoint that serves the exact path
@@ -39,10 +38,8 @@ import java.util.concurrent.TimeUnit
  * [MatrixRepository.onPushDelivered] — a single syncOnce round while idle,
  * which the existing notification watcher turns into the local
  * notification.
- *
  * No tokens leave the phone: the payload carries no message content or keys —
  * push is a wake-up signal only.
- *
  * Two URLs are stored separately because one side sees the gateway from the
  * phone and the other from the homeserver: the notify URL must be public
  * (Beeper POSTs from their servers), while the SSE URL is whatever the phone
@@ -114,7 +111,7 @@ object PushChannel {
         var notifyUrl = prefs.getString(KEY_NOTIFY_URL, null)
         var key = prefs.getString(KEY_PUSHKEY, null)
         if (sseUrl == null || notifyUrl == null || key == null) {
-            // Auto-provision an ntfy.sh channel (2026-08-17): one random
+            // Auto-provision an ntfy.sh channel: one random
             // topic derives the pushkey (ntfy routes by it), the SSE stream
             // the phone holds, and the notify URL (ntfy's Matrix gateway
             // serves the required path). The topic is a per-install bearer
@@ -278,7 +275,7 @@ object PushChannel {
      * always wake one sync. Counts-only payloads (Beeper's read-receipt /
      * unread-count updates) still wake, but [MatrixRepository.onPushDelivered]
      * rate-limits them — a group chat's read actions must not each run a full
-     * ~30-50 s syncOnce (battery 2026-08-17 audit).
+     * ~30-50 s syncOnce.
      */
     private suspend fun onNotification(json: String) {
         val outer = runCatching { Json { ignoreUnknownKeys = true }.parseToJsonElement(json).jsonObject }

--- a/server/src/main/kotlin/com/lightphone/chats/server/ServerBootstrapProvider.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ServerBootstrapProvider.kt
@@ -25,15 +25,15 @@ private const val LIGHTSDK_DEV_CERT_SHA256 =
 
 private const val TAG = "ServerBootstrap"
 
-// VAPID public key from the mollysocket link LightOS returned for this device
-// (2026-08-21 probe): mollysocket://link?vapid=...&url=...&type=webserver. The
+// VAPID public key from the mollysocket link LightOS returned for this device:
+// mollysocket://link?vapid=...&url=...&type=webserver. The
 // UP connector's own generated key fails its regex (3.3.2), so pass an
 // explicit format-valid key. Removed with the probe.
 private const val MOLLYSOCKET_VAPID =
     "BJpWPefLMOy_hvZsejTdQpRfvjoirNwVjhdjPo1nNPdcwQQnoANsHQlQdg_vSBqsvHY-4t_KqyFDzsuYACNuGTw"
 
 /**
- * Single-APK build (2026-08-19): the former companion's `ServerApplication`
+ * Single-APK build: the former companion's `ServerApplication`
  * wiring runs here, inside the merged tool APK. A ContentProvider is the only
  * app-start hook with a real [Context] that is not part of the tool-plugin
  * scanned module — it wires the SDK server (settings, cert check, chat
@@ -58,7 +58,7 @@ class ServerBootstrapProvider : ContentProvider() {
             // rocker adjusts the media stream here (one step per press) — the
             // tool's in-app volume panel replica mirrors it, and the native
             // LightOS panel is ringer-only for third-party tools, so volume
-            // must NOT be relayed then (feedback 2026-08-30). Otherwise every
+            // must NOT be relayed then. Otherwise every
             // event goes to LightOS (volume panel, brightness wheel, camera).
             onDeviceKeyEvent = { _, event ->
                 val volumeKeyDown = event.action == KeyEvent.ACTION_DOWN &&
@@ -86,10 +86,8 @@ class ServerBootstrapProvider : ContentProvider() {
                     // LightActivity forwards ALL actions (DOWN/UP/MULTIPLE) for
                     // mapped keys — incl. the shutter (27/80) — with
                     // componentToRelaunch, and LightOS is the handler. The
-                    // 2026-08-23 "relay shutter DOWN only" experiment deviated
-                    // from that contract and LP3-tested unchanged (2026-08-30:
-                    // camera still opened hidden, colour flipped, stale camera
-                    // on tool exit) — removed to match the SDK flow exactly.
+                    // "relay shutter DOWN only" experiment deviated
+                    // from that contract and LP3-tested unchanged — removed to match the SDK flow exactly.
                     PlatformRelay.sendDeviceKeyEvent(event)
                     // Camera key: the relay opens LightOS's camera, but a
                     // relayed event never foregrounds com.lightos (the real key
@@ -98,7 +96,7 @@ class ServerBootstrapProvider : ContentProvider() {
                     // relayed one mounts the camera hidden and flips greyscale
                     // with nothing on screen). Launch HOME so com.lightos (the
                     // home app) comes to front with the camera screen already
-                    // open, matching the toolbox-key behaviour (LP3 2026-08-30).
+                    // open, matching the toolbox-key behaviour.
                     if (event.keyCode == KeyEvent.KEYCODE_CAMERA &&
                         event.action == KeyEvent.ACTION_DOWN && (event.repeatCount ?: 0) == 0
                     ) {
@@ -109,7 +107,7 @@ class ServerBootstrapProvider : ContentProvider() {
                     }
                 }
             }
-            // Runtime permission flow (audit 2026-08-23): the tool requests
+            // Runtime permission flow: the tool requests
             // POST_NOTIFICATIONS through the SDK flow; this APK hosts the AOSP
             // dialog activity (ChatsPermissionActivity) and adds the
             // notification permission to the grantable set.

--- a/server/src/main/kotlin/com/lightphone/chats/server/ServerBootstrapProvider.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/ServerBootstrapProvider.kt
@@ -158,13 +158,11 @@ class ServerBootstrapProvider : ContentProvider() {
         }
         val md = MessageDigest.getInstance("SHA-256")
         val matches = signers.any { sig ->
-            md.digest(sig.toByteArray()).toHexString()
+            md.digest(sig.toByteArray()).toHexString(HexFormat { upperCase = true })
                 .equals(LIGHTSDK_DEV_CERT_SHA256, ignoreCase = true)
         }
         return if (matches) ClientCertType.LightSdkSignedUnverified else ClientCertType.Unknown
     }
-
-    private fun ByteArray.toHexString(): String = joinToString("") { "%02X".format(it) }
 
     // The provider exists for its onCreate only; no content is served.
     override fun query(

--- a/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
@@ -52,12 +52,12 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
- * The "record a voice note" screen (Phase 14). The tool runtime forbids
+ * The "record a voice note" screen. The tool runtime forbids
  * startActivity and the companion can't launch activities from the background,
  * so the tool calls `StartVoiceNoteSend` (which records the room) and then
  * starts this activity via `SimpleLightScreen.startServerActivity` — the same
  * pattern as [PhotoSendActivity]. Recording starts as soon as the panel opens
- * (feedback 2026-08-30: no idle "tap to record" step) — Opus in an ogg
+ * — Opus in an ogg
  * container (the MSC3245 canonical voice-message format, ~2-3× smaller than
  * the old AAC/m4a at speech bitrates); tap to stop; the recording is
  * uploaded to Matrix as an m.audio message and sent in the recorded room.
@@ -74,9 +74,7 @@ class VoiceNoteActivity : ComponentActivity() {
      *  podcasts) for the take (feedback 2026-08-20). */
     private var recordFocusRequest: android.media.AudioFocusRequest? = null
     /** Audio focus held while the pre-send preview plays — the preview must
-     *  pause background audio the same way the recording does (feedback
-     *  2026-08-21: the recorder got transient focus but the preview player
-     *  didn't). */
+     *  pause background audio the same way the recording does. */
     private var previewFocusRequest: android.media.AudioFocusRequest? = null
 
     // Activity-level state so the recording functions can flip the UI (a
@@ -92,21 +90,17 @@ class VoiceNoteActivity : ComponentActivity() {
     private var elapsedSeconds by mutableStateOf(0)
     /**
      * Recorded length (seconds) — the timer slot keeps showing it after the
-     * take stops, and the preview ticks through it while playing (feedback
-     * 2026-08-27: "show the final length where it was counting, count through
-     * it on playback").
+     * take stops, and the preview ticks through it while playing.
      */
     private var finalDurationSeconds by mutableStateOf(0)
-    /** RECORD_AUDIO was denied — show why, with a retry (2026-08-19 feedback
-     *  round: "the phone doesn't ask for the permission" — a denial must not
-     *  silently drop the screen). */
+    /** RECORD_AUDIO was denied — show why, with a retry. */
     private var micDenied by mutableStateOf(false)
     /** The last send failed — keep the take + SEND so the user can retry
      *  instead of a silent drop (2026-08-19 feedback round). */
     private var sendFailed by mutableStateOf(false)
     /**
-     * In-app volume panel state (null = hidden) — the shared LightOS replica
-     * (feedback 2026-08-30): while a take exists to preview, the volume rocker
+     * In-app volume panel state (null = hidden) — the shared LightOS replica:
+     * while a take exists to preview, the volume rocker
      * shows this panel and adjusts the media stream, instead of LightOS's
      * ringer-only panel.
      */
@@ -131,8 +125,8 @@ class VoiceNoteActivity : ComponentActivity() {
             return
         }
         // Start the take BEFORE the first frame renders, so the panel opens
-        // already in the recording state — the idle mic icon must not flash
-        // (feedback 2026-08-31). A missing RECORD_AUDIO grant asks first; the
+        // already in the recording state — the idle mic icon must not flash.
+        // A missing RECORD_AUDIO grant asks first; the
         // launcher callback starts the recording (or shows the mic-denied
         // retry) once the user answers.
         ensureMicThenRecord()
@@ -141,8 +135,7 @@ class VoiceNoteActivity : ComponentActivity() {
             // Haptics on the recording screen follow the real LightOS setting,
             // like the main tool: LightActivity provides LocalHapticsEnabled
             // from GetUserPreferences, but this plain activity never did —
-            // lightClickable silently skipped the vibration (feedback
-            // 2026-08-22: "the recording panel does not have haptics").
+            // lightClickable silently skipped the vibration.
             val hapticsEnabled by rememberHapticsEnabled().collectAsState()
 
             CompositionLocalProvider(LocalHapticsEnabled provides hapticsEnabled) {
@@ -150,7 +143,7 @@ class VoiceNoteActivity : ComponentActivity() {
                 // Height of the timer slot under the icon — also reserved
                 // above the icon, so the icon (not the icon+timer block) sits
                 // on the panel's vertical center with the timer hanging below
-                // it (feedback 2026-08-30).
+                // it.
                 val timerSlotHeight = 3f.gridUnitsAsDp()
                 // m:ss ticker while recording (MediaRecorder has no position
                 // query — the elapsed time comes from the wall clock).
@@ -187,16 +180,11 @@ class VoiceNoteActivity : ComponentActivity() {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             // The timer slot's height is reserved above the
                             // icon too, so the ICON sits on the panel's
-                            // vertical center — the timer hangs below it
-                            // (feedback 2026-08-30: "the icons should be
-                            // lower so that they are centred").
+                            // vertical center — the timer hangs below it.
                             Spacer(modifier = Modifier.height(timerSlotHeight))
                             // Record → tap to stop → play the take back → SEND
-                            // in the bottom bar (RETRY, X, SEND — feedback
-                            // 2026-08-27). Icons carry the states (feedback
-                            // 2026-08-30: no text labels for the control flow —
-                            // mic to open, stop while recording, play when
-                            // stopped); only the permission-denied and sending
+                            // in the bottom bar (RETRY, X, SEND).
+                            // Icons carry the states; only the permission-denied and sending
                             // states keep words. A mic denial shows a message +
                             // ALLOW instead of a silent drop.
                             Box(
@@ -228,8 +216,7 @@ class VoiceNoteActivity : ComponentActivity() {
                             }
                             // Only the states that NEED words show any: the
                             // mic denial and the send progress. The control
-                            // states are purely icon + timer (feedback
-                            // 2026-08-30).
+                            // states are purely icon + timer.
                             when {
                                 micDenied -> LightText(
                                     text = "Microphone permission is needed to record.",
@@ -243,11 +230,9 @@ class VoiceNoteActivity : ComponentActivity() {
                                 )
                             }
                             // Fixed-height slot: the timer appears/disappears
-                            // without shifting the icon above it (feedback
-                            // 2026-08-27: "the icon and text move up when you
-                            // press record"). 3 grid units — tall enough for
+                            // without shifting the icon above it. 3 grid units — tall enough for
                             // the Fine line; the old 2-unit slot clipped the
-                            // text vertically (feedback 2026-08-30).
+                            // text vertically.
                             Box(
                                 modifier = Modifier.height(timerSlotHeight),
                                 contentAlignment = Alignment.Center,
@@ -263,7 +248,7 @@ class VoiceNoteActivity : ComponentActivity() {
                                         text = timerText,
                                         // One step up from the old Superfine —
                                         // the counting time reads bigger under
-                                        // the icon (feedback 2026-08-30).
+                                        // the icon.
                                         variant = LightTextVariant.Fine,
                                         // Solid white like the thread's
                                         // timestamps (feedback 2026-08-27).
@@ -284,8 +269,7 @@ class VoiceNoteActivity : ComponentActivity() {
                         modifier = Modifier.navigationBarsPadding(),
                         items = listOf(
                             // RETRY: delete the take and start a fresh
-                            // recording (feedback 2026-08-30: no tap-to-record
-                            // step).
+                            // recording.
                             if ((previewing || sendFailed) && !sending) {
                                 LightBarButton.Text(
                                     text = "RETRY",
@@ -295,9 +279,9 @@ class VoiceNoteActivity : ComponentActivity() {
                                 null
                             },
                             // X in the middle dismisses the panel — no top-bar
-                            // back (feedback 2026-08-27). finish() only, so a
+                            // back. finish only, so a
                             // recorded take never flashes the idle panel on the
-                            // way out (feedback 2026-08-27); onStop cleans up.
+                            // way out; onStop cleans up.
                             LightBarButton.LightIcon(
                                 icon = LightIcons.CLOSE,
                                 onClick = { finish() },
@@ -330,13 +314,11 @@ class VoiceNoteActivity : ComponentActivity() {
      * main tool: volume rocker → LightOS's volume panel, scroll wheel →
      * brightness, camera button etc. The tool's screens get this via the SDK
      * server's onDeviceKeyEvent (LightOS forwards to the tool), but this plain
-     * activity sits outside that path (feedback 2026-08-22: "the recording
-     * panel does not have volume / brightness").
-     *
+     * activity sits outside that path.
      * While a take exists ([previewing]) the volume rocker is consumed here
      * instead: it adjusts the media stream (the take plays over it) and shows
      * the in-app volume panel replica — the native LightOS panel is ringer-only
-     * for third-party tools (feedback 2026-08-30).
+     * for third-party tools.
      */
     override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
         val volumeKey = event.keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
@@ -408,9 +390,8 @@ class VoiceNoteActivity : ComponentActivity() {
     }
 
     /**
-     * RETRY (feedback 2026-08-27): deletes the take and starts a fresh
-     * recording — there is no idle "tap to record" step anymore (feedback
-     * 2026-08-30), so the new take begins immediately.
+     * RETRY: deletes the take and starts a fresh
+     * recording — there is no idle "tap to record" step anymore, so the new take begins immediately.
      */
     private fun retryRecording() {
         runCatching { previewPlayer?.release() }
@@ -452,8 +433,7 @@ class VoiceNoteActivity : ComponentActivity() {
         recordingStartedAt = SystemClock.elapsedRealtime()
         elapsedSeconds = 0
         // Pause whatever is playing in the background (music, a podcast, a
-        // voice note) for the take — transient focus, released on stop
-        // (feedback 2026-08-20: "background audio should pause").
+        // voice note) for the take — transient focus, released on stop.
         recordFocus()
         recording = true
     }

--- a/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
+++ b/server/src/main/kotlin/com/lightphone/chats/server/VoiceNoteActivity.kt
@@ -441,6 +441,17 @@ class VoiceNoteActivity : ComponentActivity() {
     /** Transient media focus while recording — background audio pauses. */
     private fun recordFocus() {
         if (recordFocusRequest != null) return
+        recordFocusRequest = requestTransientSpeechFocus()
+    }
+
+    private fun abandonRecordFocus() {
+        abandonFocus(recordFocusRequest)
+        recordFocusRequest = null
+    }
+
+    /** Builds + requests transient media focus with speech content (the shared
+     *  shape of the recorder and pre-send-preview blocks). */
+    private fun requestTransientSpeechFocus(): android.media.AudioFocusRequest {
         val request = android.media.AudioFocusRequest.Builder(
             android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
         )
@@ -455,16 +466,14 @@ class VoiceNoteActivity : ComponentActivity() {
             (getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager)
                 .requestAudioFocus(request)
         }
-        recordFocusRequest = request
+        return request
     }
 
-    private fun abandonRecordFocus() {
-        recordFocusRequest?.let { request ->
-            runCatching {
-                (getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager)
-                    .abandonAudioFocusRequest(request)
-            }
-            recordFocusRequest = null
+    private fun abandonFocus(request: android.media.AudioFocusRequest?) {
+        request ?: return
+        runCatching {
+            (getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager)
+                .abandonAudioFocusRequest(request)
         }
     }
 
@@ -472,31 +481,12 @@ class VoiceNoteActivity : ComponentActivity() {
      *  as [recordFocus] — feedback 2026-08-21). */
     private fun previewFocus() {
         if (previewFocusRequest != null) return
-        val request = android.media.AudioFocusRequest.Builder(
-            android.media.AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
-        )
-            .setAudioAttributes(
-                android.media.AudioAttributes.Builder()
-                    .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
-                    .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SPEECH)
-                    .build(),
-            )
-            .build()
-        runCatching {
-            (getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager)
-                .requestAudioFocus(request)
-        }
-        previewFocusRequest = request
+        previewFocusRequest = requestTransientSpeechFocus()
     }
 
     private fun abandonPreviewFocus() {
-        previewFocusRequest?.let { request ->
-            runCatching {
-                (getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager)
-                    .abandonAudioFocusRequest(request)
-            }
-            previewFocusRequest = null
-        }
+        abandonFocus(previewFocusRequest)
+        previewFocusRequest = null
     }
 
     /** Stops + releases the recorder (idempotent). */

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,14 @@ includeBuild("../light-sdk") {
         substitute(module("com.thelightphone:sdk-shared")).using(project(":sdk:shared"))
     }
 }
+
+// Local Trixnity patch (OTK regen + /keys/upload off the sync emit path, see
+// LIGHT-SDK-PATCHES.md). Conditional: on machines without the ../trixnity clone
+// (e.g. CI) the upstream 5.8.0 artifact from Maven Central is used unchanged.
+if (file("../trixnity").exists()) {
+    includeBuild("../trixnity") {
+        dependencySubstitution {
+            substitute(module("de.connect2x.trixnity:trixnity-crypto")).using(project(":trixnity-crypto"))
+        }
+    }
+}


### PR DESCRIPTION
Cuts Chats 0.17.0 (vc 77, [release notes](https://github.com/fenleon/chats/releases/tag/v0.17.0)) on top of the repo-wide over-engineering audit (~1,900 lines identified, net −331).

**User-visible since 0.16.0:**
- Faster sends — pre-echo "sent" tag, sync-stall kicker, megolm pre-warm on room open
- Repeat texts no longer vanish from the thread (dedupe signature gains origin ts)
- Unread badges rebuilt to Beeper's cursor model; message-less bridge/notice rooms hidden from the list
- Undecryptable member/state heads re-classify instead of pinning ghost groups at the top
- Battery Saver Mode: pauses sync/notifications only while the screen is dark
- Forwarded-row grammar unified (glyph trails content, tag underneath)

**Internal:** phases 1–4 of the ponytail audit — dead code removal, stdlib swaps, shared helpers (`CooldownMap`, `mediaSourceOf`, `patchedWith`, generic `handle` dispatch), NO-SEAM flow conversion landed in 0.16.0.

Verified end-to-end on the lightos emulator; LP3 beta device verified for the badge/parking fixes.